### PR TITLE
Fix daemon relay exit classification

### DIFF
--- a/.github/memory/known-issues/ide.md
+++ b/.github/memory/known-issues/ide.md
@@ -16,3 +16,15 @@ unrelated-looking test failure rather than a clear composition error.
 **Workaround:** When IDE tests fail unexpectedly, check the export attributes
 first (`[ExportLanguageService]`/`[ExportWorkspaceService]`, `[Shared]`,
 `[ImportingConstructor]` + `[Obsolete(MefConstruction.ImportingConstructorMessage)]`).
+
+## LSP relay completions identify endpoints, not connections
+
+**Affected area:** `src/LanguageServer/roslyn-language-server/LspRelay.cs`
+**Description:** The relay has one copy task per traffic direction. Each task
+reports the endpoint that ended that copy, not which connection closed overall.
+A clean shutdown can report the editor endpoint from both tasks because the
+editor closes its bidirectional transport after sending LSP `exit`, before the
+daemon closes its side.
+**Workaround:** Treat two server-endpoint completions as definitive daemon loss,
+but do not require the two tasks to report opposite endpoints for a clean
+shutdown.

--- a/src/LanguageServer/roslyn-language-server/LspRelay.cs
+++ b/src/LanguageServer/roslyn-language-server/LspRelay.cs
@@ -37,9 +37,10 @@ internal static class LspRelay
         var completedTask = await Task.WhenAny(editorToServer, serverToEditor).ConfigureAwait(false);
         var closedEndpoint = await completedTask.ConfigureAwait(false);
 
-        // Give the other direction a brief window to finish on its own. A clean shutdown closes the editor
-        // input in one direction and the server input in the other. If both copies instead terminate at the
-        // same endpoint, that endpoint was lost and caused both directions to stop.
+        // Give the other direction a brief window to finish on its own. If both copies terminate at the server,
+        // the server connection was lost and caused both directions to stop. Any other pair is a clean shutdown:
+        // an editor closes its bidirectional transport after sending LSP 'exit', so both copies can terminate at
+        // the editor before the server closes its side.
         var otherTask = completedTask == editorToServer ? serverToEditor : editorToServer;
         RelayEndpoint? otherClosedEndpoint = null;
         if (await Task.WhenAny(otherTask, Task.Delay(s_secondCloseGracePeriod)).ConfigureAwait(false) == otherTask)
@@ -47,8 +48,12 @@ internal static class LspRelay
 
         cancellationSource.Cancel();
 
-        if (otherClosedEndpoint is not null && otherClosedEndpoint != closedEndpoint)
-            return RelayCompletionKind.CleanShutdown;
+        if (otherClosedEndpoint is not null)
+        {
+            return closedEndpoint == RelayEndpoint.Server && otherClosedEndpoint == RelayEndpoint.Server
+                ? RelayCompletionKind.ServerConnectionLost
+                : RelayCompletionKind.CleanShutdown;
+        }
 
         return closedEndpoint == RelayEndpoint.Editor
             ? RelayCompletionKind.EditorConnectionLost

--- a/src/LanguageServer/roslyn-language-server/LspRelay.cs
+++ b/src/LanguageServer/roslyn-language-server/LspRelay.cs
@@ -35,7 +35,6 @@ internal static class LspRelay
         var editorToServer = CopyUntilClosedAsync(fromEditor, toServer, RelayEndpoint.Editor, RelayEndpoint.Server, cancellationSource.Token);
         var serverToEditor = CopyUntilClosedAsync(fromServer, toEditor, RelayEndpoint.Server, RelayEndpoint.Editor, cancellationSource.Token);
         var completedTask = await Task.WhenAny(editorToServer, serverToEditor).ConfigureAwait(false);
-        var closedEndpoint = await completedTask.ConfigureAwait(false);
 
         // Give the other direction a brief window to finish on its own. If both copies terminate at the server,
         // the server connection was lost and caused both directions to stop. Any other pair is a clean shutdown:
@@ -47,6 +46,7 @@ internal static class LspRelay
             otherClosedEndpoint = await otherTask.ConfigureAwait(false);
 
         cancellationSource.Cancel();
+        var closedEndpoint = await completedTask.ConfigureAwait(false);
 
         if (otherClosedEndpoint is not null)
         {

--- a/src/LanguageServer/roslyn-language-server/LspRelay.cs
+++ b/src/LanguageServer/roslyn-language-server/LspRelay.cs
@@ -10,17 +10,11 @@ internal enum RelayEndpoint
     Server,
 }
 
-internal readonly struct RelayResult(RelayEndpoint closedEndpoint, bool bothSidesClosed)
+internal enum RelayCompletionKind
 {
-    /// <summary>The endpoint whose stream closed first, ending the relay.</summary>
-    public RelayEndpoint ClosedEndpoint { get; } = closedEndpoint;
-
-    /// <summary>
-    /// True when, shortly after the first side closed, the other side also closed on its own. A clean LSP
-    /// shutdown closes both sides (the editor sends <c>exit</c> and closes; the server processes it and
-    /// closes), whereas a crash leaves one side connected.
-    /// </summary>
-    public bool BothSidesClosed { get; } = bothSidesClosed;
+    CleanShutdown,
+    EditorConnectionLost,
+    ServerConnectionLost,
 }
 
 internal static class LspRelay
