### PR TITLE
More fixes for Razor multiline attribute formatting

### DIFF
--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpFormattingPass.CSharpDocumentGenerator.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpFormattingPass.CSharpDocumentGenerator.cs
@@ -369,23 +369,38 @@ internal partial class CSharpFormattingPass
 
                 // We can't use node.Span because it can contain newlines from the line before, so we have to work a little.
 
-                // If we're inside an Html attribute, the indentation recorded in the Razor file already includes the fixed
-                // attribute indentation that will be reapplied when we map the formatted C# back. Remove that baseline here
-                // so Roslyn only sees the relative indentation within the expression instead of compounding it each time.
+                // If we're inside an Html attribute, the indentation recorded in the Razor file already includes the containing
+                // markup indentation that Roslyn will recreate, plus fixed attribute indentation that mapping will reapply.
+                // Remove that baseline here so Roslyn only sees the relative indentation within the expression.
                 var htmlIndentLevel = 0;
                 int? additionalIndentation = null;
+                // This is only removed from the generated C# indentation. Unlike additionalIndentation, it must not be
+                // passed through LineInfo and reapplied because Roslyn recreates the containing tag indentation structurally.
+                var startTagIndentationWidth = 0;
                 var attributeNode = node.Ancestors().FirstOrDefault(n => n.IsAnyAttributeSyntax())
                     ?? (previousLineStartedWithAttributeName ? previousTokenParent?.Parent : null);
                 if (attributeNode?.Parent is BaseMarkupStartTagSyntax attributeStartTag)
                 {
                     GetAttributeIndentation(attributeStartTag, out htmlIndentLevel, out var attributeAdditionalIndentation);
                     additionalIndentation = attributeAdditionalIndentation;
+                    // A leading '[' identifies a collection expression. Roslyn preserves its continuation indentation,
+                    // so unlike ordinary expressions we must not subtract the start tag indentation.
+                    if (!expressionStartsBlockLambda &&
+                        _sourceText[node.SpanStart] != '[')
+                    {
+                        startTagIndentationWidth = _sourceText.Lines[GetLineNumber(attributeStartTag.Name)].GetIndentationSize(_tabSize);
+                        if (ElementCausesIndentation(attributeStartTag))
+                        {
+                            // The start tag is emitted as an open brace, so Roslyn contributes one more structural indent.
+                            startTagIndentationWidth += _tabSize;
+                        }
+                    }
                 }
 
                 // First, emit the whitespace, so user spacing is honoured if possible. We do this while taking into account
                 // any indentation we want to add to line up attribute content, otherwise we'd end up pushing that content to
                 // the right repeatedly.
-                var attributeIndentationWidth = (htmlIndentLevel * _tabSize) + additionalIndentation.GetValueOrDefault();
+                var attributeIndentationWidth = startTagIndentationWidth + (htmlIndentLevel * _tabSize) + additionalIndentation.GetValueOrDefault();
 
                 // For lambda attributes like `OnClick=@(() => ...)`, Roslyn already contributes the
                 // lambda-body indentation on wrapped lines. If we keep applying the full attribute
@@ -615,9 +630,21 @@ internal partial class CSharpFormattingPass
                     return EmitCurrentLineAsComment();
                 }
 
-                var lineInfo = ElementCausesIndentation(node)
-                    ? EmitOpenBraceLine()          // When an element causes indentation, we emit an open brace to tell the C# formatter to indent.
-                    : EmitCurrentLineAsComment();  // This is a single line element, so it doesn't cause indentation
+                LineInfo lineInfo;
+                if (ElementCausesIndentation(node))
+                {
+                    // When an element causes indentation, we emit an open brace to tell the C# formatter to indent.
+                    lineInfo = EmitOpenBraceLine();
+                }
+                else if (ContainsMultilineCollectionExpressionStartingOnCurrentLine(node))
+                {
+                    lineInfo = EmitCollectionExpressionAssignmentLine();
+                }
+                else
+                {
+                    // This is a single line element, so it doesn't cause indentation.
+                    lineInfo = EmitCurrentLineAsComment();
+                }
 
                 if (RazorSyntaxFacts.IsScriptOrStyleBlock(node.ParentElement) &&
                     _honourHtmlFormattingUntilLine is null)
