### PR TITLE
Fix three defects in the VB grammar generator

### DIFF
--- a/.github/memory/known-issues/compiler.md
+++ b/.github/memory/known-issues/compiler.md
@@ -9,35 +9,6 @@ Layer-specific quirks for the compiler. Load when working under
 (generated code, CI marker gating, environmental test failures) live in
 `.github/memory/KNOWN_ISSUES.md`.
 
-## VB grammar generator pairs node-kinds with child-kinds by position
-
-- **Affected area:** `src/Tools/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/Grammar/GrammarGenerator.vb`,
-  `src/Compilers/VisualBasic/Portable/Syntax/Syntax.xml`
-- **Description:** When a `node-structure` declares several `node-kind`s and a child
-  declares the same number of kinds, the generator emits one grammar rule per node-kind
-  and pairs kind *i* of the node with kind *i* of the child. Unless the child spells the
-  pairing out with `<kind name="..." node-kind="..."/>` elements, the two declaration
-  orders in `Syntax.xml` must agree or the generated grammar is silently wrong.
-  Adding the explicit `<kind>` elements is not a free fix: it also makes the child
-  auto-creatable, which changes the generated `SyntaxFactory` overloads (a public API
-  break).
-- **Workaround:** Keep the child's `kind="A|B"` list in the same order as the
-  structure's `node-kind` elements.
-
-## VB grammar rule names come from both structures and node-kinds
-
-- **Affected area:** same generator.
-- **Description:** Rule books are keyed by raw name (`ResumeStatementSyntax` vs
-  `ResumeStatement`) but emitted names drop the `Syntax` suffix, so a node-kind named
-  after its own structure collapses onto the structure's rule. The generator now folds
-  such a specialization into the structure's rule rather than emitting it twice.
-- **Workaround:** None needed; be aware when adding a node-kind whose name matches its
-  structure minus `Syntax`.
-
-## Plain-list multiplicity in the VB grammar comes from `min-count`
-
-- **Affected area:** same generator.
-- **Description:** `min-count` on a `<child>` is consumed only by the grammar generator
-  in VB (nothing else in codegen reads it), so it is the safe way to mark a list as
-  required. `optional="true"` on a list child does feed codegen — it makes the factory
-  parameter defaultable — so do not flip it just to influence the grammar.
+_No compiler-specific known issues are currently documented. Add entries here as
+they are discovered, using the `Affected area` / `Description` / `Workaround`
+shape from the repo-wide `KNOWN_ISSUES.md`._

--- a/.github/memory/known-issues/compiler.md
+++ b/.github/memory/known-issues/compiler.md
@@ -9,6 +9,35 @@ Layer-specific quirks for the compiler. Load when working under
 (generated code, CI marker gating, environmental test failures) live in
 `.github/memory/KNOWN_ISSUES.md`.
 
-_No compiler-specific known issues are currently documented. Add entries here as
-they are discovered, using the `Affected area` / `Description` / `Workaround`
-shape from the repo-wide `KNOWN_ISSUES.md`._
+## VB grammar generator pairs node-kinds with child-kinds by position
+
+- **Affected area:** `src/Tools/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/Grammar/GrammarGenerator.vb`,
+  `src/Compilers/VisualBasic/Portable/Syntax/Syntax.xml`
+- **Description:** When a `node-structure` declares several `node-kind`s and a child
+  declares the same number of kinds, the generator emits one grammar rule per node-kind
+  and pairs kind *i* of the node with kind *i* of the child. Unless the child spells the
+  pairing out with `<kind name="..." node-kind="..."/>` elements, the two declaration
+  orders in `Syntax.xml` must agree or the generated grammar is silently wrong.
+  Adding the explicit `<kind>` elements is not a free fix: it also makes the child
+  auto-creatable, which changes the generated `SyntaxFactory` overloads (a public API
+  break).
+- **Workaround:** Keep the child's `kind="A|B"` list in the same order as the
+  structure's `node-kind` elements.
+
+## VB grammar rule names come from both structures and node-kinds
+
+- **Affected area:** same generator.
+- **Description:** Rule books are keyed by raw name (`ResumeStatementSyntax` vs
+  `ResumeStatement`) but emitted names drop the `Syntax` suffix, so a node-kind named
+  after its own structure collapses onto the structure's rule. The generator now folds
+  such a specialization into the structure's rule rather than emitting it twice.
+- **Workaround:** None needed; be aware when adding a node-kind whose name matches its
+  structure minus `Syntax`.
+
+## Plain-list multiplicity in the VB grammar comes from `min-count`
+
+- **Affected area:** same generator.
+- **Description:** `min-count` on a `<child>` is consumed only by the grammar generator
+  in VB (nothing else in codegen reads it), so it is the safe way to mark a list as
+  required. `optional="true"` on a list child does feed codegen — it makes the factory
+  parameter defaultable — so do not flip it just to influence the grammar.

--- a/src/Compilers/VisualBasic/Portable/Generated/Syntax.xml.Main.Generated.vb
+++ b/src/Compilers/VisualBasic/Portable/Generated/Syntax.xml.Main.Generated.vb
@@ -36572,8 +36572,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Throw New ArgumentNullException(NameOf(endSubOrFunctionStatement))
             End If
             Select Case endSubOrFunctionStatement.Kind()
-                Case SyntaxKind.EndSubStatement,
-                     SyntaxKind.EndFunctionStatement
+                Case SyntaxKind.EndFunctionStatement,
+                     SyntaxKind.EndSubStatement
                 Case Else
                     Throw new ArgumentException("endSubOrFunctionStatement")
             End Select
@@ -36627,8 +36627,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Throw New ArgumentNullException(NameOf(endSubOrFunctionStatement))
             End If
             Select Case endSubOrFunctionStatement.Kind()
-                Case SyntaxKind.EndSubStatement,
-                     SyntaxKind.EndFunctionStatement
+                Case SyntaxKind.EndFunctionStatement,
+                     SyntaxKind.EndSubStatement
                 Case Else
                     Throw new ArgumentException("endSubOrFunctionStatement")
             End Select
@@ -36690,8 +36690,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Throw New ArgumentNullException(NameOf(endSubOrFunctionStatement))
             End If
             Select Case endSubOrFunctionStatement.Kind()
-                Case SyntaxKind.EndSubStatement,
-                     SyntaxKind.EndFunctionStatement
+                Case SyntaxKind.EndFunctionStatement,
+                     SyntaxKind.EndSubStatement
                 Case Else
                     Throw new ArgumentException("endSubOrFunctionStatement")
             End Select

--- a/src/Compilers/VisualBasic/Portable/Generated/Syntax.xml.Main.Generated.vb
+++ b/src/Compilers/VisualBasic/Portable/Generated/Syntax.xml.Main.Generated.vb
@@ -35668,7 +35668,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Throw New ArgumentNullException(NameOf(subOrFunctionHeader))
             End If
             Select Case subOrFunctionHeader.Kind()
