### PR TITLE
Escape token text in VB grammar generator

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Generated/VisualBasic.Grammar.g4
+++ b/src/Compilers/VisualBasic/Portable/Generated/VisualBasic.Grammar.g4
@@ -837,7 +837,7 @@ remove_handler_statement
   ;
 
 assignment_statement
-  : expression ('=' | '+=' | '-=' | '*=' | '/=' | '\=' | '^=' | '<<=' | '>>=' | '&=') expression
+  : expression ('=' | '+=' | '-=' | '*=' | '/=' | '\\=' | '^=' | '<<=' | '>>=' | '&=') expression
   ;
 
 call_statement

--- a/src/Tools/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/Grammar/GrammarGenerator.vb
+++ b/src/Tools/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/Grammar/GrammarGenerator.vb
@@ -286,13 +286,8 @@ Friend Class GrammarGenerator
 
     Private Function HandleNodeKind(nodeKind As ParseNodeKind) As Production
         If Not String.IsNullOrEmpty(nodeKind.TokenText) Then
-            If nodeKind.TokenText = "\" Then
-                Return New Production("'\\'")
-            ElseIf nodeKind.TokenText = "'" Then
-                Return New Production("'\''")
-            Else
-                Return New Production("'" + nodeKind.TokenText + "'")
-            End If
+            Dim tokenText = nodeKind.TokenText.Replace("\", "\\").Replace("'", "\'")
+            Return New Production("'" + tokenText + "'")
         End If
 
         If nodeKind.Name = "EmptyToken" Then


### PR DESCRIPTION
Fixes #84635

The Visual Basic grammar generator only escaped token text when the entire text was `\` or `'`. As a result, `\=` was emitted as the invalid ANTLR literal `'\='`.

Escape backslashes and apostrophes in every token text before emitting a grammar literal, then regenerate `VisualBasic.Grammar.g4`. Existing escaped token output remains unchanged, while `IntegerDivideEqualsToken` is now emitted as `'\\='`.

Validation:

- Built `Compilers.slnf` in Debug configuration (0 warnings, 0 errors).
- Verified generated files with `eng/generate-compiler-code.cs -test`.
- Ran the Visual Basic syntax unit tests (4,031 passed, 3 skipped).
- Verified with ANTLR 4.13.2 that `error(156)` is removed; the three pre-existing duplicate-rule diagnostics tracked by #84633 remain.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84659)