@@ -634,6 +661,14 @@ internal partial class CSharpFormattingPass
 
                 return lineInfo;
             }
+
+            private bool ContainsMultilineCollectionExpressionStartingOnCurrentLine(RazorSyntaxNode node)
+                => node.DescendantNodes()
+                    .OfType<CSharpExpressionLiteralSyntax>()
+                    .Any(expression =>
+                        GetLineNumber(expression) == _currentLine.LineNumber &&
+                        _sourceText.GetLinePositionSpan(expression.Span).SpansMultipleLines() &&
+                        _sourceText[expression.SpanStart] == '[');
 
             public override LineInfo VisitMarkupEndTag(MarkupEndTagSyntax node)
             {
@@ -773,6 +808,15 @@ internal partial class CSharpFormattingPass
                 {
                     GetAttributeIndentation(startTag, out var htmlIndentLevel, out var additionalIndentation);
 
+                    // Keep collection-expression scaffolding scoped to this attribute instead of another attribute on the tag.
+                    var attributeNode = node.Parent;
+                    Debug.Assert(attributeNode?.IsAnyAttributeSyntax() == true);
+                    if (attributeNode is not null &&
+                        ContainsMultilineCollectionExpressionStartingOnCurrentLine(attributeNode))
+                    {
+                        return EmitCollectionExpressionAssignmentLine(htmlIndentLevel, additionalIndentation);
+                    }
+
                     // Self-closing tags can be the last line of a multiline template, so emit the synthetic close here.
                     if (startTag.IsSelfClosing() &&
                         GetLineNumber(startTag.CloseAngle) == _currentLine.LineNumber &&
@@ -792,6 +836,14 @@ internal partial class CSharpFormattingPass
                 }
 
                 return null;
+            }
+
+            private LineInfo EmitCollectionExpressionAssignmentLine(int htmlIndentLevel = 0, int? additionalIndentation = null)
+            {
+                // Without an expression context, C# parses the leading '[' as an attribute list and loses the element's
+                // structural indentation. This line is synthetic, so only its indentation is mapped back to Razor.
+                _builder.AppendLine("_ =");
+                return CreateLineInfo(htmlIndentLevel: htmlIndentLevel, additionalIndentation: additionalIndentation);
             }
 
             private void GetAttributeIndentation(BaseMarkupStartTagSyntax startTag, out int htmlIndentLevel, out int additionalIndentation)

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Formatting/DocumentFormattingTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Formatting/DocumentFormattingTest.cs
@@ -11405,7 +11405,177 @@ public class DocumentFormattingTest(ITestOutputHelper testOutput) : DocumentForm
 
     [Fact]
     [WorkItem("https://github.com/dotnet/razor/issues/13121")]
-    public async Task MultilineExplicitExpressionInAttribute_DoesNotShiftRight_IndentByOne()
+    public async Task NestedMultilineExplicitExpressionInFirstAttribute_IsStable()
+    {
+        var code = """
+            <div>
+                <MyComponent String="@("foo " +
+                                       "bar " +
+                                       "baz")"
+                             Show="@_bool1" />
+            </div>
+            """;
+
+        await RunFormattingTestAsync(
+            input: code,
+            htmlFormatted: code,
+            expected: code);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13121")]
+    public async Task NestedMultilineCollectionExpressionInSecondAttribute_IsStable()
+    {
+        var code = """
+            <div>
+                <MyComponent2 Show="@_bool1"
+                              Strings="@(["string1",
+                                          "string2",
+                                          "string3"])" />
+            </div>
+            """;
+
+        await RunFormattingTestAsync(
+            input: code,
+            htmlFormatted: code,
+            expected: code);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13121")]
+    public async Task TopLevelMultilineCollectionExpressionInFirstAttribute_IsStable()
+    {
+        var code = """
+            <MyComponent2 Strings="@(["string1",
+                                      "string2",
+                                      "string3"])" />
+            """;
+
+        await RunFormattingTestAsync(
+            input: code,
+            htmlFormatted: code,
+            expected: code);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13121")]
+    public async Task TopLevelMultilineCollectionExpressionInFirstAttribute_IsStable_IndentByOne()
+    {
+        var code = """
+            <MyComponent2 Strings="@(["string1",
+                                      "string2",
+                                      "string3"])" />
+            """;
+
+        await RunFormattingTestAsync(
+            input: code,
+            htmlFormatted: code,
+            expected: code,
+            attributeIndentStyle: AttributeIndentStyle.IndentByOne);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13121")]
+    public async Task TopLevelMultilineCollectionExpressionInFirstAttribute_IsStable_IndentByTwo()
+    {
+        var code = """
+            <MyComponent2 Strings="@(["string1",
+                                      "string2",
+                                      "string3"])" />
+            """;
+
+        await RunFormattingTestAsync(
+            input: code,
+            htmlFormatted: code,
+            expected: code,
+            attributeIndentStyle: AttributeIndentStyle.IndentByTwo);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13121")]
+    public async Task NestedMultilineExplicitExpressionInNonSelfClosingElement_IsStable()
+    {
+        var code = """
+            <div>
+                <MyComponent String="@("foo " +
+                                       "bar " +
+                                       "baz")">
+                    <span>Content</span>
+                </MyComponent>
+            </div>
+            """;
+
+        await RunFormattingTestAsync(
+            input: code,
+            htmlFormatted: code,
+            expected: code);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13121")]
+    public async Task NestedMultilineCollectionExpressionInNonSelfClosingElement_IsStable()
+    {
+        var code = """
+            <div>
+                <MyComponent2 Strings="@(["string1",
+                                          "string2",
+                                          "string3"])">
+                    <span>Content</span>
+                </MyComponent2>
+            </div>
+            """;
+
+        await RunFormattingTestAsync(
+            input: code,
+            htmlFormatted: code,
+            expected: code);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13121")]
+    public async Task NestedMixedMultilineExplicitAndCollectionExpressions_AreStable()
+    {
+        var code = """
+            <div>
+                <MyComponent String="@("foo " +
+                                       "bar " +
+                                       "baz")"
+                             Strings="@(["string1",
+                                         "string2",
+                                         "string3"])" />
+            </div>
+            """;
+
+        await RunFormattingTestAsync(
+            input: code,
+            htmlFormatted: code,
+            expected: code);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13121")]
+    public async Task NestedMixedMultilineCollectionAndExplicitExpressions_AreStable()
+    {
+        var code = """
+            <div>
+                <MyComponent Strings="@(["string1",
+                                         "string2",
+                                         "string3"])"
+                             String="@("foo " +
+                                       "bar " +
+                                       "baz")" />
+            </div>
+            """;
+
+        await RunFormattingTestAsync(
+            input: code,
+            htmlFormatted: code,
+            expected: code);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13121")]
+    public async Task TopLevelMultilineExplicitExpressionInSecondAttribute_IsStable_IndentByOne()
     {
         var code = """
             <MyComponent Show="@_bool1"
@@ -11428,7 +11598,7 @@ public class DocumentFormattingTest(ITestOutputHelper testOutput) : DocumentForm
 
     [Fact]
     [WorkItem("https://github.com/dotnet/razor/issues/13121")]
-    public async Task MultilineExplicitExpressionInAttribute_DoesNotShiftRight_IndentByTwo()
+    public async Task TopLevelMultilineExplicitExpressionInSecondAttribute_IsStable_IndentByTwo()
     {
         var code = """
             <MyComponent Show="@_bool1"
@@ -11444,6 +11614,584 @@ public class DocumentFormattingTest(ITestOutputHelper testOutput) : DocumentForm
                              String="@("foo " +
                             "bar " +
                             "baz")" />
+                """,
+            expected: code,
+            attributeIndentStyle: AttributeIndentStyle.IndentByTwo);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13121")]
+    public async Task TopLevelMultilineExplicitExpressionInSecondAttribute_FormatsUnindentedInput()
+    {
+        await RunFormattingTestAsync(
+            input: """
+                <MyComponent Show="@_bool1"
+                String="@("foo " +
+                "bar " +
+                "baz")" />
+                """,
+            htmlFormatted: """
+                <MyComponent Show="@_bool1"
+                             String="@("foo " +
+                "bar " +
+                "baz")" />
+                """,
+            expected: """
+                <MyComponent Show="@_bool1"
+                             String="@("foo " +
+                             "bar " +
+                             "baz")" />
+                """);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13121")]
+    public async Task TopLevelMultilineExplicitExpressionInSecondAttribute_FormattedOutputIsStable()
+    {
+        var code = """
+            <MyComponent Show="@_bool1"
+                         String="@("foo " +
+                         "bar " +
+                         "baz")" />
+            """;
+
+        await RunFormattingTestAsync(
+            input: code,
+            htmlFormatted: code,
+            expected: code);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13121")]
+    public async Task NestedMultilineExplicitExpressionInSecondAttribute_FormatsUnindentedInput()
+    {
+        await RunFormattingTestAsync(
+            input: """
+                <div>
+                <MyComponent Show="@_bool1"
+                String="@("foo " +
+                "bar " +
+                "baz")" />
+                </div>
+                """,
+            htmlFormatted: """
+                <div>
+                    <MyComponent Show="@_bool1"
+                                 String="@("foo " +
+                "bar " +
+                "baz")" />
+                </div>
+                """,
+            expected: """
+                <div>
+                    <MyComponent Show="@_bool1"
+                                 String="@("foo " +
+                                 "bar " +
+                                 "baz")" />
+                </div>
+                """);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13121")]
+    public async Task NestedMultilineExplicitExpressionInSecondAttribute_FormattedOutputIsStable()
+    {
+        var code = """
+            <div>
+                <MyComponent Show="@_bool1"
+                             String="@("foo " +
+                             "bar " +
+                             "baz")" />
+            </div>
+            """;
+
+        await RunFormattingTestAsync(
+            input: code,
+            htmlFormatted: code,
+            expected: code);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13121")]
+    public async Task NestedMultilineCollectionExpressionInFirstAttribute_FormatsUnindentedInput()
+    {
+        await RunFormattingTestAsync(
+            input: """
+                <div>
+                <MyComponent2 Strings="@(["string1",
+                "string2",
+                "string3"])" />
+                </div>
+                """,
+            htmlFormatted: """
+                <div>
+                    <MyComponent2 Strings="@(["string1",
+                "string2",
+                "string3"])" />
+                </div>
+                """,
+            expected: """
+                <div>
+                    <MyComponent2 Strings="@(["string1",
+                              "string2",
+                              "string3"])" />
+                </div>
+                """);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13121")]
+    public async Task NestedMultilineCollectionExpressionInFirstAttribute_FormattedOutputIsStable()
+    {
+        var code = """
+            <div>
+                <MyComponent2 Strings="@(["string1",
+                          "string2",
+                          "string3"])" />
+            </div>
+            """;
+
+        await RunFormattingTestAsync(
+            input: code,
+            htmlFormatted: code,
+            expected: code);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13121")]
+    public async Task NestedSingleLineCollectionExpressionInFirstAttribute_FormatsUnindentedInput()
+    {
+        await RunFormattingTestAsync(
+            input: """
+                <div>
+                <MyComponent2 Strings="@(["string1", "string2", "string3"])" />
+                </div>
+                """,
+            htmlFormatted: """
+                <div>
+                    <MyComponent2 Strings="@(["string1", "string2", "string3"])" />
+                </div>
+                """,
+            expected: """
+                <div>
+                    <MyComponent2 Strings="@(["string1", "string2", "string3"])" />
+                </div>
+                """);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13121")]
+    public async Task NestedMultilineExplicitExpressionInFirstAttribute_FormatsUnindentedInput()
+    {
+        await RunFormattingTestAsync(
+            input: """
+                <div>
+                <MyComponent String="@("foo " +
+                "bar " +
+                "baz")"
+                Show="@_bool1" />
+                </div>
+                """,
+            htmlFormatted: """
+                <div>
+                    <MyComponent String="@("foo " +
+                "bar " +
+                "baz")"
+                                 Show="@_bool1" />
+                </div>
+                """,
+            expected: """
+                <div>
+                    <MyComponent String="@("foo " +
+                                 "bar " +
+                                 "baz")"
+                                 Show="@_bool1" />
+                </div>
+                """);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13121")]
+    public async Task NestedMultilineExplicitExpressionInFirstAttribute_FormattedOutputIsStable()
+    {
+        var code = """
+            <div>
+                <MyComponent String="@("foo " +
+                             "bar " +
+                             "baz")"
+                             Show="@_bool1" />
+            </div>
+            """;
+
+        await RunFormattingTestAsync(
+            input: code,
+            htmlFormatted: code,
+            expected: code);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13121")]
+    public async Task NestedMultilineCollectionExpressionInSecondAttribute_FormatsUnindentedInput()
+    {
+        await RunFormattingTestAsync(
+            input: """
+                <div>
+                <MyComponent2 Show="@_bool1"
+                Strings="@(["string1",
+                "string2",
+                "string3"])" />
+                </div>
+                """,
+            htmlFormatted: """
+                <div>
+                    <MyComponent2 Show="@_bool1"
+                                  Strings="@(["string1",
+                "string2",
+                "string3"])" />
+                </div>
+                """,
+            expected: """
+                <div>
+                    <MyComponent2 Show="@_bool1"
+                                  Strings="@(["string1",
+                              "string2",
+                              "string3"])" />
+                </div>
+                """);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13121")]
+    public async Task NestedMultilineCollectionExpressionInSecondAttribute_FormattedOutputIsStable()
+    {
+        var code = """
+            <div>
+                <MyComponent2 Show="@_bool1"
+                              Strings="@(["string1",
+                          "string2",
+                          "string3"])" />
+            </div>
+            """;
+
+        await RunFormattingTestAsync(
+            input: code,
+            htmlFormatted: code,
+            expected: code);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13121")]
+    public async Task TopLevelMultilineCollectionExpressionInFirstAttribute_FormatsUnindentedInput()
+    {
+        var input = """
+            <MyComponent2 Strings="@(["string1",
+            "string2",
+            "string3"])" />
+            """;
+
+        await RunFormattingTestAsync(
+            input: input,
+            htmlFormatted: input,
+            expected: """
+                <MyComponent2 Strings="@(["string1",
+                              "string2",
+                              "string3"])" />
+                """);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13121")]
+    public async Task TopLevelMultilineCollectionExpressionInFirstAttribute_FormattedOutputIsStable()
+    {
+        var code = """
+            <MyComponent2 Strings="@(["string1",
+                          "string2",
+                          "string3"])" />
+            """;
+
+        await RunFormattingTestAsync(
+            input: code,
+            htmlFormatted: code,
+            expected: code);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13121")]
+    public async Task TopLevelMultilineCollectionExpressionInFirstAttribute_FormatsUnindentedInput_IndentByOne()
+    {
+        var input = """
+            <MyComponent2 Strings="@(["string1",
+            "string2",
+            "string3"])" />
+            """;
+
+        await RunFormattingTestAsync(
+            input: input,
+            htmlFormatted: input,
+            expected: """
+                <MyComponent2 Strings="@(["string1",
+                    "string2",
+                    "string3"])" />
+                """,
+            attributeIndentStyle: AttributeIndentStyle.IndentByOne);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13121")]
+    public async Task TopLevelMultilineCollectionExpressionInFirstAttribute_FormattedOutputIsStable_IndentByOne()
+    {
+        var code = """
+            <MyComponent2 Strings="@(["string1",
+                "string2",
+                "string3"])" />
+            """;
+
+        await RunFormattingTestAsync(
+            input: code,
+            htmlFormatted: code,
+            expected: code,
+            attributeIndentStyle: AttributeIndentStyle.IndentByOne);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13121")]
+    public async Task TopLevelMultilineCollectionExpressionInFirstAttribute_FormatsUnindentedInput_IndentByTwo()
+    {
+        var input = """
+            <MyComponent2 Strings="@(["string1",
+            "string2",
+            "string3"])" />
+            """;
+
+        await RunFormattingTestAsync(
+            input: input,
+            htmlFormatted: input,
+            expected: """
+                <MyComponent2 Strings="@(["string1",
+                        "string2",
+                        "string3"])" />
+                """,
+            attributeIndentStyle: AttributeIndentStyle.IndentByTwo);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13121")]
+    public async Task TopLevelMultilineCollectionExpressionInFirstAttribute_FormattedOutputIsStable_IndentByTwo()
+    {
+        var code = """
+            <MyComponent2 Strings="@(["string1",
+                    "string2",
+                    "string3"])" />
+            """;
+
+        await RunFormattingTestAsync(
+            input: code,
+            htmlFormatted: code,
+            expected: code,
+            attributeIndentStyle: AttributeIndentStyle.IndentByTwo);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13121")]
+    public async Task NestedMultilineExplicitExpressionInNonSelfClosingElement_FormatsUnindentedInput()
+    {
+        await RunFormattingTestAsync(
+            input: """
+                <div>
+                <MyComponent String="@("foo " +
+                "bar " +
+                "baz")">
+                <span>Content</span>
+                </MyComponent>
+                </div>
+                """,
+            htmlFormatted: """
+                <div>
+                    <MyComponent String="@("foo " +
+                "bar " +
+                "baz")">
+                        <span>Content</span>
+                    </MyComponent>
+                </div>
+                """,
+            expected: """
+                <div>
+                    <MyComponent String="@("foo " +
+                                 "bar " +
+                                 "baz")">
+                        <span>Content</span>
+                    </MyComponent>
+                </div>
+                """);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13121")]
+    public async Task NestedMultilineExplicitExpressionInNonSelfClosingElement_FormattedOutputIsStable()
+    {
+        var code = """
+            <div>
+                <MyComponent String="@("foo " +
+                             "bar " +
+                             "baz")">
+                    <span>Content</span>
+                </MyComponent>
+            </div>
+            """;
+
+        await RunFormattingTestAsync(
+            input: code,
+            htmlFormatted: code,
+            expected: code);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13121")]
+    public async Task NestedMultilineCollectionExpressionInNonSelfClosingElement_FormatsUnindentedInput()
+    {
+        await RunFormattingTestAsync(
+            input: """
+                <div>
+                <MyComponent2 Strings="@(["string1",
+                "string2",
+                "string3"])">
+                <span>Content</span>
+                </MyComponent2>
+                </div>
+                """,
+            htmlFormatted: """
+                <div>
+                    <MyComponent2 Strings="@(["string1",
+                "string2",
+                "string3"])">
+                        <span>Content</span>
+                    </MyComponent2>
+                </div>
+                """,
+            expected: """
+                <div>
+                    <MyComponent2 Strings="@(["string1",
+                          "string2",
+                          "string3"])">
+                        <span>Content</span>
+                    </MyComponent2>
+                </div>
+                """);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13121")]
+    public async Task NestedMultilineCollectionExpressionInNonSelfClosingElement_FormattedOutputIsStable()
+    {
+        var code = """
+            <div>
+                <MyComponent2 Strings="@(["string1",
+                      "string2",
+                      "string3"])">
+                    <span>Content</span>
+                </MyComponent2>
+            </div>
+            """;
+
+        await RunFormattingTestAsync(
+            input: code,
+            htmlFormatted: code,
+            expected: code);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13121")]
+    public async Task TopLevelMultilineExplicitExpressionInSecondAttribute_FormatsUnindentedInput_IndentByOne()
+    {
+        await RunFormattingTestAsync(
+            input: """
+                <MyComponent Show="@_bool1"
+                String="@("foo " +
+                "bar " +
+                "baz")" />
+                """,
+            htmlFormatted: """
+                <MyComponent Show="@_bool1"
+                             String="@("foo " +
+                "bar " +
+                "baz")" />
+                """,
+            expected: """
+                <MyComponent Show="@_bool1"
+                    String="@("foo " +
+                    "bar " +
+                    "baz")" />
+                """,
+            attributeIndentStyle: AttributeIndentStyle.IndentByOne);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13121")]
+    public async Task TopLevelMultilineExplicitExpressionInSecondAttribute_FormattedOutputIsStable_IndentByOne()
+    {
+        var code = """
+            <MyComponent Show="@_bool1"
+                String="@("foo " +
+                "bar " +
+                "baz")" />
+            """;
+
+        await RunFormattingTestAsync(
+            input: code,
+            htmlFormatted: """
+                <MyComponent Show="@_bool1"
+                             String="@("foo " +
+                    "bar " +
+                    "baz")" />
+                """,
+            expected: code,
+            attributeIndentStyle: AttributeIndentStyle.IndentByOne);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13121")]
+    public async Task TopLevelMultilineExplicitExpressionInSecondAttribute_FormatsUnindentedInput_IndentByTwo()
+    {
+        await RunFormattingTestAsync(
+            input: """
+                <MyComponent Show="@_bool1"
+                String="@("foo " +
+                "bar " +
+                "baz")" />
+                """,
+            htmlFormatted: """
+                <MyComponent Show="@_bool1"
+                             String="@("foo " +
+                "bar " +
+                "baz")" />
+                """,
+            expected: """
+                <MyComponent Show="@_bool1"
+                        String="@("foo " +
+                        "bar " +
+                        "baz")" />
+                """,
+            attributeIndentStyle: AttributeIndentStyle.IndentByTwo);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13121")]
+    public async Task TopLevelMultilineExplicitExpressionInSecondAttribute_FormattedOutputIsStable_IndentByTwo()
+    {
+        var code = """
+            <MyComponent Show="@_bool1"
+                    String="@("foo " +
+                    "bar " +
+                    "baz")" />
+            """;
+
+        await RunFormattingTestAsync(
+            input: code,
+            htmlFormatted: """
+                <MyComponent Show="@_bool1"
+                             String="@("foo " +
+                        "bar " +
+                        "baz")" />
                 """,
             expected: code,
             attributeIndentStyle: AttributeIndentStyle.IndentByTwo);

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Formatting/DocumentFormattingTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Formatting/DocumentFormattingTest.cs
@@ -11335,13 +11335,66 @@ public class DocumentFormattingTest(ITestOutputHelper testOutput) : DocumentForm
 
     [Fact]
     [WorkItem("https://github.com/dotnet/razor/issues/13121")]
-    public async Task MultilineExplicitExpressionInAttribute_DoesNotShiftRight()
+    public async Task TopLevelMultilineExplicitExpressionInSecondAttribute_IsStable()
     {
         var code = """
             <MyComponent Show="@_bool1"
                          String="@("foo " +
                                    "bar " +
                                    "baz")" />
