### PR TITLE
Stream project.assets.json when checking for unresolved package references

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/ProjectDependencyHelperTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/ProjectDependencyHelperTests.cs
@@ -156,6 +156,29 @@ public sealed class ProjectDependencyHelperTests : IDisposable
         Assert.False(NeedsRestore(file.Path, ("Package", "1.0.0")));
     }
 
+    [Theory]
+    [InlineData("[]")]
+    [InlineData("null")]
+    [InlineData("\"nope\"")]
+    [InlineData("12")]
+    public void NeedsRestore_LibrariesIsNotAnObject(string librariesValue)
+    {
+        // Valid JSON of an unexpected shape. LockFileFormat also read these as having no libraries rather
+        // than failing, so they report every reference as unresolved instead of throwing.
+        var projectAssetsPath = WriteAssetsFile($"{{\"version\":3,\"libraries\":{librariesValue}}}");
+
+        Assert.True(NeedsRestore(projectAssetsPath, ("Package", "1.0.0")));
+    }
+
+    [Fact]
+    public void NeedsRestore_MatchesProjectLibraries()
+    {
+        // Project libraries share the "Name/Version" key shape and were matched by the lock file model too.
+        var projectAssetsPath = WriteAssetsFile("""{"version":3,"libraries":{"Package/1.0.0":{"type":"project"}}}""");
+
+        Assert.False(NeedsRestore(projectAssetsPath, ("Package", "1.0.0")));
+    }
+
     private string WriteAssetsFile(string contents)
     {
         var file = _tempRoot.CreateFile();

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/ProjectDependencyHelperTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/ProjectDependencyHelperTests.cs
@@ -1,0 +1,169 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text;
+using System.Text.Json;
+using Microsoft.CodeAnalysis.LanguageServer.HostWorkspace;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests;
+
+public sealed class ProjectDependencyHelperTests : IDisposable
+{
+    private readonly TempRoot _tempRoot = new();
+
+    public void Dispose()
+        => _tempRoot.Dispose();
+
+    [Fact]
+    public void NeedsRestore_MissingAssetsFile()
+    {
+        var projectAssetsPath = Path.Combine(_tempRoot.CreateDirectory().Path, "missing.assets.json");
+
+        Assert.True(NeedsRestore(projectAssetsPath, ("Package", "1.0.0")));
+    }
+
+    [Fact]
+    public void NeedsRestore_NoPackageReferencesDoesNotParseAssetsFile()
+    {
+        var projectAssetsPath = WriteAssetsFile("not json");
+
+        Assert.False(NeedsRestore(projectAssetsPath));
+    }
+
+    [Fact]
+    public void NeedsRestore_MalformedAssetsFileThrows()
+    {
+        var projectAssetsPath = WriteAssetsFile("""{"libraries":{"Package/1.0.0":{}}""");
+
+        Assert.ThrowsAny<JsonException>(() => NeedsRestore(projectAssetsPath, ("Package", "1.0.0")));
+    }
+
+    [Theory]
+    [InlineData("Package", "1.0.0", "Package/1.0.0", false)]
+    [InlineData("PACKAGE", "1.0.0", "package/1.0.0", false)]
+    [InlineData("Package", "[1.0.0]", "Package/1.0.0", false)]
+    [InlineData("Package", "[1.0.0,2.0.0)", "Package/1.5.0", false)]
+    [InlineData("Package", "(1.0.0,2.0.0)", "Package/1.0.0", true)]
+    [InlineData("Package", "[2.0.0]", "Package/1.0.0", true)]
+    [InlineData("Package", "not a range", "Package/1.0.0", false)]
+    [InlineData("Other", "1.0.0", "Package/1.0.0", true)]
+    public void NeedsRestore_PackageNameAndVersion(
+        string packageName,
+        string versionRange,
+        string restoredLibrary,
+        bool expectedNeedsRestore)
+    {
+        var projectAssetsPath = WriteAssetsFile($"{{\"version\":3,\"libraries\":{{\"{restoredLibrary}\":{{\"type\":\"package\"}}}}}}");
+
+        Assert.Equal(expectedNeedsRestore, NeedsRestore(projectAssetsPath, (packageName, versionRange)));
+    }
+
+    [Fact]
+    public void NeedsRestore_UsesTopLevelLibrariesFromRealisticAssetsFile()
+    {
+        var projectAssetsPath = WriteAssetsFile("""
+                {
+                  "version": 3,
+                  "targets": {
+                    "net10.0": {
+                      "Misleading.Package/9.0.0": {
+                        "type": "package",
+                        "compile": {}
+                      }
+                    }
+                  },
+                  "libraries": {
+                    "Newtonsoft.Json/13.0.3": {
+                      "sha512": "hash",
+                      "type": "package",
+                      "path": "newtonsoft.json/13.0.3",
+                      "files": [
+                        ".nupkg.metadata",
+                        "lib/net6.0/Newtonsoft.Json.dll"
+                      ]
+                    },
+                    "Microsoft.CodeAnalysis.Common/5.0.0": {
+                      "sha512": "hash",
+                      "type": "package",
+                      "path": "microsoft.codeanalysis.common/5.0.0",
+                      "files": []
+                    }
+                  },
+                  "projectFileDependencyGroups": {
+                    "net10.0": [
+                      "Newtonsoft.Json >= 13.0.0"
+                    ]
+                  },
+                  "packageFolders": {
+                    "C:\\Users\\test\\.nuget\\packages\\": {}
+                  },
+                  "project": {
+                    "version": "1.0.0",
+                    "restore": {
+                      "projectName": "TestProject"
+                    }
+                  }
+                }
+                """);
+
+        Assert.False(NeedsRestore(
+            projectAssetsPath,
+            ("newtonsoft.json", "[13.0.0,14.0.0)"),
+            ("Microsoft.CodeAnalysis.Common", "[5.0.0]")));
+    }
+
+    [Fact]
+    public void NeedsRestore_HandlesLibraryNameAcrossBufferBoundary()
+    {
+        // Large enough that the library name lands in a later read, but still smaller than the read buffer.
+        var padding = new string('x', 12 * 1024);
+        var projectAssetsPath = WriteAssetsFile($"{{\"padding\":\"{padding}\",\"libraries\":{{\"Package/1.0.0\":{{}}}}}}");
+
+        Assert.False(NeedsRestore(projectAssetsPath, ("Package", "1.0.0")));
+    }
+
+    [Fact]
+    public void NeedsRestore_HandlesTokenLargerThanBuffer()
+    {
+        // A single token too large for the initial buffer, which forces the read buffer to grow.
+        var padding = new string('x', 64 * 1024);
+        var projectAssetsPath = WriteAssetsFile($"{{\"padding\":\"{padding}\",\"libraries\":{{\"Package/1.0.0\":{{}}}}}}");
+
+        Assert.False(NeedsRestore(projectAssetsPath, ("Package", "1.0.0")));
+    }
+
+    [Fact]
+    public void NeedsRestore_HandlesLibraryNameLargerThanBuffer()
+    {
+        // The grown buffer has to preserve the library key itself, not just skip past oversized values.
+        var packageName = new string('x', 64 * 1024);
+        var projectAssetsPath = WriteAssetsFile($"{{\"libraries\":{{\"{packageName}/1.0.0\":{{}}}}}}");
+
+        Assert.False(NeedsRestore(projectAssetsPath, (packageName, "1.0.0")));
+    }
+
+    [Fact]
+    public void NeedsRestore_SkipsByteOrderMark()
+    {
+        var file = _tempRoot.CreateFile();
+        File.WriteAllBytes(
+            file.Path,
+            [.. Encoding.UTF8.Preamble, .. """{"version":3,"libraries":{"Package/1.0.0":{"type":"package"}}}"""u8]);
+
+        Assert.False(NeedsRestore(file.Path, ("Package", "1.0.0")));
+    }
+
+    private string WriteAssetsFile(string contents)
+    {
+        var file = _tempRoot.CreateFile();
+        file.WriteAllText(contents);
+        return file.Path;
+    }
+
+    private static bool NeedsRestore(string projectAssetsPath, params (string Name, string VersionRange)[] packageReferences)
+        => ProjectDependencyHelper.TestAccessor.CheckProjectAssetsForUnresolvedDependencies(
+            projectAssetsPath, packageReferences, NullLogger.Instance);
+}

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/ProjectDependencyHelperTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/ProjectDependencyHelperTests.cs
@@ -3,9 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Text;
-using System.Text.Json;
 using Microsoft.CodeAnalysis.LanguageServer.HostWorkspace;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests;
@@ -33,12 +33,43 @@ public sealed class ProjectDependencyHelperTests : IDisposable
         Assert.False(NeedsRestore(projectAssetsPath));
     }
 
+    [Theory]
+    [InlineData("""{"libraries":{"Package/1.0.0":{}}""")]
+    [InlineData("not json")]
+    [InlineData("")]
+    [InlineData("\u0001\u0002\u0003")]
+    [InlineData("""{"version":3,"libraries":"unterminated""")]
+    public void NeedsRestore_UnreadableAssetsFile(string contents)
+    {
+        // The lock file model this replaced reported no resolved packages when it failed to parse, so an
+        // unreadable file has to report a restore rather than failing the project load.
+        var projectAssetsPath = WriteAssetsFile(contents);
+
+        Assert.True(NeedsRestore(projectAssetsPath, ("Package", "1.0.0")));
+    }
+
     [Fact]
-    public void NeedsRestore_MalformedAssetsFileThrows()
+    public void NeedsRestore_UnreadableAssetsFileLogsVersion()
+    {
+        var projectAssetsPath = WriteAssetsFile("""{"version":3,"libraries":{"Package/1.0.0":{}}""");
+        var logger = new TestLogger();
+
+        Assert.True(NeedsRestore(projectAssetsPath, logger, ("Package", "1.0.0")));
+
+        var message = Assert.Single(logger.Messages);
+        Assert.Contains(projectAssetsPath, message);
+        Assert.Contains("(version 3)", message);
+    }
+
+    [Fact]
+    public void NeedsRestore_UnreadableAssetsFileWithoutVersionLogsUnknown()
     {
         var projectAssetsPath = WriteAssetsFile("""{"libraries":{"Package/1.0.0":{}}""");
+        var logger = new TestLogger();
 
-        Assert.ThrowsAny<JsonException>(() => NeedsRestore(projectAssetsPath, ("Package", "1.0.0")));
+        Assert.True(NeedsRestore(projectAssetsPath, logger, ("Package", "1.0.0")));
+
+        Assert.Contains("(version <unknown>)", Assert.Single(logger.Messages));
     }
 
     [Theory]
