### PR TITLE
Unions: enforce the same order of processing for base interfaces of a member provider interface source vs. metadata.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -51,6 +51,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private sealed class UnionDataForDefinition : UnionData
         {
             public NamedTypeSymbol? _lazyMemberProviderInterface = ErrorTypeSymbol.UnknownResultType;
+            public ImmutableArray<NamedTypeSymbol> _lazyMemberProviderInterfaceAllInterfaces;
         }
 
         private sealed partial class UncommonProperties
@@ -1969,7 +1970,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             void addUseSiteInfoForCachedResult(ref CompoundUseSiteInfo<AssemblySymbol> useSiteInfo)
             {
-                AddUseSiteInfoForCachedUnionFactoryMethodsResult(ref useSiteInfo);
+                AddUseSiteInfoForCachedUnionFactoryMethodsResult(GetMemberProviderInterfaceAllInterfacesForDefinition(), ref useSiteInfo);
             }
         }
 
@@ -1982,7 +1983,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (!lazyFactoryMethods.IsDefault)
             {
-                AddUseSiteInfoForCachedUnionFactoryMethodsResult(ref membersInterfaceForDefinitionInterfacesUseSiteInfo);
+                AddUseSiteInfoForCachedUnionFactoryMethodsResult(GetMemberProviderInterfaceAllInterfacesForDefinition(), ref membersInterfaceForDefinitionInterfacesUseSiteInfo);
                 return lazyFactoryMethods;
             }
 
@@ -2067,7 +2068,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         }
                     }
 
-                    foreach (var baseInterfaceForDefinition in membersInterfaceForDefinition.AllInterfacesWithDefinitionUseSiteDiagnostics(ref membersInterfaceForDefinitionInterfacesUseSiteInfo))
+                    ImmutableArray<NamedTypeSymbol> memberProviderInterfaceAllInterfaces = GetMemberProviderInterfaceAllInterfacesForDefinition();
+                    AddUseSiteInfoForCachedUnionFactoryMethodsResult(memberProviderInterfaceAllInterfaces, ref membersInterfaceForDefinitionInterfacesUseSiteInfo);
+
+                    foreach (var baseInterfaceForDefinition in memberProviderInterfaceAllInterfaces)
                     {
                         Debug.Assert(shadowingMethods is not null);
                         bool canShadow = !baseInterfaceForDefinition.OriginalDefinition.InterfacesNoUseSiteDiagnostics().IsEmpty;
@@ -2153,11 +2157,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// Add use site info that would be added during calculation of non-cached result of
         /// <see cref="UnionFactoryMethods"/>.
         /// </summary>
-        private void AddUseSiteInfoForCachedUnionFactoryMethodsResult(ref CompoundUseSiteInfo<AssemblySymbol> membersInterfaceForDefinitionInterfacesUseSiteInfo)
+        private void AddUseSiteInfoForCachedUnionFactoryMethodsResult(ImmutableArray<NamedTypeSymbol> memberProviderInterfaceAllInterfaces, ref CompoundUseSiteInfo<AssemblySymbol> membersInterfaceForDefinitionInterfacesUseSiteInfo)
         {
-            if (membersInterfaceForDefinitionInterfacesUseSiteInfo.AccumulatesDependencies || membersInterfaceForDefinitionInterfacesUseSiteInfo.AccumulatesDiagnostics)
+            if (!memberProviderInterfaceAllInterfaces.IsDefault &&
+                (membersInterfaceForDefinitionInterfacesUseSiteInfo.AccumulatesDependencies || membersInterfaceForDefinitionInterfacesUseSiteInfo.AccumulatesDiagnostics))
             {
-                GetMemberProviderInterfaceForDefinition()?.AllInterfacesWithDefinitionUseSiteDiagnostics(ref membersInterfaceForDefinitionInterfacesUseSiteInfo);
+                foreach (var iface in memberProviderInterfaceAllInterfaces)
+                {
+                    iface.OriginalDefinition.AddUseSiteInfo(ref membersInterfaceForDefinitionInterfacesUseSiteInfo);
+                }
             }
         }
 
@@ -2204,6 +2212,69 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
 
                 return null;
+            }
+        }
+
+        internal ImmutableArray<NamedTypeSymbol> GetMemberProviderInterfaceAllInterfacesForDefinition()
+        {
+            if (!this.IsDefinition)
+            {
+                return this.OriginalDefinition.GetMemberProviderInterfaceAllInterfacesForDefinition();
+            }
+
+            var lazyUnionData = (UnionDataForDefinition)GetUnionData();
+            ImmutableArray<NamedTypeSymbol> lazyAllInterfaces = lazyUnionData._lazyMemberProviderInterfaceAllInterfaces;
+
+            if (!lazyAllInterfaces.IsDefault)
+            {
+                return lazyAllInterfaces;
+            }
+
+            NamedTypeSymbol? memberProviderInterface = GetMemberProviderInterfaceForDefinition();
+            if (memberProviderInterface is null)
+            {
+                return default;
+            }
+
+            ImmutableInterlocked.InterlockedInitialize(ref lazyUnionData._lazyMemberProviderInterfaceAllInterfaces, makeAllInterfaces(memberProviderInterface));
+            return lazyUnionData._lazyMemberProviderInterfaceAllInterfaces;
+
+            // Produce all implemented interfaces in topologically sorted order.
+            ImmutableArray<NamedTypeSymbol> makeAllInterfaces(NamedTypeSymbol memberProviderInterface)
+            {
+                var result = ArrayBuilder<NamedTypeSymbol>.GetInstance();
+                var visited = TypeSymbol.AllIgnoreOptionsSetPool.Allocate();
+
+                var interfaces = memberProviderInterface.GetInterfacesToEmit();
+                for (int i = interfaces.Length - 1; i >= 0; i--)
+                {
+                    addAllInterfaces(interfaces[i], visited, result);
+                }
+
+                visited.Free();
+                result.ReverseContents();
+                return result.ToImmutableAndFree();
+
+                static void addAllInterfaces(NamedTypeSymbol @interface, HashSet<TypeSymbol> visited, ArrayBuilder<NamedTypeSymbol> result)
+                {
+                    if (visited.Add(@interface))
+                    {
+                        ImmutableArray<NamedTypeSymbol> baseInterfaces = @interface.OriginalDefinition.GetInterfacesToEmit();
+                        for (int i = baseInterfaces.Length - 1; i >= 0; i--)
+                        {
+                            var baseInterface = baseInterfaces[i];
+
+                            if (!@interface.IsDefinition)
+                            {
+                                baseInterface = @interface.TypeSubstitution.SubstituteNamedType(baseInterface);
+                            }
+
+                            addAllInterfaces(baseInterface, visited, result);
+                        }
+
+                        result.Add(@interface);
+                    }
+                }
             }
         }
 