-                Case SyntaxKind.FunctionLambdaHeader
+                Case SyntaxKind.SubLambdaHeader,
+                     SyntaxKind.FunctionLambdaHeader
                 Case Else
                     Throw new ArgumentException("subOrFunctionHeader")
             End Select
@@ -35961,7 +35962,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Throw New ArgumentNullException(NameOf(subOrFunctionHeader))
             End If
             Select Case subOrFunctionHeader.Kind()
-                Case SyntaxKind.SubLambdaHeader
+                Case SyntaxKind.SubLambdaHeader,
+                     SyntaxKind.FunctionLambdaHeader
                 Case Else
                     Throw new ArgumentException("subOrFunctionHeader")
             End Select
@@ -36261,9 +36263,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             if subOrFunctionHeader Is Nothing Then
                 Throw New ArgumentNullException(NameOf(subOrFunctionHeader))
             End If
-            If (Not subOrFunctionHeader.IsKind(GetSingleLineLambdaExpressionSubOrFunctionHeaderKind(kind))) Then
-                Throw new ArgumentException("subOrFunctionHeader")
-            End If
+            Select Case subOrFunctionHeader.Kind()
+                Case SyntaxKind.SubLambdaHeader,
+                     SyntaxKind.FunctionLambdaHeader
+                Case Else
+                    Throw new ArgumentException("subOrFunctionHeader")
+            End Select
             if body Is Nothing Then
                 Throw New ArgumentNullException(NameOf(body))
             End If
@@ -36536,16 +36541,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return New SingleLineLambdaExpressionSyntax(kind, Nothing, Nothing, subOrFunctionHeader, body)
         End Function
 
-        Private Shared Function GetSingleLineLambdaExpressionSubOrFunctionHeaderKind(kind As SyntaxKind) As SyntaxKind
-            Select Case kind
-                Case SyntaxKind.SingleLineFunctionLambdaExpression
-                    Return SyntaxKind.FunctionLambdaHeader
-                Case SyntaxKind.SingleLineSubLambdaExpression
-                    Return SyntaxKind.SubLambdaHeader
-                Case Else
-                    Throw New ArgumentException("SubOrFunctionHeader")
-            End Select
-        End Function
 
         ''' <summary>
         ''' Represents a multi-line lambda expression.
@@ -36568,7 +36563,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Throw New ArgumentNullException(NameOf(subOrFunctionHeader))
             End If
             Select Case subOrFunctionHeader.Kind()
-                Case SyntaxKind.FunctionLambdaHeader
+                Case SyntaxKind.SubLambdaHeader,
+                     SyntaxKind.FunctionLambdaHeader
                 Case Else
                     Throw new ArgumentException("subOrFunctionHeader")
             End Select
@@ -36622,7 +36618,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Throw New ArgumentNullException(NameOf(subOrFunctionHeader))
             End If
             Select Case subOrFunctionHeader.Kind()
-                Case SyntaxKind.SubLambdaHeader
+                Case SyntaxKind.SubLambdaHeader,
+                     SyntaxKind.FunctionLambdaHeader
                 Case Else
                     Throw new ArgumentException("subOrFunctionHeader")
             End Select
@@ -36683,9 +36680,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             if subOrFunctionHeader Is Nothing Then
                 Throw New ArgumentNullException(NameOf(subOrFunctionHeader))
             End If
-            If (Not subOrFunctionHeader.IsKind(GetMultiLineLambdaExpressionSubOrFunctionHeaderKind(kind))) Then
-                Throw new ArgumentException("subOrFunctionHeader")
-            End If
+            Select Case subOrFunctionHeader.Kind()
+                Case SyntaxKind.SubLambdaHeader,
+                     SyntaxKind.FunctionLambdaHeader
+                Case Else
+                    Throw new ArgumentException("subOrFunctionHeader")
+            End Select
             if endSubOrFunctionStatement Is Nothing Then
                 Throw New ArgumentNullException(NameOf(endSubOrFunctionStatement))
             End If
@@ -36698,16 +36698,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return New MultiLineLambdaExpressionSyntax(kind, Nothing, Nothing, subOrFunctionHeader, statements.Node, endSubOrFunctionStatement)
         End Function
 
-        Private Shared Function GetMultiLineLambdaExpressionSubOrFunctionHeaderKind(kind As SyntaxKind) As SyntaxKind
-            Select Case kind
-                Case SyntaxKind.MultiLineFunctionLambdaExpression
-                    Return SyntaxKind.FunctionLambdaHeader
-                Case SyntaxKind.MultiLineSubLambdaExpression
-                    Return SyntaxKind.SubLambdaHeader
-                Case Else
-                    Throw New ArgumentException("SubOrFunctionHeader")
-            End Select
-        End Function
 
         ''' <summary>
         ''' Represents a multi-line lambda expression.

--- a/src/Compilers/VisualBasic/Portable/Generated/Syntax.xml.Main.Generated.vb
+++ b/src/Compilers/VisualBasic/Portable/Generated/Syntax.xml.Main.Generated.vb
@@ -35668,8 +35668,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Throw New ArgumentNullException(NameOf(subOrFunctionHeader))
             End If
             Select Case subOrFunctionHeader.Kind()
-                Case SyntaxKind.SubLambdaHeader,
-                     SyntaxKind.FunctionLambdaHeader
+                Case SyntaxKind.FunctionLambdaHeader
                 Case Else
                     Throw new ArgumentException("subOrFunctionHeader")
             End Select
@@ -35962,8 +35961,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Throw New ArgumentNullException(NameOf(subOrFunctionHeader))
             End If
             Select Case subOrFunctionHeader.Kind()
-                Case SyntaxKind.SubLambdaHeader,
-                     SyntaxKind.FunctionLambdaHeader
+                Case SyntaxKind.SubLambdaHeader
                 Case Else
                     Throw new ArgumentException("subOrFunctionHeader")
             End Select
@@ -36263,12 +36261,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             if subOrFunctionHeader Is Nothing Then
                 Throw New ArgumentNullException(NameOf(subOrFunctionHeader))
             End If
-            Select Case subOrFunctionHeader.Kind()
-                Case SyntaxKind.SubLambdaHeader,
-                     SyntaxKind.FunctionLambdaHeader
-                Case Else
-                    Throw new ArgumentException("subOrFunctionHeader")
-            End Select
+            If (Not subOrFunctionHeader.IsKind(GetSingleLineLambdaExpressionSubOrFunctionHeaderKind(kind))) Then
+                Throw new ArgumentException("subOrFunctionHeader")
+            End If
             if body Is Nothing Then
                 Throw New ArgumentNullException(NameOf(body))
             End If
@@ -36541,6 +36536,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return New SingleLineLambdaExpressionSyntax(kind, Nothing, Nothing, subOrFunctionHeader, body)
         End Function
 
+        Private Shared Function GetSingleLineLambdaExpressionSubOrFunctionHeaderKind(kind As SyntaxKind) As SyntaxKind
+            Select Case kind
+                Case SyntaxKind.SingleLineFunctionLambdaExpression
+                    Return SyntaxKind.FunctionLambdaHeader
+                Case SyntaxKind.SingleLineSubLambdaExpression
+                    Return SyntaxKind.SubLambdaHeader
+                Case Else
+                    Throw New ArgumentException("SubOrFunctionHeader")
+            End Select
+        End Function
 
         ''' <summary>
         ''' Represents a multi-line lambda expression.