@@ -31,7 +25,7 @@ internal static class LspRelay
     /// </summary>
     private static readonly TimeSpan s_secondCloseGracePeriod = TimeSpan.FromSeconds(5);
 
-    public static async Task<RelayResult> RelayAsync(
+    public static async Task<RelayCompletionKind> RelayAsync(
         Stream fromEditor,
         Stream toEditor,
         Stream fromServer,
@@ -41,15 +35,24 @@ internal static class LspRelay
         var editorToServer = CopyUntilClosedAsync(fromEditor, toServer, RelayEndpoint.Editor, RelayEndpoint.Server, cancellationSource.Token);
         var serverToEditor = CopyUntilClosedAsync(fromServer, toEditor, RelayEndpoint.Server, RelayEndpoint.Editor, cancellationSource.Token);
         var completedTask = await Task.WhenAny(editorToServer, serverToEditor).ConfigureAwait(false);
+        var closedEndpoint = await completedTask.ConfigureAwait(false);
 
-        // Give the other direction a brief window to finish on its own. If it does, both sides closed, which
-        // indicates a clean shutdown rather than a crash on one side.
+        // Give the other direction a brief window to finish on its own. A clean shutdown closes the editor
+        // input in one direction and the server input in the other. If both copies instead terminate at the
+        // same endpoint, that endpoint was lost and caused both directions to stop.
         var otherTask = completedTask == editorToServer ? serverToEditor : editorToServer;
-        var bothSidesClosed = await Task.WhenAny(otherTask, Task.Delay(s_secondCloseGracePeriod)).ConfigureAwait(false) == otherTask;
+        RelayEndpoint? otherClosedEndpoint = null;
+        if (await Task.WhenAny(otherTask, Task.Delay(s_secondCloseGracePeriod)).ConfigureAwait(false) == otherTask)
+            otherClosedEndpoint = await otherTask.ConfigureAwait(false);
 
         cancellationSource.Cancel();
-        var result = await completedTask.ConfigureAwait(false);
-        return new RelayResult(result, bothSidesClosed);
+
+        if (otherClosedEndpoint is not null && otherClosedEndpoint != closedEndpoint)
+            return RelayCompletionKind.CleanShutdown;
+
+        return closedEndpoint == RelayEndpoint.Editor
+            ? RelayCompletionKind.EditorConnectionLost
+            : RelayCompletionKind.ServerConnectionLost;
     }
 
     private static async Task<RelayEndpoint> CopyUntilClosedAsync(

--- a/src/LanguageServer/roslyn-language-server/Program.cs
+++ b/src/LanguageServer/roslyn-language-server/Program.cs
@@ -71,27 +71,29 @@ internal static class Program
         Stream daemonStream,
         EditorConnection editorConnection)
     {
-        var relayResult = await LspRelay.RelayAsync(
+        var relayCompletionKind = await LspRelay.RelayAsync(
             editorConnection.Input,
             editorConnection.Output,
             daemonStream,
             daemonStream);
 
-        // A clean LSP shutdown closes both sides; report success so the editor doesn't treat it as a crash.
-        if (relayResult.BothSidesClosed)
+        switch (relayCompletionKind)
         {
-            Console.Error.WriteLine("Language server session ended cleanly.");
-            return ExitCodes.Success;
-        }
+            case RelayCompletionKind.CleanShutdown:
+                Console.Error.WriteLine("Language server session ended cleanly.");
+                return ExitCodes.Success;
 
-        if (relayResult.ClosedEndpoint == RelayEndpoint.Editor)
-        {
-            Console.Error.WriteLine("Editor connection closed before the language server daemon connection.");
-            return ExitCodes.EditorConnectionLost;
-        }
+            case RelayCompletionKind.EditorConnectionLost:
+                Console.Error.WriteLine("Editor connection closed before the language server daemon connection.");
+                return ExitCodes.EditorConnectionLost;
 
-        Console.Error.WriteLine("Language server daemon connection closed before the editor connection.");
-        return ExitCodes.ServerConnectionLost;
+            case RelayCompletionKind.ServerConnectionLost:
+                Console.Error.WriteLine("Language server daemon connection closed before the editor connection.");
+                return ExitCodes.ServerConnectionLost;
+
+            default:
+                throw new InvalidOperationException($"Unexpected relay completion kind: {relayCompletionKind}");
+        }
     }
 
     private static Task StartClientProcessMonitorAsync(int? processId)


### PR DESCRIPTION
Fixes #84662

When the daemon endpoint is lost, both directional relay tasks can complete against the server endpoint. The thin client previously interpreted any pair of completed relay tasks as a clean shutdown and returned exit code 0.

Classify relay completion using the endpoint reported by each copy direction:
- two server-endpoint completions indicate daemon connection loss
- a single completion indicates loss of that endpoint
- any other pair indicates clean shutdown

A clean editor shutdown may complete both copies at the editor because the editor closes its bidirectional transport after sending LSP `exit`, before the daemon closes its side.

Validation:
- Built `src\LanguageServer\roslyn-language-server\roslyn-language-server.csproj`
- Ran the existing daemon lifecycle tests for clean shutdown, daemon loss, editor loss, and keepalive behavior across both transports (7 passed)
- Ran `KeepAlive_DaemonReusedWithinWindow_ThenExitsWhenIdle` in Release (passed)

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84666)