+            """;
+
+        await RunFormattingTestAsync(
+            input: code,
+            htmlFormatted: code,
+            expected: code);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13121")]
+    public async Task NestedMultilineExplicitExpressionInSecondAttribute_IsStable()
+    {
+        var code = """
+            <div>
+                <MyComponent Show="@_bool1"
+                             String="@("foo " +
+                                       "bar " +
+                                       "baz")" />
+            </div>
+            """;
+
+        await RunFormattingTestAsync(
+            input: code,
+            htmlFormatted: code,
+            expected: code);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13121")]
+    public async Task NestedMultilineCollectionExpressionInFirstAttribute_IsStable()
+    {
+        var code = """
+            <div>
+                <MyComponent2 Strings="@(["string1",
+                                          "string2",
+                                          "string3"])" />
+            </div>
+            """;
+
+        await RunFormattingTestAsync(
+            input: code,
+            htmlFormatted: code,
+            expected: code);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/13121")]
+    public async Task NestedSingleLineCollectionExpressionInFirstAttribute_IsStable()
+    {
+        var code = """
+            <div>
+                <MyComponent2 Strings="@(["string1", "string2", "string3"])" />
+            </div>
             """;
 
         await RunFormattingTestAsync(


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/13121 again

My previous fix didn't have enough testing, and then collection expressions came along and broke it in more ways. This time I've added a bunch more test coverage, most of which didn't need many changes, and also collection expression coverage/support, which needs specific handling lest Roslyn think a collection expression is an attribute list, due to the standalone way we write out C# expressions from attributes.

Some of the tests `expected` don't look that good, but I'm okay with it because a) it mirrors roslyn, which doesn't indent anything but the first line of a multiline expression in most cases and b) the results are at least stable, which is proven by multiple new tests, so worst case the user can manually fix up the results, and the formatter won't undo their work.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84656)