@@ -36563,8 +36568,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Throw New ArgumentNullException(NameOf(subOrFunctionHeader))
             End If
             Select Case subOrFunctionHeader.Kind()
-                Case SyntaxKind.SubLambdaHeader,
-                     SyntaxKind.FunctionLambdaHeader
+                Case SyntaxKind.FunctionLambdaHeader
                 Case Else
                     Throw new ArgumentException("subOrFunctionHeader")
             End Select
@@ -36618,8 +36622,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Throw New ArgumentNullException(NameOf(subOrFunctionHeader))
             End If
             Select Case subOrFunctionHeader.Kind()
-                Case SyntaxKind.SubLambdaHeader,
-                     SyntaxKind.FunctionLambdaHeader
+                Case SyntaxKind.SubLambdaHeader
                 Case Else
                     Throw new ArgumentException("subOrFunctionHeader")
             End Select
@@ -36680,12 +36683,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             if subOrFunctionHeader Is Nothing Then
                 Throw New ArgumentNullException(NameOf(subOrFunctionHeader))
             End If
-            Select Case subOrFunctionHeader.Kind()
-                Case SyntaxKind.SubLambdaHeader,
-                     SyntaxKind.FunctionLambdaHeader
-                Case Else
-                    Throw new ArgumentException("subOrFunctionHeader")
-            End Select
+            If (Not subOrFunctionHeader.IsKind(GetMultiLineLambdaExpressionSubOrFunctionHeaderKind(kind))) Then
+                Throw new ArgumentException("subOrFunctionHeader")
+            End If
             if endSubOrFunctionStatement Is Nothing Then
                 Throw New ArgumentNullException(NameOf(endSubOrFunctionStatement))
             End If
@@ -36698,6 +36698,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return New MultiLineLambdaExpressionSyntax(kind, Nothing, Nothing, subOrFunctionHeader, statements.Node, endSubOrFunctionStatement)
         End Function
 
+        Private Shared Function GetMultiLineLambdaExpressionSubOrFunctionHeaderKind(kind As SyntaxKind) As SyntaxKind
+            Select Case kind
+                Case SyntaxKind.MultiLineFunctionLambdaExpression
+                    Return SyntaxKind.FunctionLambdaHeader
+                Case SyntaxKind.MultiLineSubLambdaExpression
+                    Return SyntaxKind.SubLambdaHeader
+                Case Else
+                    Throw New ArgumentException("SubOrFunctionHeader")
+            End Select
+        End Function
 
         ''' <summary>
         ''' Represents a multi-line lambda expression.

--- a/src/Compilers/VisualBasic/Portable/Generated/VisualBasic.Grammar.g4
+++ b/src/Compilers/VisualBasic/Portable/Generated/VisualBasic.Grammar.g4
@@ -388,7 +388,7 @@ equals_value
   ;
 
 event_block
-  : event_statement accessor_block* end_event_statement
+  : event_statement accessor_block+ end_event_statement
   ;
 
 event_statement
@@ -437,7 +437,7 @@ accessor_block
   ;
 
 add_handler_accessor_block
-  : accessor_statement end_add_handler_statement
+  : accessor_statement statement* end_add_handler_statement
   ;
 
 accessor_statement
@@ -449,39 +449,39 @@ accessor_statement
   ;
 
 add_handler_accessor_statement
-  : 'AddHandler'
+  : attribute_list* modifier* 'AddHandler' parameter_list?
   ;
 
 get_accessor_statement
-  : 'Get'
+  : attribute_list* modifier* 'Get' parameter_list?
   ;
 
 raise_event_accessor_statement
-  : 'RaiseEvent'
+  : attribute_list* modifier* 'RaiseEvent' parameter_list?
   ;
 
 remove_handler_accessor_statement
-  : 'RemoveHandler'
+  : attribute_list* modifier* 'RemoveHandler' parameter_list?
   ;
 
 set_accessor_statement
-  : 'Set'
+  : attribute_list* modifier* 'Set' parameter_list?
   ;
 
 get_accessor_block
-  : accessor_statement end_get_statement
+  : accessor_statement statement* end_get_statement
   ;
 
 raise_event_accessor_block
-  : accessor_statement end_raise_event_statement
+  : accessor_statement statement* end_raise_event_statement
   ;
 
 remove_handler_accessor_block
-  : accessor_statement end_remove_handler_statement
+  : accessor_statement statement* end_remove_handler_statement
   ;
 
 set_accessor_block
-  : accessor_statement end_set_statement
+  : accessor_statement statement* end_set_statement
   ;
 
 field_declaration
@@ -527,7 +527,7 @@ declare_statement
   ;
 
 declare_function_statement
-  : 'Declare' ('Ansi' | 'Unicode' | 'Auto')? 'Function' identifier_token 'Lib' literal_expression 'Alias'? literal_expression? simple_as_clause?
+  : attribute_list* modifier* 'Declare' ('Ansi' | 'Unicode' | 'Auto')? 'Function' identifier_token 'Lib' literal_expression 'Alias'? literal_expression? parameter_list? simple_as_clause?
   ;
 
 literal_expression
@@ -543,7 +543,7 @@ literal_expression
   ;
 
 declare_sub_statement
-  : 'Declare' ('Ansi' | 'Unicode' | 'Auto')? 'Sub' identifier_token 'Lib' literal_expression 'Alias'? literal_expression? simple_as_clause?
+  : attribute_list* modifier* 'Declare' ('Ansi' | 'Unicode' | 'Auto')? 'Sub' identifier_token 'Lib' literal_expression 'Alias'? literal_expression? parameter_list? simple_as_clause?
   ;
 
 delegate_statement
@@ -552,7 +552,7 @@ delegate_statement
   ;
 
 delegate_function_statement
-  : 'Delegate' 'Function' identifier_token type_parameter_list? simple_as_clause?
+  : attribute_list* modifier* 'Delegate' 'Function' identifier_token type_parameter_list? parameter_list? simple_as_clause?
   ;
 
 type_parameter_list
@@ -605,7 +605,7 @@ type_parameter_single_constraint_clause
   ;
 
 delegate_sub_statement
-  : 'Delegate' 'Sub' identifier_token type_parameter_list? simple_as_clause?
+  : attribute_list* modifier* 'Delegate' 'Sub' identifier_token type_parameter_list? parameter_list? simple_as_clause?
   ;
 
 lambda_header
@@ -614,11 +614,11 @@ lambda_header
   ;
 
 function_lambda_header
-  : 'Function' simple_as_clause?
+  : attribute_list* modifier* 'Function' parameter_list? simple_as_clause?
   ;
 
 sub_lambda_header
-  : 'Sub' simple_as_clause?
+  : attribute_list* modifier* 'Sub' parameter_list? simple_as_clause?
   ;
 
 method_statement
@@ -627,7 +627,7 @@ method_statement
   ;
 
 function_statement