@@ -187,6 +218,21 @@ public sealed class ProjectDependencyHelperTests : IDisposable
     }
 
     private static bool NeedsRestore(string projectAssetsPath, params (string Name, string VersionRange)[] packageReferences)
+        => NeedsRestore(projectAssetsPath, NullLogger.Instance, packageReferences);
+
+    private static bool NeedsRestore(string projectAssetsPath, ILogger logger, params (string Name, string VersionRange)[] packageReferences)
         => ProjectDependencyHelper.TestAccessor.CheckProjectAssetsForUnresolvedDependencies(
-            projectAssetsPath, packageReferences, NullLogger.Instance);
+            projectAssetsPath, packageReferences, logger);
+
+    private sealed class TestLogger : ILogger
+    {
+        public List<string> Messages { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            => Messages.Add(formatter(state, exception));
+    }
 }

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectAssetsReader.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectAssetsReader.cs
@@ -36,10 +36,16 @@ internal static class ProjectAssetsReader
     /// Entries are only ever set to <see langword="true"/>, so <paramref name="resolvedReferences"/> must
     /// start cleared.
     /// </summary>
+    /// <param name="assetsFileVersion">
+    /// Set to the value of the top level <c>version</c> property once it is read, and left unchanged if the
+    /// file does not have an integer one. Reported when the file cannot be read, so it is passed by reference
+    /// to stay available to the caller if parsing later fails.
+    /// </param>
     public static void FindResolvedPackageReferences(
         string projectAssetsPath,
         ReadOnlySpan<PackageReferenceItem> packageReferences,
-        Span<bool> resolvedReferences)
+        Span<bool> resolvedReferences,
+        ref int? assetsFileVersion)
     {
         Contract.ThrowIfFalse(packageReferences.Length == resolvedReferences.Length);
 
@@ -62,6 +68,7 @@ internal static class ProjectAssetsReader
             // Depth of the object value of the top level "libraries" property, or -1 while outside of it.
             var librariesDepth = -1;
             var atLibrariesValue = false;
+            var atVersionValue = false;
 
             while (!isFinalBlock)
             {
@@ -87,6 +94,12 @@ internal static class ProjectAssetsReader
                         if (reader.TokenType == JsonTokenType.StartObject)
                             librariesDepth = reader.CurrentDepth;
                     }
+                    else if (atVersionValue)
+                    {
+                        atVersionValue = false;
+                        if (reader.TokenType == JsonTokenType.Number && reader.TryGetInt32(out var version))
+                            assetsFileVersion = version;
+                    }
                     else if (librariesDepth >= 0)
                     {
                         if (reader.TokenType == JsonTokenType.PropertyName && reader.CurrentDepth == librariesDepth + 1)
@@ -94,11 +107,12 @@ internal static class ProjectAssetsReader
                         else if (reader.TokenType == JsonTokenType.EndObject && reader.CurrentDepth == librariesDepth)
                             librariesDepth = -1;
                     }
-                    else if (reader.TokenType == JsonTokenType.PropertyName &&
-                        reader.CurrentDepth == 1 &&
-                        reader.ValueTextEquals("libraries"))
+                    else if (reader.TokenType == JsonTokenType.PropertyName && reader.CurrentDepth == 1)
                     {
-                        atLibrariesValue = true;
+                        if (reader.ValueTextEquals("libraries"))
+                            atLibrariesValue = true;
+                        else if (reader.ValueTextEquals("version"))
+                            atVersionValue = true;
                     }
                 }
 

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectAssetsReader.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectAssetsReader.cs
@@ -86,6 +86,7 @@ internal static class ProjectAssetsReader
                 isFinalBlock = readCount == 0;
 
                 var reader = new Utf8JsonReader(buffer.AsSpan(0, bufferedCount), isFinalBlock, state);
