### PR TITLE
Allow submitting rename conflicts and rename unambiguous erroneous references 

### DIFF
--- a/src/EditorFeatures/Core/InlineRename/UI/Adornment/RenameFlyoutViewModel.cs
+++ b/src/EditorFeatures/Core/InlineRename/UI/Adornment/RenameFlyoutViewModel.cs
@@ -229,7 +229,7 @@ internal class RenameFlyoutViewModel : INotifyPropertyChanged, IDisposable
 
     public bool Submit()
     {
-        if (StatusSeverity == Severity.Error)
+        if (!_isReplacementTextValid)
         {
             return false;
         }

--- a/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
+++ b/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
@@ -7,12 +7,16 @@ Imports Microsoft.CodeAnalysis.CodeActions
 Imports Microsoft.CodeAnalysis.CodeRefactorings
 Imports Microsoft.CodeAnalysis.Collections
 Imports Microsoft.CodeAnalysis.Editor.Host
+Imports Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
+Imports Microsoft.CodeAnalysis.Editor.Shared.Utilities
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.RenameTracking
 Imports Microsoft.CodeAnalysis.InlineRename
 Imports Microsoft.CodeAnalysis.IntroduceVariable
 Imports Microsoft.CodeAnalysis.Notification
 Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.Rename
+Imports Microsoft.CodeAnalysis.Shared.TestHooks
+Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.VisualStudio.Text
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
@@ -110,7 +114,7 @@ class C
 
         <WpfTheory>
         <CombinatorialData, Trait(Traits.Feature, Traits.Features.Rename)>
-        Public Async Function RenameToConflictingMemberReportsConflict(host As RenameTestHost) As Task
+        Public Async Function RenameToConflictingMemberReportsConflictAndAllowsSubmit(host As RenameTestHost) As Task
             Using workspace = CreateWorkspaceWithWaiter(
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
@@ -126,23 +130,34 @@ class C
 
                 Dim session = StartSession(workspace)
 
-                Dim replacementInfo As IInlineRenameReplacementInfo = Nothing
-                AddHandler session.ReplacementsComputed, Sub(sender, info) replacementInfo = info
-
                 Dim cursorDocument = workspace.Documents.Single(Function(d) d.CursorPosition.HasValue)
                 Dim caretPosition = cursorDocument.CursorPosition.Value
                 Dim textBuffer = cursorDocument.GetTextBuffer()
 
-                ' Rename Foo to Bar
-                textBuffer.Delete(New Span(caretPosition, 3))
-                textBuffer.Insert(caretPosition, "Bar")
+                Using viewModel = New RenameFlyoutViewModel(
+                        session,
+                        New TextSpan(caretPosition, 3),
+                        registerOleComponent:=False,
+                        workspace.GetService(Of IGlobalOptionService)(),
+                        workspace.GetService(Of IThreadingContext)(),
+                        workspace.GetService(Of IAsynchronousOperationListenerProvider)(),
+                        smartRenameSessionFactory:=Nothing)
 
-                Await WaitForRename(workspace)
+                    textBuffer.Delete(New Span(caretPosition, 3))
+                    textBuffer.Insert(caretPosition, "1")
 
-                ' Reports an unresolved conflict
-                Assert.NotNull(replacementInfo)
-                Dim replacementKinds = replacementInfo.GetAllReplacementKinds().ToList()
-                Assert.Contains(InlineRenameReplacementKind.UnresolvedConflict, replacementKinds)
+                    Await WaitForRename(workspace)
+
+                    Assert.False(viewModel.Submit())
+
+                    textBuffer.Delete(New Span(caretPosition, 1))
+                    textBuffer.Insert(caretPosition, "Bar")
+
+                    Await WaitForRename(workspace)
+
+                    Assert.Equal(RenameFlyoutViewModel.Severity.Error, viewModel.StatusSeverity)
+                    Assert.True(viewModel.Submit())
+                End Using
             End Using
         End Function
 

--- a/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
+++ b/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
@@ -157,6 +157,8 @@ class C
 
                     Assert.Equal(RenameFlyoutViewModel.Severity.Error, viewModel.StatusSeverity)
                     Assert.True(viewModel.Submit())
+
+                    Await WaitForRename(workspace)
                 End Using
             End Using
         End Function

--- a/src/EditorFeatures/Test2/Rename/RenameEngineTests.CSharpConflicts.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameEngineTests.CSharpConflicts.vb
@@ -15,6 +15,82 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
                 _outputHelper = outputHelper
             End Sub
 
+            <Theory>
+            <CombinatorialData>
+            Public Sub RenameMethodReferenceWithUnboundArgument(host As RenameTestHost)
+                Using result = RenameEngineResult.Create(_outputHelper,
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true">
+                            <Document>
+class Program
+{
+    static void Main(string[] args)
+    {
+        [|Test|](x);
+        [|Test|](1);
+    }
+
+    static void [|$$Test|](int number)
+    {
+    }
+}
+                            </Document>
+                        </Project>
+                    </Workspace>, host:=host, renameTo:="Test2")
+                End Using
+            End Sub
+
+            <Theory>
+            <CombinatorialData>
+            Public Sub RenameMethodDoesNotRenameAmbiguousReferenceWithUnboundArgument(host As RenameTestHost)
+                Using result = RenameEngineResult.Create(_outputHelper,
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true">
+                            <Document>
+class Program
+{
+    static void Main(string[] args)
+    {
+        Test(x);
+        [|Test|](1);
+    }
+
+    static void [|$$Test|](int number)
+    {
+    }
+
+    static void Test(string value)
+    {
+    }
+}
+                            </Document>
+                        </Project>
+                    </Workspace>, host:=host, renameTo:="Test2")
+                End Using
+            End Sub
+
+            <Theory>
+            <CombinatorialData>
+            Public Sub RenameTypeReferenceWithUnboundConstructorArgument(host As RenameTestHost)
+                Using result = RenameEngineResult.Create(_outputHelper,
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true">
+                            <Document>
+record [|$$MyRecord|](int Number);
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        var r = new [|MyRecord|](x);
+    }
+}
+                            </Document>
+                        </Project>
+                    </Workspace>, host:=host, renameTo:="MyRecord2")
+                End Using
+            End Sub
+
             <WpfTheory, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/773543")>
             <CombinatorialData>
             Public Sub BreakingRenameWithRollBacksInsideLambdas_2(host As RenameTestHost)