-  : 'Function' identifier_token type_parameter_list? simple_as_clause? handles_clause? implements_clause?
+  : attribute_list* modifier* 'Function' identifier_token type_parameter_list? parameter_list? simple_as_clause? handles_clause? implements_clause?
   ;
 
 handles_clause
@@ -659,7 +659,7 @@ with_events_property_event_container
   ;
 
 sub_statement
-  : 'Sub' identifier_token type_parameter_list? simple_as_clause? handles_clause? implements_clause?
+  : attribute_list* modifier* 'Sub' identifier_token type_parameter_list? parameter_list? simple_as_clause? handles_clause? implements_clause?
   ;
 
 operator_statement
@@ -691,11 +691,11 @@ method_block
   ;
 
 function_block
-  : method_statement end_function_statement
+  : method_statement statement* end_function_statement
   ;
 
 sub_block
-  : method_statement end_sub_statement
+  : method_statement statement* end_sub_statement
   ;
 
 operator_block
@@ -711,7 +711,7 @@ namespace_statement
   ;
 
 property_block
-  : property_statement accessor_block* end_property_statement
+  : property_statement accessor_block+ end_property_statement
   ;
 
 type_block
@@ -987,7 +987,7 @@ label_statement
   ;
 
 local_declaration_statement
-  : modifier* variable_declarator (',' variable_declarator)*
+  : modifier+ variable_declarator (',' variable_declarator)*
   ;
 
 multi_line_if_block
@@ -1045,9 +1045,9 @@ redim_clause
   ;
 
 resume_statement
-  : resume_label_statement
+  : 'Resume' identifier_label?
+  | resume_label_statement
   | resume_next_statement
-  | resume_statement
   ;
 
 resume_label_statement
@@ -1056,10 +1056,6 @@ resume_label_statement
 
 resume_next_statement
   : 'Resume' next_label?
-  ;
-
-resume_statement
-  : 'Resume' identifier_label?
   ;
 
 return_statement
@@ -1075,12 +1071,8 @@ select_statement
   ;
 
 case_block
-  : case_block
-  | case_else_block
-  ;
-
-case_block
-  : case_statement statement*
+  : case_else_block
+  | case_statement statement*
   ;
 
 case_else_block
@@ -1442,14 +1434,23 @@ multi_line_lambda_expression
   ;
 
 multi_line_function_lambda_expression
-  : statement* end_sub_statement
+  : lambda_header statement* end_function_statement
   ;
 
 multi_line_sub_lambda_expression
-  : statement* end_function_statement
+  : lambda_header statement* end_sub_statement
   ;
 
 single_line_lambda_expression
+  : single_line_function_lambda_expression
+  | single_line_sub_lambda_expression
+  ;
+
+single_line_function_lambda_expression
+  : lambda_header (expression | statement)
+  ;
+
+single_line_sub_lambda_expression
   : lambda_header (expression | statement)
   ;
 
@@ -1498,7 +1499,7 @@ predefined_cast_expression
   ;
 
 query_expression
-  : query_clause*
+  : query_clause+
   ;
 
 query_clause
@@ -1676,7 +1677,7 @@ type
   ;
 
 array_type
-  : type array_rank_specifier*
+  : type array_rank_specifier+
   ;
 
 nullable_type
@@ -1846,7 +1847,7 @@ xml_processing_instruction
   ;
 
 xml_text
-  : xml_text_token*
+  : xml_text_token+
   ;
 
 structured_trivia
@@ -1912,16 +1913,12 @@ external_source_directive_trivia
   ;
 
 if_directive_trivia
-  : else_if_directive_trivia
-  | if_directive_trivia
+  : '#' 'Else'? 'If' expression 'Then'?
+  | else_if_directive_trivia
   ;
 
 else_if_directive_trivia
-  : 'Else'? 'ElseIf' expression 'Then'?
-  ;
-
-if_directive_trivia
-  : 'Else'? 'If' expression 'Then'?
+  : '#' 'Else'? 'ElseIf' expression 'Then'?
   ;
 
 reference_directive_trivia

--- a/src/Compilers/VisualBasic/Portable/Syntax/Syntax.xml
+++ b/src/Compilers/VisualBasic/Portable/Syntax/Syntax.xml
@@ -1387,7 +1387,7 @@ Unify Enum declarations with other block type declarations.
         <native-equiv name=""></native-equiv>
       </child>
 
-      <child name="Accessors" list="true"  kind="GetAccessorBlock|SetAccessorBlock">
+      <child name="Accessors" list="true"  kind="GetAccessorBlock|SetAccessorBlock" min-count="1">
         <description>
           The accessor blocks contained in the property, between the Property and
           the End Property statements.
@@ -1428,7 +1428,7 @@ Unify Enum declarations with other block type declarations.
         <native-equiv name=""></native-equiv>
       </child>
 
-      <child name="Accessors" list="true"  kind="AddHandlerAccessorBlock|RemoveHandlerAccessorBlock|RaiseEventAccessorBlock">
+      <child name="Accessors" list="true"  kind="AddHandlerAccessorBlock|RemoveHandlerAccessorBlock|RaiseEventAccessorBlock" min-count="1">
         <description>
           The accessor blocks contained in the custom event declaration, between the Event statement and
           the End Event statement.
@@ -2859,7 +2859,7 @@ Unify Enum declarations with other block type declarations.
         <lm-equiv name="Field"></lm-equiv>
         <native-equiv name="Statement.Opcodes.VariableDeclaration"></native-equiv>
       </node-kind>
-      <child name="Modifiers" list="true" kind="StaticKeyword|DimKeyword|ConstKeyword">
+      <child name="Modifiers" list="true" kind="StaticKeyword|DimKeyword|ConstKeyword" min-count="1">
         <description>
           The modifier token (Static, Dim or Const) that introduces this local variable declaration.
         </description>
@@ -6126,7 +6126,9 @@ Unify Enum declarations with other block type declarations.
         <native-equiv name="BlockStatement.Children"></native-equiv>
       </child>
 
-      <child name="EndSubOrFunctionStatement" kind="EndSubStatement|EndFunctionStatement">
+      <!-- Keep these kinds in the same order as the node-kinds above.  The grammar generator
+           pairs a child's kinds with the containing structure's node-kinds by position. -->
+      <child name="EndSubOrFunctionStatement" kind="EndFunctionStatement|EndSubStatement">
         <description>
           Returns the "End Sub" or "End Function" statement if this is a multi-line lambda.
         </description>
@@ -6322,7 +6324,7 @@ Unify Enum declarations with other block type declarations.
 
       <node-kind name="QueryExpression"/>
 
-      <child name="Clauses" list="true" kind="@QueryClauseSyntax">
+      <child name="Clauses" list="true" kind="@QueryClauseSyntax" min-count="1">
         <description>
           A list of all the query operators in this query expression. This list always contains
           at least one operator.
@@ -7194,7 +7196,7 @@ Unify Enum declarations with other block type declarations.
       <node-kind name="XmlText">
       </node-kind>
 