@@ -2336,7 +2407,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     {
                         if (valueProperty?.ContainingType.OriginalDefinition != (object)memberProviderInterface)
                         {
-                            memberProviderInterface.AllInterfacesWithDefinitionUseSiteDiagnostics(ref useSiteInfo);
+                            foreach (var iface in GetMemberProviderInterfaceAllInterfacesForDefinition())
+                            {
+                                iface.OriginalDefinition.AddUseSiteInfo(ref useSiteInfo);
+                            }
                         }
                     }
                     else
@@ -2378,8 +2452,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
 
                 PropertySymbol? match = null;
+                ImmutableArray<NamedTypeSymbol> memberProviderInterfaceAllInterfaces = GetMemberProviderInterfaceAllInterfacesForDefinition();
 
-                foreach (var baseInterfaceForDefinition in membersInterfaceForDefinition.AllInterfacesWithDefinitionUseSiteDiagnostics(ref membersProviderForDefinitionBasesUseSiteInfo))
+                foreach (var iface in memberProviderInterfaceAllInterfaces)
+                {
+                    iface.OriginalDefinition.AddUseSiteInfo(ref membersProviderForDefinitionBasesUseSiteInfo);
+                }
+
+                foreach (var baseInterfaceForDefinition in memberProviderInterfaceAllInterfaces)
                 {
                     if (getMemberDeclaredInType(baseInterfaceForDefinition, memberName, isSuitableUnionMember, out member))
                     {
@@ -2616,7 +2696,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     addCandidates(membersInterfaceForDefinition, ref typeSet, result);
 
-                    foreach (var declaringType in membersInterfaceForDefinition.AllInterfacesNoUseSiteDiagnostics)
+                    foreach (var declaringType in GetMemberProviderInterfaceAllInterfacesForDefinition())
                     {
                         addCandidates(declaringType, ref typeSet, result);
                     }

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -2240,7 +2240,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return lazyUnionData._lazyMemberProviderInterfaceAllInterfaces;
 
             // Produce all implemented interfaces in topologically sorted order.
-            ImmutableArray<NamedTypeSymbol> makeAllInterfaces(NamedTypeSymbol memberProviderInterface)
+            static ImmutableArray<NamedTypeSymbol> makeAllInterfaces(NamedTypeSymbol memberProviderInterface)
             {
                 var result = ArrayBuilder<NamedTypeSymbol>.GetInstance();
                 var visited = TypeSymbol.AllIgnoreOptionsSetPool.Allocate();

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -336,7 +336,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// TypeSymbol.Interfaces as the source of edge data, which has had cycles and infinitely
         /// long dependency cycles removed. Consequently, it is possible (and we do) use the
         /// simplest version of Tarjan's topological sorting algorithm.
-        protected virtual ImmutableArray<NamedTypeSymbol> MakeAllInterfaces()
+        protected ImmutableArray<NamedTypeSymbol> MakeAllInterfaces()
         {
             var result = ArrayBuilder<NamedTypeSymbol>.GetInstance();
             var visited = new HashSet<NamedTypeSymbol>(SymbolEqualityComparer.ConsiderEverything);

--- a/src/Compilers/CSharp/Test/CSharp15/UnionsTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/UnionsTests.cs
@@ -40058,7 +40058,7 @@ class Program
             CompileAndVerify(comp2, expectedOutput: "FalseFalseTrue").VerifyDiagnostics();
         }
 
-        [Theory(Skip = "There is metadata vs. source difference for this scenario")] // https://github.com/dotnet/roslyn/issues/82636
+        [Theory]
         [CombinatorialData]
         [WorkItem("https://github.com/dotnet/roslyn/issues/82636")]
         public void NonBoxingUnionMatching_MemberProvider_TryGetValue_Inheritance_37_ImplicitReferenceConversion_Determinism(


### PR DESCRIPTION

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84664)