+                // The expected json structure is indicated by the conditional logic below.
                 while (reader.Read())
                 {
                     if (atLibrariesValue)

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectAssetsReader.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectAssetsReader.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Buffers;
+using System.Text;
 using System.Text.Json;
 using NuGet.Versioning;
 
@@ -27,7 +28,7 @@ internal static class ProjectAssetsReader
     /// </summary>
     private const int MaxStackAllocatedKeyLength = 512;
 
-    private static ReadOnlySpan<byte> Utf8Bom => [0xEF, 0xBB, 0xBF];
+    private static ReadOnlySpan<byte> Utf8Bom => Encoding.UTF8.Preamble;
 
     /// <summary>
     /// Sets the entry in <paramref name="resolvedReferences"/> for each item in
@@ -127,7 +128,8 @@ internal static class ProjectAssetsReader
             ? keyBuffer[..reader.CopyString(keyBuffer)]
             : reader.GetString().AsSpan();
 
-        // Keys are "PackageId/Version"; anything else (including project libraries) cannot match a package.
+        // Package and project libraries both use "Name/Version" keys, and the lock file model this replaced
+        // matched against both. A key without that shape belongs to neither.
         var separatorIndex = libraryKey.LastIndexOf('/');
         if (separatorIndex <= 0 || separatorIndex == libraryKey.Length - 1)
             return;

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectAssetsReader.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectAssetsReader.cs
@@ -1,0 +1,153 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.Text.Json;
+using NuGet.Versioning;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace;
+
+/// <summary>
+/// Reads the <c>libraries</c> section of a <c>project.assets.json</c> file to discover which packages a
+/// restore has already resolved. Only the library keys are inspected, so the file is streamed through a
+/// small fixed buffer instead of being materialized into a <c>LockFile</c> model.
+/// </summary>
+internal static class ProjectAssetsReader
+{
+    /// <summary>
+    /// Initial size of the read buffer. It grows if a single JSON token does not fit, which real assets files
+    /// never require; the longest token in one is a few hundred bytes.
+    /// </summary>
+    private const int BufferSize = 16 * 1024;
+
+    /// <summary>
+    /// Upper bound on the length of a library key decoded on the stack. Keys are a package id (which NuGet
+    /// limits to 100 characters) plus a version, so realistic keys stay well below this.
+    /// </summary>
+    private const int MaxStackAllocatedKeyLength = 512;
+
+    private static ReadOnlySpan<byte> Utf8Bom => [0xEF, 0xBB, 0xBF];
+
+    /// <summary>
+    /// Sets the entry in <paramref name="resolvedReferences"/> for each item in
+    /// <paramref name="packageReferences"/> that the assets file lists at a version satisfying its range.
+    /// Entries are only ever set to <see langword="true"/>, so <paramref name="resolvedReferences"/> must
+    /// start cleared.
+    /// </summary>
+    public static void FindResolvedPackageReferences(
+        string projectAssetsPath,
+        ReadOnlySpan<PackageReferenceItem> packageReferences,
+        Span<bool> resolvedReferences)
+    {
+        Contract.ThrowIfFalse(packageReferences.Length == resolvedReferences.Length);
+
+        // A buffer size of 1 disables FileStream's internal buffer; this reader does its own buffering.
+        using var stream = new FileStream(projectAssetsPath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 1);
+        var buffer = ArrayPool<byte>.Shared.Rent(BufferSize);
+        try
+        {
+            var state = new JsonReaderState();
+            var isFinalBlock = false;
+
+            // Utf8JsonReader does not consume a byte order mark, so strip one before parsing begins.
+            var bufferedCount = stream.ReadAtLeast(buffer, Utf8Bom.Length, throwOnEndOfStream: false);
+            if (buffer.AsSpan(0, bufferedCount).StartsWith(Utf8Bom))
+            {
+                bufferedCount -= Utf8Bom.Length;
+                buffer.AsSpan(Utf8Bom.Length, bufferedCount).CopyTo(buffer);
+            }
+
+            // Depth of the object value of the top level "libraries" property, or -1 while outside of it.
+            var librariesDepth = -1;
+            var atLibrariesValue = false;
+
+            while (!isFinalBlock)
+            {
+                if (bufferedCount == buffer.Length)
+                {
+                    // The buffer holds a single incomplete token, so it has to grow for that token to be read.
+                    var grownBuffer = ArrayPool<byte>.Shared.Rent(checked(buffer.Length * 2));
+                    buffer.AsSpan(0, bufferedCount).CopyTo(grownBuffer);
+                    ArrayPool<byte>.Shared.Return(buffer);
+                    buffer = grownBuffer;
+                }
+
+                var readCount = stream.Read(buffer, bufferedCount, buffer.Length - bufferedCount);
+                bufferedCount += readCount;
+                isFinalBlock = readCount == 0;
+
+                var reader = new Utf8JsonReader(buffer.AsSpan(0, bufferedCount), isFinalBlock, state);
+                while (reader.Read())
+                {
+                    if (atLibrariesValue)
+                    {
+                        atLibrariesValue = false;
+                        if (reader.TokenType == JsonTokenType.StartObject)
+                            librariesDepth = reader.CurrentDepth;
+                    }
+                    else if (librariesDepth >= 0)
+                    {
+                        if (reader.TokenType == JsonTokenType.PropertyName && reader.CurrentDepth == librariesDepth + 1)
+                            MarkResolvedPackageReferences(ref reader, packageReferences, resolvedReferences);
+                        else if (reader.TokenType == JsonTokenType.EndObject && reader.CurrentDepth == librariesDepth)
+                            librariesDepth = -1;
+                    }
+                    else if (reader.TokenType == JsonTokenType.PropertyName &&
+                        reader.CurrentDepth == 1 &&
+                        reader.ValueTextEquals("libraries"))
+                    {
+                        atLibrariesValue = true;
+                    }
+                }
+
+                state = reader.CurrentState;
+
+                // Keep the trailing partial token so the next read can complete it.
+                var consumedCount = checked((int)reader.BytesConsumed);
+                bufferedCount -= consumedCount;
+                buffer.AsSpan(consumedCount, bufferedCount).CopyTo(buffer);
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    private static void MarkResolvedPackageReferences(
+        ref Utf8JsonReader reader,
+        ReadOnlySpan<PackageReferenceItem> packageReferences,
+        Span<bool> resolvedReferences)
+    {
+        // Decoding to UTF-16 gives escaped and unescaped keys a single code path. A decoded key is never
+        // longer than its raw UTF-8 form, so only implausibly long keys fall back to allocating.
+        Span<char> keyBuffer = stackalloc char[MaxStackAllocatedKeyLength];
+        var libraryKey = reader.ValueSpan.Length <= keyBuffer.Length
+            ? keyBuffer[..reader.CopyString(keyBuffer)]
+            : reader.GetString().AsSpan();
+
+        // Keys are "PackageId/Version"; anything else (including project libraries) cannot match a package.
+        var separatorIndex = libraryKey.LastIndexOf('/');
+        if (separatorIndex <= 0 || separatorIndex == libraryKey.Length - 1)
+            return;
+
+        var packageId = libraryKey[..separatorIndex];
+        var resolvedVersion = libraryKey[(separatorIndex + 1)..];
+        for (var i = 0; i < packageReferences.Length; i++)
+        {
+            if (resolvedReferences[i] || !packageId.Equals(packageReferences[i].Name, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            // Only packages the project references get this far, so versions are allocated a handful of times.
+            if (NuGetVersion.TryParse(resolvedVersion.ToString(), out var version) &&
+                GetVersionRange(packageReferences[i]).Satisfies(version))
+            {
+                resolvedReferences[i] = true;
+            }
+        }
+    }
+
+    private static VersionRange GetVersionRange(PackageReferenceItem reference)
+        => VersionRange.TryParse(reference.VersionRange, out var versionRange) ? versionRange : VersionRange.All;
+}

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectAssetsReader.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectAssetsReader.cs
@@ -86,7 +86,20 @@ internal static class ProjectAssetsReader
                 isFinalBlock = readCount == 0;
 
                 var reader = new Utf8JsonReader(buffer.AsSpan(0, bufferedCount), isFinalBlock, state);
-                // The expected json structure is indicated by the conditional logic below.
+                // Expected json looks something like the following:
+                // {
+                //   "version": 3,
+                //   "targets": {},
+                //   "libraries": {
+                //     "Newtonsoft.Json/13.0.3": {
+                //       "sha512": "hash",
+                //       "type": "package",
+                //       "path": "newtonsoft.json/13.0.3",
+                //       "files": [
+                //         ".nupkg.metadata",
+                //         "lib/net6.0/Newtonsoft.Json.dll"
+                //   	  ]
+                //   },
                 while (reader.Read())
                 {
                     if (atLibrariesValue)

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectDependencyHelper.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectDependencyHelper.cs
@@ -91,7 +91,7 @@ internal static class ProjectDependencyHelper
         {
             // The file could not be read, so nothing is known about which packages are resolved. Report a
             // restore, which rewrites the file and recovers from a corrupt or partially written one.
-            logger.LogError(string.Format(
+            logger.LogError(e, string.Format(
                 LanguageServerResources.Failed_to_read_project_assets_file_0_version_1_2,
                 projectAssetsPath,
                 assetsFileVersion?.ToString() ?? "<unknown>",

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectDependencyHelper.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectDependencyHelper.cs
@@ -2,12 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.LanguageServer.Handler;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.Extensions.Logging;
-using NuGet.ProjectModel;
-using NuGet.Versioning;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace;
@@ -60,60 +59,56 @@ internal static class ProjectDependencyHelper
             return false;
         }
 
-        // Iterate the project's package references and check if there is a package with the same name
-        // and acceptable version in the lock file.
-
-        var lockFileFormat = new LockFileFormat();
-        var lockFile = lockFileFormat.Read(projectAssetsPath);
-        var projectAssetsMap = CreateProjectAssetsMap(lockFile);
-
-        using var _ = PooledHashSet<PackageReferenceItem>.GetInstance(out var unresolved);
-
-        foreach (var reference in projectFileInfo.PackageReferences)
+        var packageReferences = projectFileInfo.PackageReferences;
+        var resolvedReferences = ArrayPool<bool>.Shared.Rent(packageReferences.Length);
+        Array.Clear(resolvedReferences, 0, packageReferences.Length);
+        try
         {
-            if (!projectAssetsMap.TryGetValue(reference.Name, out var projectAssetsVersions))
+            ProjectAssetsReader.FindResolvedPackageReferences(
+                projectAssetsPath, packageReferences, resolvedReferences.AsSpan(0, packageReferences.Length));
+
+            using var _ = PooledHashSet<PackageReferenceItem>.GetInstance(out var unresolved);
+            for (var i = 0; i < packageReferences.Length; i++)
             {
-                // If the package name isn't in the lock file then it's unresolved.
-                unresolved.Add(reference);
-                continue;
+                if (!resolvedReferences[i])
+                    unresolved.Add(packageReferences[i]);
             }
 
-            var requestedVersionRange = VersionRange.TryParse(reference.VersionRange, out var versionRange)
-                ? versionRange
-                : VersionRange.All;
-
-            var projectAssetsHasVersion = projectAssetsVersions.Any(projectAssetsVersion => SatisfiesVersion(requestedVersionRange, projectAssetsVersion));
-            if (!projectAssetsHasVersion)
+            if (unresolved.Any())
             {
-                // If the package name is in the lock file but none of the versions satisfy the requested version range then it's unresolved.
-                unresolved.Add(reference);
+                var message = string.Format(LanguageServerResources.Project_0_has_unresolved_dependencies, projectFileInfo.FilePath)
+                    + Environment.NewLine
+                    + string.Join(Environment.NewLine, unresolved.Select(r => $"    {r.Name}-{r.VersionRange}"));
+                logger.LogWarning(message);
+                return true;
             }
+
+            return false;
         }
-
-        if (unresolved.Any())
+        finally
         {
-            var message = string.Format(LanguageServerResources.Project_0_has_unresolved_dependencies, projectFileInfo.FilePath)
-                + Environment.NewLine
-                + string.Join(Environment.NewLine, unresolved.Select(r => $"    {r.Name}-{r.VersionRange}"));
-            logger.LogWarning(message);
-            return true;
+            ArrayPool<bool>.Shared.Return(resolvedReferences);
         }
+    }
 
-        return false;
-
-        static ImmutableDictionary<string, ImmutableArray<NuGetVersion>> CreateProjectAssetsMap(LockFile lockFile)
+    internal static class TestAccessor
+    {
+        public static bool CheckProjectAssetsForUnresolvedDependencies(
+            string projectAssetsPath,
+            (string Name, string VersionRange)[] packageReferences,
+            ILogger logger)
         {
-            // Create a map of package names to all versions in the lock file.
-            var map = lockFile.Libraries
-                .GroupBy(l => l.Name, l => l.Version, StringComparer.OrdinalIgnoreCase)
-                .ToImmutableDictionary(g => g.Key, g => g.ToImmutableArray(), StringComparer.OrdinalIgnoreCase);
+            var packageReferenceItems = new PackageReferenceItem[packageReferences.Length];
+            for (var i = 0; i < packageReferences.Length; i++)
+                packageReferenceItems[i] = new(packageReferences[i].Name, packageReferences[i].VersionRange);
 
-            return map;
-        }
+            var projectFileInfo = ProjectFileInfo.CreateEmpty(LanguageNames.CSharp, "TestProject.csproj") with
+            {
+                ProjectAssetsFilePath = projectAssetsPath,
+                PackageReferences = packageReferenceItems,
+            };
 
-        static bool SatisfiesVersion(VersionRange requestedVersionRange, NuGetVersion projectAssetsVersion)
-        {
-            return requestedVersionRange.Satisfies(projectAssetsVersion);
+            return ProjectDependencyHelper.CheckProjectAssetsForUnresolvedDependencies(projectFileInfo, logger);
         }
     }
 

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectDependencyHelper.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/ProjectDependencyHelper.cs
@@ -4,6 +4,7 @@
 
 using System.Buffers;
 using System.Collections.Immutable;
+using System.Text.Json;
 using Microsoft.CodeAnalysis.LanguageServer.Handler;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.Extensions.Logging;
@@ -62,10 +63,11 @@ internal static class ProjectDependencyHelper
         var packageReferences = projectFileInfo.PackageReferences;
         var resolvedReferences = ArrayPool<bool>.Shared.Rent(packageReferences.Length);
         Array.Clear(resolvedReferences, 0, packageReferences.Length);
+        int? assetsFileVersion = null;
         try
         {
             ProjectAssetsReader.FindResolvedPackageReferences(
-                projectAssetsPath, packageReferences, resolvedReferences.AsSpan(0, packageReferences.Length));
+                projectAssetsPath, packageReferences, resolvedReferences.AsSpan(0, packageReferences.Length), ref assetsFileVersion);
 
             using var _ = PooledHashSet<PackageReferenceItem>.GetInstance(out var unresolved);
             for (var i = 0; i < packageReferences.Length; i++)
@@ -84,6 +86,17 @@ internal static class ProjectDependencyHelper
             }
 
             return false;
+        }
+        catch (Exception e) when (e is JsonException or IOException or UnauthorizedAccessException)
+        {
+            // The file could not be read, so nothing is known about which packages are resolved. Report a
+            // restore, which rewrites the file and recovers from a corrupt or partially written one.
+            logger.LogError(string.Format(
+                LanguageServerResources.Failed_to_read_project_assets_file_0_version_1_2,
+                projectAssetsPath,
+                assetsFileVersion?.ToString() ?? "<unknown>",
+                e.Message));
+            return true;
         }
         finally
         {

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServerResources.resx
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServerResources.resx
@@ -252,6 +252,9 @@
   <data name="Project_0_has_unresolved_dependencies" xml:space="preserve">
     <value>Project {0} has unresolved dependencies</value>
   </data>
+  <data name="Failed_to_read_project_assets_file_0_version_1_2" xml:space="preserve">
+    <value>Failed to read project assets file {0} (version {1}), assuming a restore is required. {2}</value>
+  </data>
   <data name="Standard_Output_Messages" xml:space="preserve">
     <value>Standard Output Messages</value>
   </data>

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.cs.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.cs.xlf
@@ -67,6 +67,11 @@
         <target state="translated">Neúspěšné:    {0}, Úspěšné:    {1}, Přeskočeno:    {2}, Celkem:    {3}, Doba trvání: {4}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_read_project_assets_file_0_version_1_2">
+        <source>Failed to read project assets file {0} (version {1}), assuming a restore is required. {2}</source>
+        <target state="new">Failed to read project assets file {0} (version {1}), assuming a restore is required. {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Failed_to_read_runsettings_file_at_0_1">
         <source>Failed to read .runsettings file at {0}:{1}</source>
         <target state="translated">Čtení souboru .runsettings na {0} se nezdařilo:{1}</target>

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.de.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.de.xlf
@@ -67,6 +67,11 @@
         <target state="translated">Fehlgeschlagen:    {0}, erfolgreich:    {1}, übersprungen:    {2}, gesamt:    {3}, Dauer: {4}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_read_project_assets_file_0_version_1_2">
+        <source>Failed to read project assets file {0} (version {1}), assuming a restore is required. {2}</source>
+        <target state="new">Failed to read project assets file {0} (version {1}), assuming a restore is required. {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Failed_to_read_runsettings_file_at_0_1">
         <source>Failed to read .runsettings file at {0}:{1}</source>
         <target state="translated">Fehler beim Lesen der RUNSETTINGS-Datei unter {0}:{1}</target>

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.es.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.es.xlf
@@ -67,6 +67,11 @@
         <target state="translated">Error:    {0}, Correcto:    {1}, Omitido:    {2}, Total:    {3}, Duración: {4}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_read_project_assets_file_0_version_1_2">
+        <source>Failed to read project assets file {0} (version {1}), assuming a restore is required. {2}</source>
+        <target state="new">Failed to read project assets file {0} (version {1}), assuming a restore is required. {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Failed_to_read_runsettings_file_at_0_1">
         <source>Failed to read .runsettings file at {0}:{1}</source>
         <target state="translated">No se pudo leer el archivo .runsettings en {0}:{1}</target>

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.fr.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.fr.xlf
@@ -67,6 +67,11 @@
         <target state="translated">Échec : {0}, Réussi : {1}, Ignoré : {2}, Total : {3}, Durée : {4}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_read_project_assets_file_0_version_1_2">
+        <source>Failed to read project assets file {0} (version {1}), assuming a restore is required. {2}</source>
+        <target state="new">Failed to read project assets file {0} (version {1}), assuming a restore is required. {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Failed_to_read_runsettings_file_at_0_1">
         <source>Failed to read .runsettings file at {0}:{1}</source>
         <target state="translated">Échec de la lecture du fichier .runsettings à l'adresse {0} :{1}</target>

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.it.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.it.xlf
@@ -67,6 +67,11 @@
         <target state="translated">Non superati:    {0}%1, Superati:    {1}%2, Ignorati:    {2}%2, Totale:    {3}%2, Durata: {4}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_read_project_assets_file_0_version_1_2">
+        <source>Failed to read project assets file {0} (version {1}), assuming a restore is required. {2}</source>
+        <target state="new">Failed to read project assets file {0} (version {1}), assuming a restore is required. {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Failed_to_read_runsettings_file_at_0_1">
         <source>Failed to read .runsettings file at {0}:{1}</source>
         <target state="translated">Non è stato possibile leggere il file con estensione runsettings in {0}:{1}</target>

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ja.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ja.xlf
@@ -67,6 +67,11 @@
         <target state="translated">失敗:    {0}、合格:    {1}、スキップ:    {2}、合計:    {3}、期間:    {4}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_read_project_assets_file_0_version_1_2">
+        <source>Failed to read project assets file {0} (version {1}), assuming a restore is required. {2}</source>
+        <target state="new">Failed to read project assets file {0} (version {1}), assuming a restore is required. {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Failed_to_read_runsettings_file_at_0_1">
         <source>Failed to read .runsettings file at {0}:{1}</source>
         <target state="translated">{0}:{1} の .runsettings ファイルを読み取れできませんでした</target>

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ko.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ko.xlf
@@ -67,6 +67,11 @@
         <target state="translated">실패:    {0}, 통과:    {1}, 건너뜀:    {2}, 합계:    {3}, 기간: {4}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_read_project_assets_file_0_version_1_2">
+        <source>Failed to read project assets file {0} (version {1}), assuming a restore is required. {2}</source>
+        <target state="new">Failed to read project assets file {0} (version {1}), assuming a restore is required. {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Failed_to_read_runsettings_file_at_0_1">
         <source>Failed to read .runsettings file at {0}:{1}</source>
         <target state="translated">{0}:{1}에서 .runsettings 파일을 읽지 못했습니다.</target>

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.pl.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.pl.xlf
@@ -67,6 +67,11 @@
         <target state="translated">Niepowodzenie:    {0}, zakończone powodzeniem:    {1}, pominięte:    {2}, łącznie:    {3}, czas trwania: {4}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_read_project_assets_file_0_version_1_2">
+        <source>Failed to read project assets file {0} (version {1}), assuming a restore is required. {2}</source>
+        <target state="new">Failed to read project assets file {0} (version {1}), assuming a restore is required. {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Failed_to_read_runsettings_file_at_0_1">
         <source>Failed to read .runsettings file at {0}:{1}</source>
         <target state="translated">Nie można odczytać pliku .runsettings w {0}:{1}</target>

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.pt-BR.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.pt-BR.xlf
@@ -67,6 +67,11 @@
         <target state="translated">Falhou:    {0}, Passou:    {1}, Ignorado:    {2}, Total:    {3}, Duração: {4}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_read_project_assets_file_0_version_1_2">
+        <source>Failed to read project assets file {0} (version {1}), assuming a restore is required. {2}</source>
+        <target state="new">Failed to read project assets file {0} (version {1}), assuming a restore is required. {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Failed_to_read_runsettings_file_at_0_1">
         <source>Failed to read .runsettings file at {0}:{1}</source>
         <target state="translated">Falha ao ler o arquivo .runsettings em {0}:{1}</target>

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ru.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ru.xlf
@@ -67,6 +67,11 @@
         <target state="translated">Не пройдено:    {0}, пройдено:    {1}, пропущено:    {2}, всего:    {3}, длительность:    {4}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_read_project_assets_file_0_version_1_2">
+        <source>Failed to read project assets file {0} (version {1}), assuming a restore is required. {2}</source>
+        <target state="new">Failed to read project assets file {0} (version {1}), assuming a restore is required. {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Failed_to_read_runsettings_file_at_0_1">
         <source>Failed to read .runsettings file at {0}:{1}</source>
         <target state="translated">Не удалось прочитать файл RUNSETTINGS в {0}:{1}</target>

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.tr.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.tr.xlf
@@ -67,6 +67,11 @@
         <target state="translated">Başarısız:    {0}, Başarılı:    {1}, Atlandı:    {2}, Toplam:    {3}, Süre: {4}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_read_project_assets_file_0_version_1_2">
+        <source>Failed to read project assets file {0} (version {1}), assuming a restore is required. {2}</source>
+        <target state="new">Failed to read project assets file {0} (version {1}), assuming a restore is required. {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Failed_to_read_runsettings_file_at_0_1">
         <source>Failed to read .runsettings file at {0}:{1}</source>
         <target state="translated">Şu konumdaki .runsettings dosyası okunamadı: {0}:{1}</target>

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.zh-Hans.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.zh-Hans.xlf
@@ -67,6 +67,11 @@
         <target state="translated">失败: {0} 个，通过: {1} 个，已跳过: {2} 个，总计: {3} 个，持续时间: {4}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_read_project_assets_file_0_version_1_2">
+        <source>Failed to read project assets file {0} (version {1}), assuming a restore is required. {2}</source>
+        <target state="new">Failed to read project assets file {0} (version {1}), assuming a restore is required. {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Failed_to_read_runsettings_file_at_0_1">
         <source>Failed to read .runsettings file at {0}:{1}</source>
         <target state="translated">无法读取 {0}:{1}的 .runsettings 文件</target>

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.zh-Hant.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.zh-Hant.xlf
@@ -67,6 +67,11 @@
         <target state="translated">失敗:    {0}，通過:    {1}，跳過:    {2}，總計:    {3}，持續時間: {4}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Failed_to_read_project_assets_file_0_version_1_2">
+        <source>Failed to read project assets file {0} (version {1}), assuming a restore is required. {2}</source>
+        <target state="new">Failed to read project assets file {0} (version {1}), assuming a restore is required. {2}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Failed_to_read_runsettings_file_at_0_1">
         <source>Failed to read .runsettings file at {0}:{1}</source>
         <target state="translated">無法讀取位於 {0} 的 .runsettings 檔案: {1}</target>

--- a/src/Tools/IdeCoreBenchmarks/IdeCoreBenchmarks.csproj
+++ b/src/Tools/IdeCoreBenchmarks/IdeCoreBenchmarks.csproj
@@ -58,4 +58,15 @@
     <ProjectReference Include="..\..\EditorFeatures\VisualBasic\Microsoft.CodeAnalysis.VisualBasic.EditorFeatures.vbproj" />
   </ItemGroup>
 
+  <!-- Microsoft.CodeAnalysis.LanguageServer only targets .NET, so its assets reader is linked in (rather
+       than referenced) and benchmarked on .NET only. ProjectAssetsReaderBenchmarks.cs is guarded to match.
+       The Using items mirror the global usings the linked file relies on in its own project. -->
+  <ItemGroup Condition="'$(TargetFramework)' != 'net472'">
+    <PackageReference Include="NuGet.ProjectModel" />
+    <Compile Include="..\..\LanguageServer\Microsoft.CodeAnalysis.LanguageServer\HostWorkspace\ProjectAssetsReader.cs" Link="Lsp\ProjectAssetsReader.cs" />
+    <Using Include="System" />
+    <Using Include="System.IO" />
+    <Using Include="Roslyn.Utilities" />
+  </ItemGroup>
+
 </Project>

--- a/src/Tools/IdeCoreBenchmarks/Lsp/ProjectAssetsReaderBenchmarkData.json
+++ b/src/Tools/IdeCoreBenchmarks/Lsp/ProjectAssetsReaderBenchmarkData.json
@@ -1,0 +1,818 @@
+{
+  "version": 3,
+  "targets": {
+    "net10.0": {
+      "Humanizer.Core/2.14.1": {
+        "type": "package",
+        "compile": {
+          "lib/net6.0/Humanizer.dll": {
+            "related": ".xml"
+          }
+        },
+        "runtime": {
+          "lib/net6.0/Humanizer.dll": {
+            "related": ".xml"
+          }
+        }
+      },
+      "MessagePack/2.5.302": {
+        "type": "package",
+        "dependencies": {
+          "MessagePack.Annotations": "2.5.302",
+          "Microsoft.NET.StringTools": "17.6.3"
+        },
+        "compile": {
+          "lib/net6.0/MessagePack.dll": {
+            "related": ".xml"
+          }
+        },
+        "runtime": {
+          "lib/net6.0/MessagePack.dll": {
+            "related": ".xml"
+          }
+        }
+      },
+      "Microsoft.Build.Framework/18.7.1": {
+        "type": "package",
+        "compile": {
+          "ref/net10.0/Microsoft.Build.Framework.dll": {}
+        },
+        "runtime": {
+          "lib/net10.0/Microsoft.Build.Framework.dll": {}
+        }
+      },
+      "Microsoft.Extensions.Configuration/10.0.1": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Primitives": "10.0.1"
+        },
+        "compile": {
+          "lib/net10.0/Microsoft.Extensions.Configuration.dll": {}
+        },
+        "runtime": {
+          "lib/net10.0/Microsoft.Extensions.Configuration.dll": {}
+        }
+      },
+      "Microsoft.Extensions.FileSystemGlobbing/10.0.1": {
+        "type": "package",
+        "compile": {
+          "lib/net10.0/Microsoft.Extensions.FileSystemGlobbing.dll": {}
+        },
+        "runtime": {
+          "lib/net10.0/Microsoft.Extensions.FileSystemGlobbing.dll": {}
+        }
+      },
+      "Microsoft.Extensions.Logging/10.0.1": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.1",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Options": "10.0.1"
+        },
+        "compile": {
+          "lib/net10.0/Microsoft.Extensions.Logging.dll": {}
+        },
+        "runtime": {
+          "lib/net10.0/Microsoft.Extensions.Logging.dll": {}
+        }
+      },
+      "Microsoft.Extensions.Logging.Console/10.0.1": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Binder": "10.0.1",
+          "Microsoft.Extensions.Logging": "10.0.1",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.1",
+          "System.Text.Json": "10.0.1"
+        },
+        "compile": {
+          "lib/net10.0/Microsoft.Extensions.Logging.Console.dll": {}
+        },
+        "runtime": {
+          "lib/net10.0/Microsoft.Extensions.Logging.Console.dll": {}
+        }
+      },
+      "Microsoft.ServiceHub.Framework/4.10.128": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.ServiceHub.Client": "4.6.3200",
+          "Microsoft.VisualStudio.Threading": "18.7.19",
+          "Nerdbank.Streams": "2.13.16",
+          "StreamJsonRpc": "2.26.5"
+        },
+        "compile": {
+          "lib/net8.0/Microsoft.ServiceHub.Framework.dll": {}
+        },
+        "runtime": {
+          "lib/net8.0/Microsoft.ServiceHub.Framework.dll": {}
+        }
+      },
+      "Microsoft.TestPlatform.ObjectModel/17.14.1": {
+        "type": "package",
+        "dependencies": {
+          "NuGet.Frameworks": "6.5.0",
+          "System.Reflection.Metadata": "8.0.0"
+        },
+        "compile": {
+          "lib/netcoreapp3.1/Microsoft.TestPlatform.CoreUtilities.dll": {},
+          "lib/netcoreapp3.1/Microsoft.VisualStudio.TestPlatform.ObjectModel.dll": {}
+        },
+        "runtime": {
+          "lib/netcoreapp3.1/Microsoft.TestPlatform.CoreUtilities.dll": {},
+          "lib/netcoreapp3.1/Microsoft.VisualStudio.TestPlatform.ObjectModel.dll": {}
+        }
+      },
+      "Microsoft.TestPlatform.TranslationLayer/17.14.1": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "17.14.1",
+          "Newtonsoft.Json": "13.0.3"
+        },
+        "compile": {
+          "lib/netcoreapp3.1/Microsoft.TestPlatform.CommunicationUtilities.dll": {},
+          "lib/netcoreapp3.1/Microsoft.TestPlatform.CrossPlatEngine.dll": {},
+          "lib/netcoreapp3.1/Microsoft.TestPlatform.PlatformAbstractions.dll": {},
+          "lib/netcoreapp3.1/Microsoft.TestPlatform.Utilities.dll": {},
+          "lib/netcoreapp3.1/Microsoft.VisualStudio.TestPlatform.Common.dll": {},
+          "lib/netcoreapp3.1/Microsoft.TestPlatform.TranslationLayer.dll": {}
+        },
+        "runtime": {
+          "lib/netcoreapp3.1/Microsoft.TestPlatform.CommunicationUtilities.dll": {},
+          "lib/netcoreapp3.1/Microsoft.TestPlatform.CrossPlatEngine.dll": {},
+          "lib/netcoreapp3.1/Microsoft.TestPlatform.PlatformAbstractions.dll": {},
+          "lib/netcoreapp3.1/Microsoft.TestPlatform.Utilities.dll": {},
+          "lib/netcoreapp3.1/Microsoft.VisualStudio.TestPlatform.Common.dll": {},
+          "lib/netcoreapp3.1/Microsoft.TestPlatform.TranslationLayer.dll": {}
+        }
+      },
+      "Microsoft.VisualStudio.Composition/18.9.15": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading": "18.7.19",
+          "Microsoft.VisualStudio.Validation": "18.7.1",
+          "Nerdbank.Streams": "2.13.16"
+        },
+        "compile": {
+          "lib/net8.0/Microsoft.VisualStudio.Composition.dll": {}
+        },
+        "runtime": {
+          "lib/net8.0/Microsoft.VisualStudio.Composition.dll": {}
+        }
+      },
+      "Newtonsoft.Json/13.0.4": {
+        "type": "package",
+        "compile": {
+          "lib/net6.0/Newtonsoft.Json.dll": {}
+        },
+        "runtime": {
+          "lib/net6.0/Newtonsoft.Json.dll": {}
+        }
+      },
+      "NuGet.Common/6.8.0-rc.112": {
+        "type": "package",
+        "dependencies": {
+          "NuGet.Frameworks": "6.8.0-rc.112"
+        },
+        "compile": {
+          "lib/netstandard2.0/NuGet.Common.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard2.0/NuGet.Common.dll": {}
+        }
+      },
+      "NuGet.Configuration/6.8.0-rc.112": {
+        "type": "package",
+        "dependencies": {
+          "NuGet.Common": "6.8.0-rc.112"
+        },
+        "compile": {
+          "lib/netstandard2.0/NuGet.Configuration.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard2.0/NuGet.Configuration.dll": {}
+        }
+      },
+      "NuGet.Frameworks/6.8.0-rc.112": {
+        "type": "package",
+        "compile": {
+          "lib/netstandard2.0/NuGet.Frameworks.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard2.0/NuGet.Frameworks.dll": {}
+        }
+      },
+      "NuGet.LibraryModel/6.8.0-rc.112": {
+        "type": "package",
+        "dependencies": {
+          "NuGet.Common": "6.8.0-rc.112",
+          "NuGet.Versioning": "6.8.0-rc.112"
+        },
+        "compile": {
+          "lib/netstandard2.0/NuGet.LibraryModel.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard2.0/NuGet.LibraryModel.dll": {}
+        }
+      },
+      "NuGet.ProjectModel/6.8.0-rc.112": {
+        "type": "package",
+        "dependencies": {
+          "NuGet.Common": "6.8.0-rc.112",
+          "NuGet.Configuration": "6.8.0-rc.112",
+          "NuGet.DependencyResolver.Core": "6.8.0-rc.112",
+          "NuGet.Frameworks": "6.8.0-rc.112",
+          "NuGet.LibraryModel": "6.8.0-rc.112",
+          "NuGet.Packaging": "6.8.0-rc.112",
+          "NuGet.Versioning": "6.8.0-rc.112"
+        },
+        "compile": {
+          "lib/netstandard2.0/NuGet.ProjectModel.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard2.0/NuGet.ProjectModel.dll": {}
+        }
+      },
+      "NuGet.Versioning/6.8.0-rc.112": {
+        "type": "package",
+        "compile": {
+          "lib/netstandard2.0/NuGet.Versioning.dll": {}
+        },
+        "runtime": {
+          "lib/netstandard2.0/NuGet.Versioning.dll": {}
+        }
+      },
+      "SQLite3MC.PCLRaw.bundle/2.3.5": {
+        "type": "package",
+        "dependencies": {
+          "SQLite3MC.PCLRaw.lib": "2.3.5",
+          "SQLite3MC.PCLRaw.provider": "2.3.5",
+          "SQLitePCLRaw.core": "3.0.2"
+        },
+        "compile": {
+          "lib/net8.0/SQLite3MC.PCLRaw.bundle.dll": {}
+        },
+        "runtime": {
+          "lib/net8.0/SQLite3MC.PCLRaw.bundle.dll": {}
+        }
+      },
+      "SQLitePCLRaw.core/3.0.2": {
+        "type": "package",
+        "compile": {
+          "lib/net8.0/SQLitePCLRaw.core.dll": {}
+        },
+        "runtime": {
+          "lib/net8.0/SQLitePCLRaw.core.dll": {}
+        }
+      },
+      "StreamJsonRpc/2.26.5": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.VisualStudio.Threading": "18.7.19",
+          "Nerdbank.Streams": "2.13.16",
+          "Newtonsoft.Json": "13.0.4"
+        },
+        "compile": {
+          "lib/net8.0/StreamJsonRpc.dll": {}
+        },
+        "runtime": {
+          "lib/net8.0/StreamJsonRpc.dll": {}
+        }
+      },
+      "System.CommandLine/3.0.0-preview.6.26324.102": {
+        "type": "package",
+        "compile": {
+          "lib/net8.0/System.CommandLine.dll": {}
+        },
+        "runtime": {
+          "lib/net8.0/System.CommandLine.dll": {}
+        }
+      },
+      "System.Composition.Hosting/10.0.8": {
+        "type": "package",
+        "dependencies": {
+          "System.Composition.Runtime": "10.0.8"
+        },
+        "compile": {
+          "lib/net10.0/System.Composition.Hosting.dll": {}
+        },
+        "runtime": {
+          "lib/net10.0/System.Composition.Hosting.dll": {}
+        }
+      },
+      "System.Text.Json/10.0.8": {
+        "type": "package",
+        "dependencies": {
+          "System.IO.Pipelines": "10.0.8",
+          "System.Text.Encodings.Web": "10.0.8"
+        },
+        "compile": {
+          "lib/net10.0/System.Text.Json.dll": {}
+        },
+        "runtime": {
+          "lib/net10.0/System.Text.Json.dll": {}
+        }
+      },
+      "Microsoft.CodeAnalysis.Common/5.10.0-dev": {
+        "type": "project",
+        "framework": ".NETCoreApp,Version=v10.0",
+        "compile": {
+          "bin/placeholder/Microsoft.CodeAnalysis.dll": {}
+        },
+        "runtime": {
+          "bin/placeholder/Microsoft.CodeAnalysis.dll": {}
+        }
+      },
+      "Microsoft.CodeAnalysis.CSharp.Workspaces/5.10.0-dev": {
+        "type": "project",
+        "framework": ".NETCoreApp,Version=v10.0",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.CSharp": "5.10.0-dev",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "5.10.0-dev"
+        },
+        "compile": {
+          "bin/placeholder/Microsoft.CodeAnalysis.CSharp.Workspaces.dll": {}
+        },
+        "runtime": {
+          "bin/placeholder/Microsoft.CodeAnalysis.CSharp.Workspaces.dll": {}
+        }
+      },
+      "Microsoft.CodeAnalysis.Features/5.10.0-dev": {
+        "type": "project",
+        "framework": ".NETCoreApp,Version=v10.0",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Common": "5.10.0-dev",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "5.10.0-dev"
+        },
+        "compile": {
+          "bin/placeholder/Microsoft.CodeAnalysis.Features.dll": {}
+        },
+        "runtime": {
+          "bin/placeholder/Microsoft.CodeAnalysis.Features.dll": {}
+        }
+      },
+      "Microsoft.CodeAnalysis.LanguageServer.Protocol/5.10.0-dev": {
+        "type": "project",
+        "framework": ".NETCoreApp,Version=v10.0",
+        "compile": {
+          "bin/placeholder/Microsoft.CodeAnalysis.LanguageServer.Protocol.dll": {}
+        },
+        "runtime": {
+          "bin/placeholder/Microsoft.CodeAnalysis.LanguageServer.Protocol.dll": {}
+        }
+      },
+      "Microsoft.CodeAnalysis.Workspaces.MSBuild/5.10.0-dev": {
+        "type": "project",
+        "framework": ".NETCoreApp,Version=v10.0",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Workspaces.Common": "5.10.0-dev"
+        },
+        "compile": {
+          "bin/placeholder/Microsoft.CodeAnalysis.Workspaces.MSBuild.dll": {}
+        },
+        "runtime": {
+          "bin/placeholder/Microsoft.CodeAnalysis.Workspaces.MSBuild.dll": {}
+        }
+      }
+    }
+  },
+  "libraries": {
+    "Humanizer.Core/2.14.1": {
+      "sha512": "real-world-benchmark-placeholder",
+      "type": "package",
+      "path": "humanizer.core/2.14.1",
+      "files": [
+        ".nupkg.metadata",
+        "humanizer.core.2.14.1.nupkg.sha512",
+        "humanizer.core.nuspec",
+        "lib/net6.0/Humanizer.dll",
+        "lib/net6.0/Humanizer.xml"
+      ]
+    },
+    "MessagePack/2.5.302": {
+      "sha512": "real-world-benchmark-placeholder",
+      "type": "package",
+      "path": "messagepack/2.5.302",
+      "files": [
+        ".nupkg.metadata",
+        "lib/net6.0/MessagePack.dll",
+        "lib/net6.0/MessagePack.xml",
+        "messagepack.2.5.302.nupkg.sha512",
+        "messagepack.nuspec"
+      ]
+    },
+    "Microsoft.Build.Framework/18.7.1": {
+      "sha512": "real-world-benchmark-placeholder",
+      "type": "package",
+      "path": "microsoft.build.framework/18.7.1",
+      "files": [
+        ".nupkg.metadata",
+        "lib/net10.0/Microsoft.Build.Framework.dll",
+        "microsoft.build.framework.18.7.1.nupkg.sha512",
+        "microsoft.build.framework.nuspec",
+        "ref/net10.0/Microsoft.Build.Framework.dll"
+      ]
+    },
+    "Microsoft.Extensions.Configuration/10.0.1": {
+      "sha512": "real-world-benchmark-placeholder",
+      "type": "package",
+      "path": "microsoft.extensions.configuration/10.0.1",
+      "files": [
+        ".nupkg.metadata",
+        "lib/net10.0/Microsoft.Extensions.Configuration.dll",
+        "lib/net10.0/Microsoft.Extensions.Configuration.xml",
+        "microsoft.extensions.configuration.10.0.1.nupkg.sha512",
+        "microsoft.extensions.configuration.nuspec"
+      ]
+    },
+    "Microsoft.Extensions.FileSystemGlobbing/10.0.1": {
+      "sha512": "real-world-benchmark-placeholder",
+      "type": "package",
+      "path": "microsoft.extensions.filesystemglobbing/10.0.1",
+      "files": [
+        ".nupkg.metadata",
+        "lib/net10.0/Microsoft.Extensions.FileSystemGlobbing.dll",
+        "lib/net10.0/Microsoft.Extensions.FileSystemGlobbing.xml",
+        "microsoft.extensions.filesystemglobbing.10.0.1.nupkg.sha512",
+        "microsoft.extensions.filesystemglobbing.nuspec"
+      ]
+    },
+    "Microsoft.Extensions.Logging/10.0.1": {
+      "sha512": "real-world-benchmark-placeholder",
+      "type": "package",
+      "path": "microsoft.extensions.logging/10.0.1",
+      "files": [
+        ".nupkg.metadata",
+        "lib/net10.0/Microsoft.Extensions.Logging.dll",
+        "lib/net10.0/Microsoft.Extensions.Logging.xml",
+        "microsoft.extensions.logging.10.0.1.nupkg.sha512",
+        "microsoft.extensions.logging.nuspec"
+      ]
+    },
+    "Microsoft.Extensions.Logging.Console/10.0.1": {
+      "sha512": "real-world-benchmark-placeholder",
+      "type": "package",
+      "path": "microsoft.extensions.logging.console/10.0.1",
+      "files": [
+        ".nupkg.metadata",
+        "lib/net10.0/Microsoft.Extensions.Logging.Console.dll",
+        "lib/net10.0/Microsoft.Extensions.Logging.Console.xml",
+        "microsoft.extensions.logging.console.10.0.1.nupkg.sha512",
+        "microsoft.extensions.logging.console.nuspec"
+      ]
+    },
+    "Microsoft.ServiceHub.Framework/4.10.128": {
+      "sha512": "real-world-benchmark-placeholder",
+      "type": "package",
+      "path": "microsoft.servicehub.framework/4.10.128",
+      "files": [
+        ".nupkg.metadata",
+        "lib/net8.0/Microsoft.ServiceHub.Framework.dll",
+        "lib/net8.0/Microsoft.ServiceHub.Framework.xml",
+        "microsoft.servicehub.framework.4.10.128.nupkg.sha512",
+        "microsoft.servicehub.framework.nuspec"
+      ]
+    },
+    "Microsoft.TestPlatform.ObjectModel/17.14.1": {
+      "sha512": "real-world-benchmark-placeholder",
+      "type": "package",
+      "path": "microsoft.testplatform.objectmodel/17.14.1",
+      "files": [
+        ".nupkg.metadata",
+        "lib/netcoreapp3.1/Microsoft.TestPlatform.CoreUtilities.dll",
+        "lib/netcoreapp3.1/Microsoft.VisualStudio.TestPlatform.ObjectModel.dll",
+        "microsoft.testplatform.objectmodel.17.14.1.nupkg.sha512",
+        "microsoft.testplatform.objectmodel.nuspec"
+      ]
+    },
+    "Microsoft.TestPlatform.TranslationLayer/17.14.1": {
+      "sha512": "real-world-benchmark-placeholder",
+      "type": "package",
+      "path": "microsoft.testplatform.translationlayer/17.14.1",
+      "files": [
+        ".nupkg.metadata",
+        "lib/netcoreapp3.1/Microsoft.TestPlatform.TranslationLayer.dll",
+        "microsoft.testplatform.translationlayer.17.14.1.nupkg.sha512",
+        "microsoft.testplatform.translationlayer.nuspec"
+      ]
+    },
+    "Microsoft.VisualStudio.Composition/18.9.15": {
+      "sha512": "real-world-benchmark-placeholder",
+      "type": "package",
+      "path": "microsoft.visualstudio.composition/18.9.15",
+      "files": [
+        ".nupkg.metadata",
+        "lib/net8.0/Microsoft.VisualStudio.Composition.dll",
+        "lib/net8.0/Microsoft.VisualStudio.Composition.xml",
+        "microsoft.visualstudio.composition.18.9.15.nupkg.sha512",
+        "microsoft.visualstudio.composition.nuspec"
+      ]
+    },
+    "Newtonsoft.Json/13.0.4": {
+      "sha512": "real-world-benchmark-placeholder",
+      "type": "package",
+      "path": "newtonsoft.json/13.0.4",
+      "files": [
+        ".nupkg.metadata",
+        "lib/net6.0/Newtonsoft.Json.dll",
+        "lib/net6.0/Newtonsoft.Json.xml",
+        "newtonsoft.json.13.0.4.nupkg.sha512",
+        "newtonsoft.json.nuspec"
+      ]
+    },
+    "NuGet.Common/6.8.0-rc.112": {
+      "sha512": "real-world-benchmark-placeholder",
+      "type": "package",
+      "path": "nuget.common/6.8.0-rc.112",
+      "files": [
+        ".nupkg.metadata",
+        "lib/netstandard2.0/NuGet.Common.dll",
+        "lib/netstandard2.0/NuGet.Common.xml",
+        "nuget.common.6.8.0-rc.112.nupkg.sha512",
+        "nuget.common.nuspec"
+      ]
+    },
+    "NuGet.Configuration/6.8.0-rc.112": {
+      "sha512": "real-world-benchmark-placeholder",
+      "type": "package",
+      "path": "nuget.configuration/6.8.0-rc.112",
+      "files": [
+        ".nupkg.metadata",
+        "lib/netstandard2.0/NuGet.Configuration.dll",
+        "lib/netstandard2.0/NuGet.Configuration.xml",
+        "nuget.configuration.6.8.0-rc.112.nupkg.sha512",
+        "nuget.configuration.nuspec"
+      ]
+    },
+    "NuGet.Frameworks/6.8.0-rc.112": {
+      "sha512": "real-world-benchmark-placeholder",
+      "type": "package",
+      "path": "nuget.frameworks/6.8.0-rc.112",
+      "files": [
+        ".nupkg.metadata",
+        "lib/netstandard2.0/NuGet.Frameworks.dll",
+        "lib/netstandard2.0/NuGet.Frameworks.xml",
+        "nuget.frameworks.6.8.0-rc.112.nupkg.sha512",
+        "nuget.frameworks.nuspec"
+      ]
+    },
+    "NuGet.LibraryModel/6.8.0-rc.112": {
+      "sha512": "real-world-benchmark-placeholder",
+      "type": "package",
+      "path": "nuget.librarymodel/6.8.0-rc.112",
+      "files": [
+        ".nupkg.metadata",
+        "lib/netstandard2.0/NuGet.LibraryModel.dll",
+        "lib/netstandard2.0/NuGet.LibraryModel.xml",
+        "nuget.librarymodel.6.8.0-rc.112.nupkg.sha512",
+        "nuget.librarymodel.nuspec"
+      ]
+    },
+    "NuGet.ProjectModel/6.8.0-rc.112": {
+      "sha512": "real-world-benchmark-placeholder",
+      "type": "package",
+      "path": "nuget.projectmodel/6.8.0-rc.112",
+      "files": [
+        ".nupkg.metadata",
+        "lib/netstandard2.0/NuGet.ProjectModel.dll",
+        "lib/netstandard2.0/NuGet.ProjectModel.xml",
+        "nuget.projectmodel.6.8.0-rc.112.nupkg.sha512",
+        "nuget.projectmodel.nuspec"
+      ]
+    },
+    "NuGet.Versioning/6.8.0-rc.112": {
+      "sha512": "real-world-benchmark-placeholder",
+      "type": "package",
+      "path": "nuget.versioning/6.8.0-rc.112",
+      "files": [
+        ".nupkg.metadata",
+        "lib/netstandard2.0/NuGet.Versioning.dll",
+        "lib/netstandard2.0/NuGet.Versioning.xml",
+        "nuget.versioning.6.8.0-rc.112.nupkg.sha512",
+        "nuget.versioning.nuspec"
+      ]
+    },
+    "SQLite3MC.PCLRaw.bundle/2.3.5": {
+      "sha512": "real-world-benchmark-placeholder",
+      "type": "package",
+      "path": "sqlite3mc.pclraw.bundle/2.3.5",
+      "files": [
+        ".nupkg.metadata",
+        "lib/net8.0/SQLite3MC.PCLRaw.bundle.dll",
+        "sqlite3mc.pclraw.bundle.2.3.5.nupkg.sha512",
+        "sqlite3mc.pclraw.bundle.nuspec"
+      ]
+    },
+    "SQLitePCLRaw.core/3.0.2": {
+      "sha512": "real-world-benchmark-placeholder",
+      "type": "package",
+      "path": "sqlitepclraw.core/3.0.2",
+      "files": [
+        ".nupkg.metadata",
+        "lib/net8.0/SQLitePCLRaw.core.dll",
+        "lib/net8.0/SQLitePCLRaw.core.xml",
+        "sqlitepclraw.core.3.0.2.nupkg.sha512",
+        "sqlitepclraw.core.nuspec"
+      ]
+    },
+    "StreamJsonRpc/2.26.5": {
+      "sha512": "real-world-benchmark-placeholder",
+      "type": "package",
+      "path": "streamjsonrpc/2.26.5",
+      "files": [
+        ".nupkg.metadata",
+        "lib/net8.0/StreamJsonRpc.dll",
+        "lib/net8.0/StreamJsonRpc.xml",
+        "streamjsonrpc.2.26.5.nupkg.sha512",
+        "streamjsonrpc.nuspec"
+      ]
+    },
+    "System.CommandLine/3.0.0-preview.6.26324.102": {
+      "sha512": "real-world-benchmark-placeholder",
+      "type": "package",
+      "path": "system.commandline/3.0.0-preview.6.26324.102",
+      "files": [
+        ".nupkg.metadata",
+        "lib/net8.0/System.CommandLine.dll",
+        "lib/net8.0/System.CommandLine.xml",
+        "system.commandline.3.0.0-preview.6.26324.102.nupkg.sha512",
+        "system.commandline.nuspec"
+      ]
+    },
+    "System.Composition.Hosting/10.0.8": {
+      "sha512": "real-world-benchmark-placeholder",
+      "type": "package",
+      "path": "system.composition.hosting/10.0.8",
+      "files": [
+        ".nupkg.metadata",
+        "lib/net10.0/System.Composition.Hosting.dll",
+        "lib/net10.0/System.Composition.Hosting.xml",
+        "system.composition.hosting.10.0.8.nupkg.sha512",
+        "system.composition.hosting.nuspec"
+      ]
+    },
+    "System.Text.Json/10.0.8": {
+      "sha512": "real-world-benchmark-placeholder",
+      "type": "package",
+      "path": "system.text.json/10.0.8",
+      "files": [
+        ".nupkg.metadata",
+        "lib/net10.0/System.Text.Json.dll",
+        "lib/net10.0/System.Text.Json.xml",
+        "system.text.json.10.0.8.nupkg.sha512",
+        "system.text.json.nuspec"
+      ]
+    },
+    "Microsoft.CodeAnalysis.Common/5.10.0-dev": {
+      "type": "project",
+      "path": "../../Compilers/Core/Portable/Microsoft.CodeAnalysis.csproj",
+      "msbuildProject": "../../Compilers/Core/Portable/Microsoft.CodeAnalysis.csproj"
+    },
+    "Microsoft.CodeAnalysis.CSharp.Workspaces/5.10.0-dev": {
+      "type": "project",
+      "path": "../../Workspaces/CSharp/Portable/Microsoft.CodeAnalysis.CSharp.Workspaces.csproj",
+      "msbuildProject": "../../Workspaces/CSharp/Portable/Microsoft.CodeAnalysis.CSharp.Workspaces.csproj"
+    },
+    "Microsoft.CodeAnalysis.Features/5.10.0-dev": {
+      "type": "project",
+      "path": "../../Features/Core/Portable/Microsoft.CodeAnalysis.Features.csproj",
+      "msbuildProject": "../../Features/Core/Portable/Microsoft.CodeAnalysis.Features.csproj"
+    },
+    "Microsoft.CodeAnalysis.LanguageServer.Protocol/5.10.0-dev": {
+      "type": "project",
+      "path": "../Protocol/Microsoft.CodeAnalysis.LanguageServer.Protocol.csproj",
+      "msbuildProject": "../Protocol/Microsoft.CodeAnalysis.LanguageServer.Protocol.csproj"
+    },
+    "Microsoft.CodeAnalysis.Workspaces.MSBuild/5.10.0-dev": {
+      "type": "project",
+      "path": "../../Workspaces/MSBuild/Core/Microsoft.CodeAnalysis.Workspaces.MSBuild.csproj",
+      "msbuildProject": "../../Workspaces/MSBuild/Core/Microsoft.CodeAnalysis.Workspaces.MSBuild.csproj"
+    }
+  },
+  "projectFileDependencyGroups": {
+    "net10.0": [
+      "Microsoft.Extensions.FileSystemGlobbing >= 10.0.1",
+      "Microsoft.Extensions.Logging >= 10.0.1",
+      "Microsoft.ServiceHub.Framework >= 4.10.128",
+      "Microsoft.TestPlatform.ObjectModel >= 17.14.1",
+      "Microsoft.TestPlatform.TranslationLayer >= 17.14.1",
+      "Microsoft.VisualStudio.Composition >= 18.9.15",
+      "NuGet.ProjectModel >= 6.8.0-rc.112",
+      "SQLite3MC.PCLRaw.bundle >= 2.3.5",
+      "SQLitePCLRaw.core >= 3.0.2",
+      "System.CommandLine >= 3.0.0-preview.6.26324.102"
+    ]
+  },
+  "packageFolders": {
+    "C:\\Users\\developer\\.nuget\\packages\\": {}
+  },
+  "project": {
+    "version": "1.0.0",
+    "restore": {
+      "projectUniqueName": "C:\\src\\roslyn\\src\\LanguageServer\\Microsoft.CodeAnalysis.LanguageServer\\Microsoft.CodeAnalysis.LanguageServer.csproj",
+      "projectName": "Microsoft.CodeAnalysis.LanguageServer",
+      "projectPath": "C:\\src\\roslyn\\src\\LanguageServer\\Microsoft.CodeAnalysis.LanguageServer\\Microsoft.CodeAnalysis.LanguageServer.csproj",
+      "packagesPath": "C:\\Users\\developer\\.nuget\\packages\\",
+      "outputPath": "C:\\src\\roslyn\\artifacts\\obj\\Microsoft.CodeAnalysis.LanguageServer\\",
+      "projectStyle": "PackageReference",
+      "configFilePaths": [
+        "C:\\Users\\developer\\AppData\\Roaming\\NuGet\\NuGet.Config"
+      ],
+      "originalTargetFrameworks": [
+        "net10.0"
+      ],
+      "sources": {
+        "https://api.nuget.org/v3/index.json": {}
+      },
+      "frameworks": {
+        "net10.0": {
+          "targetAlias": "net10.0",
+          "projectReferences": {
+            "C:\\src\\roslyn\\src\\Compilers\\Core\\Portable\\Microsoft.CodeAnalysis.csproj": {
+              "projectPath": "C:\\src\\roslyn\\src\\Compilers\\Core\\Portable\\Microsoft.CodeAnalysis.csproj"
+            },
+            "C:\\src\\roslyn\\src\\Features\\Core\\Portable\\Microsoft.CodeAnalysis.Features.csproj": {
+              "projectPath": "C:\\src\\roslyn\\src\\Features\\Core\\Portable\\Microsoft.CodeAnalysis.Features.csproj"
+            },
+            "C:\\src\\roslyn\\src\\Workspaces\\MSBuild\\Core\\Microsoft.CodeAnalysis.Workspaces.MSBuild.csproj": {
+              "projectPath": "C:\\src\\roslyn\\src\\Workspaces\\MSBuild\\Core\\Microsoft.CodeAnalysis.Workspaces.MSBuild.csproj"
+            }
+          }
+        }
+      },
+      "warningProperties": {
+        "warnAsError": [
+          "NU1605"
+        ]
+      },
+      "restoreAuditProperties": {
+        "enableAudit": "true",
+        "auditLevel": "low",
+        "auditMode": "all"
+      }
+    },
+    "frameworks": {
+      "net10.0": {
+        "targetAlias": "net10.0",
+        "dependencies": {
+          "Microsoft.Extensions.FileSystemGlobbing": {
+            "target": "Package",
+            "version": "[10.0.1, )"
+          },
+          "Microsoft.Extensions.Logging": {
+            "target": "Package",
+            "version": "[10.0.1, )"
+          },
+          "Microsoft.ServiceHub.Framework": {
+            "target": "Package",
+            "version": "[4.10.128, )"
+          },
+          "Microsoft.TestPlatform.ObjectModel": {
+            "target": "Package",
+            "version": "[17.14.1, )"
+          },
+          "Microsoft.TestPlatform.TranslationLayer": {
+            "target": "Package",
+            "version": "[17.14.1, )"
+          },
+          "Microsoft.VisualStudio.Composition": {
+            "target": "Package",
+            "version": "[18.9.15, )"
+          },
+          "NuGet.ProjectModel": {
+            "target": "Package",
+            "version": "[6.8.0-rc.112, )"
+          },
+          "SQLite3MC.PCLRaw.bundle": {
+            "target": "Package",
+            "version": "[2.3.5, )"
+          },
+          "SQLitePCLRaw.core": {
+            "target": "Package",
+            "version": "[3.0.2, )"
+          },
+          "System.CommandLine": {
+            "target": "Package",
+            "version": "[3.0.0-preview.6.26324.102, )"
+          }
+        },
+        "imports": [
+          "net461",
+          "net462",
+          "net47",
+          "net471",
+          "net472",
+          "net48",
+          "net481"
+        ],
+        "assetTargetFallback": true,
+        "warn": true,
+        "frameworkReferences": {
+          "Microsoft.NETCore.App": {
+            "privateAssets": "all"
+          }
+        },
+        "runtimeIdentifierGraphPath": "C:\\Program Files\\dotnet\\sdk\\10.0.302/PortableRuntimeIdentifierGraph.json"
+      }
+    }
+  }
+}

--- a/src/Tools/IdeCoreBenchmarks/Lsp/ProjectAssetsReaderBenchmarks.cs
+++ b/src/Tools/IdeCoreBenchmarks/Lsp/ProjectAssetsReaderBenchmarks.cs
@@ -1,0 +1,138 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// Microsoft.CodeAnalysis.LanguageServer only targets .NET, so its assets reader is only benchmarked there.
+#if NET
+
+#nullable disable
+
+using System;
+using System.Buffers;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using Microsoft.CodeAnalysis.LanguageServer.HostWorkspace;
+using NuGet.ProjectModel;
+using NuGet.Versioning;
+
+namespace IdeCoreBenchmarks.Lsp
+{
+    /// <summary>
+    /// Compares the two ways of answering "did restore already resolve every PackageReference?" for a
+    /// project.assets.json: reading it into NuGet's LockFile model versus streaming just the library keys.
+    /// </summary>
+    /// <remarks>
+    /// Run with <c>--inProcess</c>. The default toolchain rebuilds the whole compiler graph for its generated
+    /// project, which races itself on Microsoft.CodeAnalysis' intermediate output and fails to build.
+    /// </remarks>
+    [MemoryDiagnoser]
+    public class ProjectAssetsReaderBenchmarks
+    {
+        private static readonly PackageReferenceItem[] s_packageReferences = new PackageReferenceItem[]
+        {
+            new("Microsoft.Extensions.FileSystemGlobbing", "[10.0.1]"),
+            new("Microsoft.Extensions.Logging", "[10.0.1]"),
+            new("Microsoft.ServiceHub.Framework", "[4.10.128]"),
+            new("Microsoft.TestPlatform.ObjectModel", "[17.14.1]"),
+            new("Microsoft.TestPlatform.TranslationLayer", "[17.14.1]"),
+            new("Microsoft.VisualStudio.Composition", "[18.9.15]"),
+            new("NuGet.ProjectModel", "[6.8.0-rc.112]"),
+            new("SQLite3MC.PCLRaw.bundle", "[2.3.5]"),
+            new("SQLitePCLRaw.core", "[3.0.2]"),
+            new("System.CommandLine", "[3.0.0-preview.6.26324.102]"),
+        };
+
+        private string _projectAssetsPath;
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            var roslynRoot = Environment.GetEnvironmentVariable(Program.RoslynRootPathEnvVariableName);
+            _projectAssetsPath = Path.Combine(
+                roslynRoot,
+                "src",
+                "Tools",
+                "IdeCoreBenchmarks",
+                "Lsp",
+                "ProjectAssetsReaderBenchmarkData.json");
+
+            // Both paths must agree the sample is fully restored, otherwise they are not doing the same work.
+            if (!CheckUpToDateWithLockFileModel() || !CheckUpToDateWithStreamingReader())
+                throw new InvalidDataException("The benchmark project.assets.json does not resolve all package references.");
+        }
+
+        [Benchmark(Baseline = true)]
+        public bool CheckUpToDateWithLockFileModel()
+        {
+            var lockFile = new LockFileFormat().Read(_projectAssetsPath);
+            var projectAssetsMap = lockFile.Libraries
+                .GroupBy(static library => library.Name, static library => library.Version, StringComparer.OrdinalIgnoreCase)
+                .ToImmutableDictionary(
+                    static group => group.Key,
+                    static group => group.ToImmutableArray(),
+                    StringComparer.OrdinalIgnoreCase);
+
+            foreach (var reference in s_packageReferences)
+            {
+                if (!projectAssetsMap.TryGetValue(reference.Name, out var versions))
+                    return false;
+
+                var requestedVersionRange = VersionRange.TryParse(reference.VersionRange, out var versionRange)
+                    ? versionRange
+                    : VersionRange.All;
+                if (!versions.Any(requestedVersionRange.Satisfies))
+                    return false;
+            }
+
+            return true;
+        }
+
+        [Benchmark]
+        public bool CheckUpToDateWithStreamingReader()
+        {
+            var resolvedReferences = ArrayPool<bool>.Shared.Rent(s_packageReferences.Length);
+            Array.Clear(resolvedReferences, 0, s_packageReferences.Length);
+            try
+            {
+                ProjectAssetsReader.FindResolvedPackageReferences(
+                    _projectAssetsPath,
+                    s_packageReferences,
+                    resolvedReferences.AsSpan(0, s_packageReferences.Length));
+
+                for (var i = 0; i < s_packageReferences.Length; i++)
+                {
+                    if (!resolvedReferences[i])
+                        return false;
+                }
+
+                return true;
+            }
+            finally
+            {
+                ArrayPool<bool>.Shared.Return(resolvedReferences);
+            }
+        }
+    }
+}
+
+namespace Microsoft.CodeAnalysis.LanguageServer.HostWorkspace
+{
+    /// <summary>
+    /// Stands in for the language server's model type, which is not reachable from this project.
+    /// </summary>
+    internal sealed class PackageReferenceItem
+    {
+        public PackageReferenceItem(string name, string versionRange)
+        {
+            Name = name;
+            VersionRange = versionRange;
+        }
+
+        public string Name { get; }
+        public string VersionRange { get; }
+    }
+}
+
+#endif

--- a/src/Tools/IdeCoreBenchmarks/Lsp/ProjectAssetsReaderBenchmarks.cs
+++ b/src/Tools/IdeCoreBenchmarks/Lsp/ProjectAssetsReaderBenchmarks.cs
@@ -96,10 +96,12 @@ namespace IdeCoreBenchmarks.Lsp
             Array.Clear(resolvedReferences, 0, s_packageReferences.Length);
             try
             {
+                int? assetsFileVersion = null;
                 ProjectAssetsReader.FindResolvedPackageReferences(
                     _projectAssetsPath,
                     s_packageReferences,
-                    resolvedReferences.AsSpan(0, s_packageReferences.Length));
+                    resolvedReferences.AsSpan(0, s_packageReferences.Length),
+                    ref assetsFileVersion);
 
                 for (var i = 0; i < s_packageReferences.Length; i++)
                 {


### PR DESCRIPTION
Alternative approach to #84205.

`ProjectDependencyHelper` called `LockFileFormat.Read` to materialize the whole `project.assets.json` into a `LockFile` model purely to answer one question: is every `PackageReference` resolved? That parses and allocates the entire file when only the keys of the top-level `libraries` object are needed.

Where #84205 avoids the cost by reading `project.nuget.cache` instead, this keeps reading `project.assets.json` (so there is no dependency on a second file staying in sync) and instead makes reading it cheap.

## Approach

`ProjectAssetsReader` streams the file through a pooled 16 KiB buffer with `Utf8JsonReader`, tracking depth so only the top-level `libraries` keys are examined. Keys are `Name/Version`, which is all that is needed to decide whether a `PackageReference` is satisfied.

Two details keep allocation flat rather than proportional to file size:

- Library keys are decoded onto the stack with `CopyString` instead of `GetString()`. On a large assets file (~1,500 libraries) `GetString()` alone would allocate 130-190 KB.
- `FileStream` is constructed with `bufferSize: 1`. It otherwise lazily allocates its own 4 KiB internal buffer once reads are smaller than that, which cancels out the pooling.

The buffer grows if a single JSON token does not fit. No real assets file needs this (the longest token across the 302 assets files in this repo is a few hundred bytes), but a valid file must not be rejected just because a token is unusually large.

## Benchmark

Added `ProjectAssetsReaderBenchmarks` to `IdeCoreBenchmarks`, over a checked-in 29 KB assets file taken from a real project in this repo. It is `#if NET` since `LockFileFormat` is only used on the .NET Core language server path.

Run with `--inProcess`; the default BenchmarkDotNet toolchain regenerates a project that rebuilds the Roslyn graph and races itself on `artifacts/obj`.

| Method | Median | Gen0 | Allocated |
| --- | ---: | ---: | ---: |
| `CheckUpToDateWithLockFileModel` (before) | 1.48 ms | 7.81 | 99,875 B |
| `CheckUpToDateWithStreamingReader` (after) | 1.16 ms | - | 922 B |

**Allocation drops by ~99% and no Gen0 collections remain.** Allocation was confirmed with a separate deterministic harness (explicit GC, 20 warmup + 200 measured iterations, `GC.GetAllocatedBytesForCurrentThread`), which independently measured 100,349 B vs 633 B per check.

Timing is the less reliable half of this table: it moved around with machine load across runs, with the streaming reader landing between 0.6x and 0.9x of baseline. Allocation is the durable result here, not the speedup.

Measured end to end, loading this repo's solution in the language server went from 340,849,616 to 328,875,544 bytes allocated (**-11.4 MiB, -3.5%**), which is in line with ~99 KB saved per project across the projects that have package references.

## Behavior

Unchanged, and covered by 21 tests: missing assets file, projects with no package references (file is not read at all), case-insensitive package ids, exact versions and version ranges, unparseable ranges, malformed files (still throw, as `LockFileFormat.Read` did), a `libraries` value that is valid JSON but not an object, project libraries, library names spanning a buffer boundary, tokens larger than the buffer, and a UTF-8 BOM.

Two of those are worth calling out because they were verified against the old code path rather than assumed:

- `Utf8JsonReader` does not consume a byte order mark, but `LockFileFormat` did, so the reader strips one explicitly to avoid rejecting a file that used to load.
- A `libraries` value that is valid JSON but not an object (`[]`, `null`, a string) is read as "no libraries" rather than throwing. `LockFileFormat` behaved the same way, so this reports the references as unresolved exactly as before.