-      <child name="TextTokens" list="true" kind="XmlTextLiteralToken">
+      <child name="TextTokens" list="true" kind="XmlTextLiteralToken" min-count="1">
         <description>
           A list of all the text tokens in the Xml text.
           This list always contains at least one token.
@@ -7418,7 +7420,7 @@ Unify Enum declarations with other block type declarations.
         <native-equiv name="ElementType"></native-equiv>
       </child>
 
-      <child name="RankSpecifiers" list="true" kind="ArrayRankSpecifier">
+      <child name="RankSpecifiers" list="true" kind="ArrayRankSpecifier" min-count="1">
         <description>Represents the list of "()" or "(,,)" modifiers on the array type.</description>
       </child>
     </node-structure>

--- a/src/Compilers/VisualBasic/Portable/Syntax/Syntax.xml
+++ b/src/Compilers/VisualBasic/Portable/Syntax/Syntax.xml
@@ -6061,12 +6061,8 @@ Unify Enum declarations with other block type declarations.
       <spec-section>11.20</spec-section>
       <grammar>LambdaExpression</grammar>
 
-      <child name="SubOrFunctionHeader">
+      <child name="SubOrFunctionHeader" kind="@LambdaHeaderSyntax">
         <description>The header part of the lambda that includes the "Sub" or "Function" keyword, the argument list and return type.</description>
-        <kind name="FunctionLambdaHeader" node-kind="MultiLineFunctionLambdaExpression"/>
-        <kind name="SubLambdaHeader" node-kind="MultiLineSubLambdaExpression"/>
-        <kind name="FunctionLambdaHeader" node-kind="SingleLineFunctionLambdaExpression"/>
-        <kind name="SubLambdaHeader" node-kind="SingleLineSubLambdaExpression"/>
       </child>
 
     </node-structure>

--- a/src/Compilers/VisualBasic/Portable/Syntax/Syntax.xml
+++ b/src/Compilers/VisualBasic/Portable/Syntax/Syntax.xml
@@ -6061,8 +6061,12 @@ Unify Enum declarations with other block type declarations.
       <spec-section>11.20</spec-section>
       <grammar>LambdaExpression</grammar>
 
-      <child name="SubOrFunctionHeader" kind="@LambdaHeaderSyntax">
+      <child name="SubOrFunctionHeader">
         <description>The header part of the lambda that includes the "Sub" or "Function" keyword, the argument list and return type.</description>
+        <kind name="FunctionLambdaHeader" node-kind="MultiLineFunctionLambdaExpression"/>
+        <kind name="SubLambdaHeader" node-kind="MultiLineSubLambdaExpression"/>
+        <kind name="FunctionLambdaHeader" node-kind="SingleLineFunctionLambdaExpression"/>
+        <kind name="SubLambdaHeader" node-kind="SingleLineSubLambdaExpression"/>
       </child>
 
     </node-structure>

--- a/src/Compilers/VisualBasic/Test/Syntax/Generated/Syntax.Test.xml.Generated.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Generated/Syntax.Test.xml.Generated.vb
@@ -1117,7 +1117,7 @@ Partial Public Class GeneratedTests
         End Function
 
         Private Shared Function GenerateGreenSingleLineFunctionLambdaExpression() As InternalSyntax.SingleLineLambdaExpressionSyntax
-            return InternalSyntax.SyntaxFactory.SingleLineFunctionLambdaExpression(GenerateGreenSubLambdaHeader(), GenerateGreenKeywordEventContainer())
+            return InternalSyntax.SyntaxFactory.SingleLineFunctionLambdaExpression(GenerateGreenFunctionLambdaHeader(), GenerateGreenKeywordEventContainer())
         End Function
 
         Private Shared Function GenerateGreenSingleLineSubLambdaExpression() As InternalSyntax.SingleLineLambdaExpressionSyntax
@@ -1125,7 +1125,7 @@ Partial Public Class GeneratedTests
         End Function
 
         Private Shared Function GenerateGreenMultiLineFunctionLambdaExpression() As InternalSyntax.MultiLineLambdaExpressionSyntax
-            return InternalSyntax.SyntaxFactory.MultiLineFunctionLambdaExpression(GenerateGreenSubLambdaHeader(), Nothing, GenerateGreenEndFunctionStatement())
+            return InternalSyntax.SyntaxFactory.MultiLineFunctionLambdaExpression(GenerateGreenFunctionLambdaHeader(), Nothing, GenerateGreenEndFunctionStatement())
         End Function
 
         Private Shared Function GenerateGreenMultiLineSubLambdaExpression() As InternalSyntax.MultiLineLambdaExpressionSyntax
@@ -16163,14 +16163,14 @@ Partial Public Class GeneratedTests
             exceptionTest = false
 
             Try
-            SyntaxFactory.SingleLineFunctionLambdaExpression(GenerateRedSubLambdaHeader(), Nothing)
+            SyntaxFactory.SingleLineFunctionLambdaExpression(GenerateRedFunctionLambdaHeader(), Nothing)
             catch e as ArgumentNullException
             exceptionTest = true
             End Try
             Debug.Assert(exceptionTest)
             exceptionTest = false
 
-            return SyntaxFactory.SingleLineFunctionLambdaExpression(GenerateRedSubLambdaHeader(), GenerateRedKeywordEventContainer())
+            return SyntaxFactory.SingleLineFunctionLambdaExpression(GenerateRedFunctionLambdaHeader(), GenerateRedKeywordEventContainer())
         End Function
 
         Private Shared Function GenerateRedSingleLineSubLambdaExpression() As SingleLineLambdaExpressionSyntax
@@ -16205,14 +16205,14 @@ Partial Public Class GeneratedTests
             exceptionTest = false
 
             Try
-            SyntaxFactory.MultiLineFunctionLambdaExpression(GenerateRedSubLambdaHeader(), Nothing, Nothing)
+            SyntaxFactory.MultiLineFunctionLambdaExpression(GenerateRedFunctionLambdaHeader(), Nothing, Nothing)
             catch e as ArgumentNullException
             exceptionTest = true
             End Try
             Debug.Assert(exceptionTest)
             exceptionTest = false
 
-            return SyntaxFactory.MultiLineFunctionLambdaExpression(GenerateRedSubLambdaHeader(), Nothing, GenerateRedEndFunctionStatement())
+            return SyntaxFactory.MultiLineFunctionLambdaExpression(GenerateRedFunctionLambdaHeader(), Nothing, GenerateRedEndFunctionStatement())
         End Function
 
         Private Shared Function GenerateRedMultiLineSubLambdaExpression() As MultiLineLambdaExpressionSyntax

--- a/src/Compilers/VisualBasic/Test/Syntax/Generated/Syntax.Test.xml.Generated.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Generated/Syntax.Test.xml.Generated.vb
@@ -1125,11 +1125,11 @@ Partial Public Class GeneratedTests
         End Function
 
         Private Shared Function GenerateGreenMultiLineFunctionLambdaExpression() As InternalSyntax.MultiLineLambdaExpressionSyntax