@@ -3647,4 +3723,3 @@ class C
         End Sub
     End Class
 End Namespace
-

--- a/src/EditorFeatures/Test2/Rename/RenameEngineTests.CSharpConflicts.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameEngineTests.CSharpConflicts.vb
@@ -66,6 +66,10 @@ class Program
                             </Document>
                         </Project>
                     </Workspace>, host:=host, renameTo:="Test2")
+
+                    Dim documentText = result.ConflictResolution.NewSolution.Projects.Single().Documents.Single().GetTextAsync().Result.ToString()
+                    Assert.Contains("Test(x);", documentText)
+                    Assert.Contains("Test2(1);", documentText)
                 End Using
             End Sub
 

--- a/src/Workspaces/Core/Portable/Rename/RenameUtilities.cs
+++ b/src/Workspaces/Core/Portable/Rename/RenameUtilities.cs
@@ -99,7 +99,7 @@ internal static class RenameUtilities
         if (symbols.Length == 0)
         {
             var info = semanticModel.GetSymbolInfo(bindableToken, cancellationToken);
-            if (info.CandidateReason == CandidateReason.MemberGroup)
+            if (info.CandidateReason is CandidateReason.MemberGroup or CandidateReason.OverloadResolutionFailure)
             {
                 return info.CandidateSymbols;
             }

--- a/src/Workspaces/Core/Portable/Rename/SymbolicRenameLocations.ReferenceProcessing.cs
+++ b/src/Workspaces/Core/Portable/Rename/SymbolicRenameLocations.ReferenceProcessing.cs
@@ -269,6 +269,7 @@ internal sealed partial class SymbolicRenameLocations
             if (location.IsImplicit)
                 return [];
 
+            var candidateReason = await GetCandidateReasonAsync(location, cancellationToken).ConfigureAwait(false);
             var results = new List<RenameLocation>();
 
             // If we were originally naming an alias, then we'll only use the location if was
@@ -301,7 +302,7 @@ internal sealed partial class SymbolicRenameLocations
                     if (location.Alias.Name == referencedSymbolName)
                     {
                         results.Add(new RenameLocation(location.Location, location.Document.Id,
-                            candidateReason: location.CandidateReason, isRenamableAliasUsage: true, isWrittenTo: location.IsWrittenTo));
+                            candidateReason: candidateReason, isRenamableAliasUsage: true, isWrittenTo: location.IsWrittenTo));
 
                         // We also need to add the location of the alias itself
                         var aliasLocation = location.Alias.Locations.Single();
@@ -324,12 +325,31 @@ internal sealed partial class SymbolicRenameLocations
                         location.Location,
                         location.Document.Id,
                         isWrittenTo: location.IsWrittenTo,
-                        candidateReason: location.CandidateReason,
+                        candidateReason: candidateReason,
                         isRenamableAccessor: await IsPropertyAccessorOrAnOverrideAsync(referencedSymbol, solution, cancellationToken).ConfigureAwait(false)));
                 }
             }
 
             return results;
+
+            static async Task<CandidateReason> GetCandidateReasonAsync(ReferenceLocation location, CancellationToken cancellationToken)
+            {
+                if (location.CandidateReason is not CandidateReason.OverloadResolutionFailure)
+                    return location.CandidateReason;
+
+                var syntaxRoot = await location.Document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+                var token = syntaxRoot.FindToken(location.Location.SourceSpan.Start, findInsideTrivia: true);
+                var syntaxFacts = location.Document.GetRequiredLanguageService<ISyntaxFactsService>();
+                var bindableParent = syntaxFacts.TryGetBindableParent(token) ?? token.Parent;
+                if (bindableParent is null)
+                    return location.CandidateReason;
+
+                var semanticModel = await location.Document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+                var symbolInfo = semanticModel.GetSymbolInfo(bindableParent, cancellationToken);
+                return symbolInfo.CandidateSymbols.Length == 1
+                    ? CandidateReason.None
+                    : location.CandidateReason;
+            }
         }
 
         internal static async Task<(ImmutableArray<RenameLocation> strings, ImmutableArray<RenameLocation> comments)> GetRenamableLocationsInStringsAndCommentsAsync(

--- a/src/Workspaces/Core/Portable/Rename/SymbolicRenameLocations.ReferenceProcessing.cs
+++ b/src/Workspaces/Core/Portable/Rename/SymbolicRenameLocations.ReferenceProcessing.cs
@@ -269,7 +269,12 @@ internal sealed partial class SymbolicRenameLocations
             if (location.IsImplicit)
                 return [];
 
-            var candidateReason = await GetCandidateReasonAsync(location, cancellationToken).ConfigureAwait(false);
+            var candidateReason = location.CandidateReason;
+            if (candidateReason is CandidateReason.OverloadResolutionFailure)
+            {
+                candidateReason = await GetCandidateReasonForOverloadResolutionFailureAsync(location, cancellationToken).ConfigureAwait(false);
+            }
+
             var results = new List<RenameLocation>();
 
             // If we were originally naming an alias, then we'll only use the location if was
@@ -332,11 +337,9 @@ internal sealed partial class SymbolicRenameLocations
 
             return results;
 
-            static async Task<CandidateReason> GetCandidateReasonAsync(ReferenceLocation location, CancellationToken cancellationToken)
+            static async Task<CandidateReason> GetCandidateReasonForOverloadResolutionFailureAsync(
+                ReferenceLocation location, CancellationToken cancellationToken)
             {
-                if (location.CandidateReason is not CandidateReason.OverloadResolutionFailure)
-                    return location.CandidateReason;
-
                 var syntaxRoot = await location.Document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
                 var token = syntaxRoot.FindToken(location.Location.SourceSpan.Start, findInsideTrivia: true);
                 var syntaxFacts = location.Document.GetRequiredLanguageService<ISyntaxFactsService>();


### PR DESCRIPTION
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2942743

Two issues fixed:
- Unresolved conflicts remain visible but no longer block submission. Invalid replacement text still blocks submission
- References with unrelated binding errors, such as `Test(x)` where `x` does not exist, are renamed if there is exactly one candidate

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84686)