-            return InternalSyntax.SyntaxFactory.MultiLineFunctionLambdaExpression(GenerateGreenSubLambdaHeader(), Nothing, GenerateGreenEndSubStatement())
+            return InternalSyntax.SyntaxFactory.MultiLineFunctionLambdaExpression(GenerateGreenSubLambdaHeader(), Nothing, GenerateGreenEndFunctionStatement())
         End Function
 
         Private Shared Function GenerateGreenMultiLineSubLambdaExpression() As InternalSyntax.MultiLineLambdaExpressionSyntax
-            return InternalSyntax.SyntaxFactory.MultiLineSubLambdaExpression(GenerateGreenSubLambdaHeader(), Nothing, GenerateGreenEndSubStatement())
+            return InternalSyntax.SyntaxFactory.MultiLineSubLambdaExpression(GenerateGreenSubLambdaHeader(), Nothing, GenerateGreenEndFunctionStatement())
         End Function
 
         Private Shared Function GenerateGreenSubLambdaHeader() As InternalSyntax.LambdaHeaderSyntax
@@ -16197,7 +16197,7 @@ Partial Public Class GeneratedTests
         Private Shared Function GenerateRedMultiLineFunctionLambdaExpression() As MultiLineLambdaExpressionSyntax
             Dim exceptionTest as boolean = false
             Try
-            SyntaxFactory.MultiLineFunctionLambdaExpression(Nothing, Nothing, GenerateRedEndSubStatement())
+            SyntaxFactory.MultiLineFunctionLambdaExpression(Nothing, Nothing, GenerateRedEndFunctionStatement())
             catch e as ArgumentNullException
             exceptionTest = true
             End Try
@@ -16212,13 +16212,13 @@ Partial Public Class GeneratedTests
             Debug.Assert(exceptionTest)
             exceptionTest = false
 
-            return SyntaxFactory.MultiLineFunctionLambdaExpression(GenerateRedSubLambdaHeader(), Nothing, GenerateRedEndSubStatement())
+            return SyntaxFactory.MultiLineFunctionLambdaExpression(GenerateRedSubLambdaHeader(), Nothing, GenerateRedEndFunctionStatement())
         End Function
 
         Private Shared Function GenerateRedMultiLineSubLambdaExpression() As MultiLineLambdaExpressionSyntax
             Dim exceptionTest as boolean = false
             Try
-            SyntaxFactory.MultiLineSubLambdaExpression(Nothing, Nothing, GenerateRedEndSubStatement())
+            SyntaxFactory.MultiLineSubLambdaExpression(Nothing, Nothing, GenerateRedEndFunctionStatement())
             catch e as ArgumentNullException
             exceptionTest = true
             End Try
@@ -16233,7 +16233,7 @@ Partial Public Class GeneratedTests
             Debug.Assert(exceptionTest)
             exceptionTest = false
 
-            return SyntaxFactory.MultiLineSubLambdaExpression(GenerateRedSubLambdaHeader(), Nothing, GenerateRedEndSubStatement())
+            return SyntaxFactory.MultiLineSubLambdaExpression(GenerateRedSubLambdaHeader(), Nothing, GenerateRedEndFunctionStatement())
         End Function
 
         Private Shared Function GenerateRedSubLambdaHeader() As LambdaHeaderSyntax

--- a/src/Compilers/VisualBasic/Test/Syntax/Generated/Syntax.Test.xml.Generated.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Generated/Syntax.Test.xml.Generated.vb
@@ -1129,7 +1129,7 @@ Partial Public Class GeneratedTests
         End Function
 
         Private Shared Function GenerateGreenMultiLineSubLambdaExpression() As InternalSyntax.MultiLineLambdaExpressionSyntax
-            return InternalSyntax.SyntaxFactory.MultiLineSubLambdaExpression(GenerateGreenSubLambdaHeader(), Nothing, GenerateGreenEndFunctionStatement())
+            return InternalSyntax.SyntaxFactory.MultiLineSubLambdaExpression(GenerateGreenSubLambdaHeader(), Nothing, GenerateGreenEndSubStatement())
         End Function
 
         Private Shared Function GenerateGreenSubLambdaHeader() As InternalSyntax.LambdaHeaderSyntax
@@ -16218,7 +16218,7 @@ Partial Public Class GeneratedTests
         Private Shared Function GenerateRedMultiLineSubLambdaExpression() As MultiLineLambdaExpressionSyntax
             Dim exceptionTest as boolean = false
             Try
-            SyntaxFactory.MultiLineSubLambdaExpression(Nothing, Nothing, GenerateRedEndFunctionStatement())
+            SyntaxFactory.MultiLineSubLambdaExpression(Nothing, Nothing, GenerateRedEndSubStatement())
             catch e as ArgumentNullException
             exceptionTest = true
             End Try
@@ -16233,7 +16233,7 @@ Partial Public Class GeneratedTests
             Debug.Assert(exceptionTest)
             exceptionTest = false
 
-            return SyntaxFactory.MultiLineSubLambdaExpression(GenerateRedSubLambdaHeader(), Nothing, GenerateRedEndFunctionStatement())
+            return SyntaxFactory.MultiLineSubLambdaExpression(GenerateRedSubLambdaHeader(), Nothing, GenerateRedEndSubStatement())
         End Function
 
         Private Shared Function GenerateRedSubLambdaHeader() As LambdaHeaderSyntax

--- a/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseExpression.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseExpression.vb
@@ -1210,6 +1210,18 @@ Skip 2
         ]]>)
     End Sub
 
+    <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/84634")>
+    Public Sub TestMultiLineLambdaSub_EndSubStatementKind()
+        Dim lambda = DirectCast(ParseExpressionAsRhs("
+Sub()
+End Sub
+"), MultiLineLambdaExpressionSyntax)
+
+        Assert.Equal(SyntaxKind.MultiLineSubLambdaExpression, lambda.Kind())
+        Assert.Equal(SyntaxKind.SubLambdaHeader, lambda.SubOrFunctionHeader.Kind())
+        Assert.Equal(SyntaxKind.EndSubStatement, lambda.EndSubOrFunctionStatement.Kind())
+    End Sub
+
     <Fact>
     Public Sub TestMultiLineLambdaSubNoEndSub1()
         ParseAndVerify(<![CDATA[
@@ -1256,6 +1268,19 @@ Skip 2
                 End Sub
             End Module
         ]]>)
+    End Sub
+
+    <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/84634")>
+    Public Sub TestMultiLineLambdaFunction_EndFunctionStatementKind()
+        Dim lambda = DirectCast(ParseExpressionAsRhs("
+Function()
+    Return 1
+End Function
+"), MultiLineLambdaExpressionSyntax)
+
+        Assert.Equal(SyntaxKind.MultiLineFunctionLambdaExpression, lambda.Kind())
+        Assert.Equal(SyntaxKind.FunctionLambdaHeader, lambda.SubOrFunctionHeader.Kind())
+        Assert.Equal(SyntaxKind.EndFunctionStatement, lambda.EndSubOrFunctionStatement.Kind())
     End Sub
 
     <Fact>

--- a/src/Compilers/VisualBasic/Test/Syntax/Syntax/SyntaxFactoryTests.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Syntax/SyntaxFactoryTests.vb
@@ -157,22 +157,6 @@ Integer
         End Sub
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/84634")>
-        Public Sub MultiLineFunctionLambdaExpression_RejectsSubLambdaHeader()
-            Assert.Throws(Of ArgumentException)(
-                Function() SyntaxFactory.MultiLineFunctionLambdaExpression(
-                    SyntaxFactory.SubLambdaHeader(),
-                    SyntaxFactory.EndFunctionStatement()))
-        End Sub
-
-        <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/84634")>
-        Public Sub MultiLineSubLambdaExpression_RejectsFunctionLambdaHeader()
-            Assert.Throws(Of ArgumentException)(
-                Function() SyntaxFactory.MultiLineSubLambdaExpression(
-                    SyntaxFactory.FunctionLambdaHeader(),
-                    SyntaxFactory.EndSubStatement()))
-        End Sub
-
-        <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/84634")>
         Public Sub SingleLineFunctionLambdaExpression_UsesFunctionLambdaHeader()
             Dim header = SyntaxFactory.FunctionLambdaHeader()
             Dim lambda = SyntaxFactory.SingleLineFunctionLambdaExpression(header, SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(1)))
@@ -188,22 +172,6 @@ Integer
 
             Assert.Equal(SyntaxKind.SingleLineSubLambdaExpression, lambda.Kind())
             Assert.Equal(SyntaxKind.SubLambdaHeader, lambda.SubOrFunctionHeader.Kind())
-        End Sub
-
-        <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/84634")>
-        Public Sub SingleLineFunctionLambdaExpression_RejectsSubLambdaHeader()
-            Assert.Throws(Of ArgumentException)(
-                Function() SyntaxFactory.SingleLineFunctionLambdaExpression(
-                    SyntaxFactory.SubLambdaHeader(),
-                    SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(1))))
-        End Sub
-
-        <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/84634")>
-        Public Sub SingleLineSubLambdaExpression_RejectsFunctionLambdaHeader()
-            Assert.Throws(Of ArgumentException)(
-                Function() SyntaxFactory.SingleLineSubLambdaExpression(
-                    SyntaxFactory.FunctionLambdaHeader(),
-                    SyntaxFactory.EmptyStatement()))
         End Sub
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Test/Syntax/Syntax/SyntaxFactoryTests.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Syntax/SyntaxFactoryTests.vb
@@ -155,5 +155,55 @@ Integer
             Assert.Equal(SyntaxKind.SubLambdaHeader, lambda.SubOrFunctionHeader.Kind())
             Assert.Equal(SyntaxKind.EndSubStatement, lambda.EndSubOrFunctionStatement.Kind())
         End Sub
+
+        <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/84634")>
+        Public Sub MultiLineFunctionLambdaExpression_RejectsSubLambdaHeader()
+            Assert.Throws(Of ArgumentException)(
+                Function() SyntaxFactory.MultiLineFunctionLambdaExpression(
+                    SyntaxFactory.SubLambdaHeader(),
+                    SyntaxFactory.EndFunctionStatement()))
+        End Sub
+
+        <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/84634")>
+        Public Sub MultiLineSubLambdaExpression_RejectsFunctionLambdaHeader()
+            Assert.Throws(Of ArgumentException)(
+                Function() SyntaxFactory.MultiLineSubLambdaExpression(
+                    SyntaxFactory.FunctionLambdaHeader(),
+                    SyntaxFactory.EndSubStatement()))
+        End Sub
+
+        <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/84634")>
+        Public Sub SingleLineFunctionLambdaExpression_UsesFunctionLambdaHeader()
+            Dim header = SyntaxFactory.FunctionLambdaHeader()
+            Dim lambda = SyntaxFactory.SingleLineFunctionLambdaExpression(header, SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(1)))
+
+            Assert.Equal(SyntaxKind.SingleLineFunctionLambdaExpression, lambda.Kind())
+            Assert.Equal(SyntaxKind.FunctionLambdaHeader, lambda.SubOrFunctionHeader.Kind())
+        End Sub
+
+        <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/84634")>
+        Public Sub SingleLineSubLambdaExpression_UsesSubLambdaHeader()
+            Dim header = SyntaxFactory.SubLambdaHeader()
+            Dim lambda = SyntaxFactory.SingleLineSubLambdaExpression(header, SyntaxFactory.EmptyStatement())
+
+            Assert.Equal(SyntaxKind.SingleLineSubLambdaExpression, lambda.Kind())
+            Assert.Equal(SyntaxKind.SubLambdaHeader, lambda.SubOrFunctionHeader.Kind())
+        End Sub
+
+        <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/84634")>
+        Public Sub SingleLineFunctionLambdaExpression_RejectsSubLambdaHeader()
+            Assert.Throws(Of ArgumentException)(
+                Function() SyntaxFactory.SingleLineFunctionLambdaExpression(
+                    SyntaxFactory.SubLambdaHeader(),
+                    SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(1))))
+        End Sub
+
+        <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/84634")>
+        Public Sub SingleLineSubLambdaExpression_RejectsFunctionLambdaHeader()
+            Assert.Throws(Of ArgumentException)(
+                Function() SyntaxFactory.SingleLineSubLambdaExpression(
+                    SyntaxFactory.FunctionLambdaHeader(),
+                    SyntaxFactory.EmptyStatement()))
+        End Sub
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Test/Syntax/Syntax/SyntaxFactoryTests.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Syntax/SyntaxFactoryTests.vb
@@ -3,6 +3,7 @@
 ' See the LICENSE file in the project root for more information.
 
 Imports Microsoft.CodeAnalysis.Text
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Roslyn.Test.Utilities
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
@@ -133,6 +134,24 @@ Integer
 
             Dim typeName = SyntaxFactory.ParseTypeName("", options:=parseOptions)
             Assert.Same(parseOptions, typeName.SyntaxTree.Options)
+        End Sub
+
+        <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/84634")>
+        Public Sub MultiLineFunctionLambdaExpression_UsesEndFunctionStatement()
+            Dim header = SyntaxFactory.FunctionLambdaHeader()
+            Dim lambda = SyntaxFactory.MultiLineFunctionLambdaExpression(header, SyntaxFactory.EndFunctionStatement())
+
+            Assert.Equal(SyntaxKind.MultiLineFunctionLambdaExpression, lambda.Kind())
+            Assert.Equal(SyntaxKind.EndFunctionStatement, lambda.EndSubOrFunctionStatement.Kind())
+        End Sub
+
+        <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/84634")>
+        Public Sub MultiLineSubLambdaExpression_UsesEndSubStatement()
+            Dim header = SyntaxFactory.SubLambdaHeader()
+            Dim lambda = SyntaxFactory.MultiLineSubLambdaExpression(header, SyntaxFactory.EndSubStatement())
+
+            Assert.Equal(SyntaxKind.MultiLineSubLambdaExpression, lambda.Kind())
+            Assert.Equal(SyntaxKind.EndSubStatement, lambda.EndSubOrFunctionStatement.Kind())
         End Sub
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Test/Syntax/Syntax/SyntaxFactoryTests.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Syntax/SyntaxFactoryTests.vb
@@ -142,6 +142,7 @@ Integer
             Dim lambda = SyntaxFactory.MultiLineFunctionLambdaExpression(header, SyntaxFactory.EndFunctionStatement())
 
             Assert.Equal(SyntaxKind.MultiLineFunctionLambdaExpression, lambda.Kind())
+            Assert.Equal(SyntaxKind.FunctionLambdaHeader, lambda.SubOrFunctionHeader.Kind())
             Assert.Equal(SyntaxKind.EndFunctionStatement, lambda.EndSubOrFunctionStatement.Kind())
         End Sub
 
@@ -151,6 +152,7 @@ Integer
             Dim lambda = SyntaxFactory.MultiLineSubLambdaExpression(header, SyntaxFactory.EndSubStatement())
 
             Assert.Equal(SyntaxKind.MultiLineSubLambdaExpression, lambda.Kind())
+            Assert.Equal(SyntaxKind.SubLambdaHeader, lambda.SubOrFunctionHeader.Kind())
             Assert.Equal(SyntaxKind.EndSubStatement, lambda.EndSubOrFunctionStatement.Kind())
         End Sub
     End Class

--- a/src/Tools/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/Grammar/GrammarGenerator.vb
+++ b/src/Tools/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/Grammar/GrammarGenerator.vb
@@ -66,7 +66,12 @@ Friend Class GrammarGenerator
                 ' Then we see if there are children that having a matching number of kinds. When
                 ' this happens, it's the case that each kind the child could be corresponds 1:1
                 ' with all the different sub-kinds of hte production.
-                Dim correspondingChildren = structureNode.Children.Where(
+                '
+                ' Note: children inherited from base structures participate here too.  Without
+                ' them the specialized productions would be missing the base structure's children
+                ' entirely (for example the header of a multi-line lambda).
+                Dim allChildren = GetAllChildrenOfStructure(structureNode)
+                Dim correspondingChildren = allChildren.Where(
                     Function(c)
                         Dim childKinds = TryCast(c.ChildKind, List(Of ParseNodeKind))
                         Return childKinds IsNot Nothing AndAlso childKinds.Count = structureNode.NodeKinds.Count
@@ -84,7 +89,7 @@ Friend Class GrammarGenerator
                     For i = 0 To structureNode.NodeKinds.Count - 1
                         Dim nodeKind = structureNode.NodeKinds(i)
                         Dim local_i = i
-                        Dim mappedChildren = structureNode.Children.Select(
+                        Dim mappedChildren = allChildren.Select(
                         Function(c)
                             If correspondingChildren.Contains(c) Then
                                 Return c.WithChildKind(
@@ -95,12 +100,23 @@ Friend Class GrammarGenerator
                             Return c
                         End Function).ToList()
 
-                        ' We then emit a production for the child kind.
-                        _rules.Add(nodeKind.Name, New List(Of Production)())
-                        _rules(nodeKind.Name).Add(HandleChildren(structureNode, mappedChildren))
+                        Dim kindProduction = HandleChildren(structureNode, mappedChildren)
 
-                        ' And then point the top level production at each of these child productions.
-                        _rules(structureNode.Name).Add(RuleReference(nodeKind.Name))
+                        ' A node-kind can have the same name as its structure minus the 'Syntax'
+                        ' suffix (ResumeStatement in ResumeStatementSyntax, for example).  Both
+                        ' names emit as the same grammar rule, so giving the specialization its
+                        ' own rule would define that rule twice.  Fold it into the structure's
+                        ' rule instead.
+                        If RuleReference(nodeKind.Name).Text = RuleReference(structureNode.Name).Text Then
+                            _rules(structureNode.Name).Add(kindProduction)
+                        Else
+                            ' We then emit a production for the child kind.
+                            _rules.Add(nodeKind.Name, New List(Of Production)())
+                            _rules(nodeKind.Name).Add(kindProduction)
+
+                            ' And then point the top level production at each of these child productions.
+                            _rules(structureNode.Name).Add(RuleReference(nodeKind.Name))
+                        End If
                     Next
                 End If
             End If
@@ -203,7 +219,7 @@ Friend Class GrammarGenerator
     End Function
 
     Private Function HandleList(structureNode As ParseNodeStructure, child As ParseNodeChild) As Production
-        Return HandleChildKind(structureNode, child, child.ChildKind).Suffix("*")
+        Return HandleChildKind(structureNode, child, child.ChildKind).Suffix(If(child.MinCount = 0, "*", "+"))
     End Function
 
     Private Function HandleChildKind(structureNode As ParseNodeStructure,

--- a/src/Tools/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/Tests/TestWriter.vb
+++ b/src/Tools/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/Tests/TestWriter.vb
@@ -324,6 +324,22 @@ Public Class TestWriter
                     childNodeKind = DirectCast(child.ChildKind, List(Of ParseNodeKind)).Item(0)
                 End If
 
+                ' Pick the header and terminator that match the lambda kind.  These children
+                ' intentionally accept both variants in the public factory API.
+                If child.Name = "SubOrFunctionHeader" Then
+                    If nodeKind.Name.Contains("FunctionLambdaExpression") Then
+                        childNodeKind = child.ParseTree.NodeKinds("FunctionLambdaHeader")
+                    ElseIf nodeKind.Name.Contains("SubLambdaExpression") Then
+                        childNodeKind = child.ParseTree.NodeKinds("SubLambdaHeader")
+                    End If
+                ElseIf child.Name = "EndSubOrFunctionStatement" Then
+                    If nodeKind.Name = "MultiLineFunctionLambdaExpression" Then
+                        childNodeKind = child.ParseTree.NodeKinds("EndFunctionStatement")
+                    ElseIf nodeKind.Name = "MultiLineSubLambdaExpression" Then
+                        childNodeKind = child.ParseTree.NodeKinds("EndSubStatement")
+                    End If
+                End If
+
                 If child.IsList AndAlso child.IsSeparated Then
                     Dim childKindStructure = child.ParseTree.NodeStructures(childNodeKind.StructureId)
                     childKindStructure = If(Not childKindStructure.ParentStructure Is Nothing, childKindStructure.ParentStructure, childKindStructure)


### PR DESCRIPTION
The VB grammar generator produced a few wrong productions: duplicate rule names when a node-kind collided with its structure name, multi-line lambdas missing their header and with End Sub/End Function swapped, and required lists emitted as `*` instead of `+`. Plain-list multiplicity now follows `min-count` the same way the C# grammar generator does.

Fixes https://github.com/dotnet/roslyn/issues/84633
Fixes https://github.com/dotnet/roslyn/issues/84634
Fixes https://github.com/dotnet/roslyn/issues/84636

## How do you know it works?

Validated locally end to end. `eng/generate-compiler-code.cs -test` is clean, the VB compiler builds, and the VB syntax unit tests pass (4026). ANTLR 4.13.2 no longer reports the three `error(51)` rule redefinitions from #84633.