### PR TITLE
Skip redundant discovery and declaration lowering when replaying a Razor document

### DIFF
--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/SourceGeneratorProjectEngine.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/SourceGeneratorProjectEngine.cs
@@ -79,7 +79,6 @@ internal sealed class SourceGeneratorProjectEngine
     {
         Debug.Assert(sgDocument.CodeDocument.GetSyntaxTree() is not null);
 
-        int startIndex = _discoveryPhaseIndex;
         var codeDocument = sgDocument.CodeDocument;
 
         if (checkForIdempotency && codeDocument.TryGetTagHelpers(out var previousTagHelpers))
@@ -111,16 +110,19 @@ internal sealed class SourceGeneratorProjectEngine
             // Re-process the document with the updated tag helpers, starting from IR lowering. Resolution
             // binds unresolved nodes to their tag helpers by mutating the IR in place, so replaying from
             // resolution over an already-resolved tree finds nothing left to bind. Re-lowering rebuilds
-            // fresh unresolved IR from the syntax tree; classification, the split, discovery, and
-            // resolution then re-run over it against the new tag helpers.
-            startIndex = _loweringPhaseIndex;
-        }
-        else
-        {
-            codeDocument = codeDocument.WithTagHelpers(tagHelpers);
+            // fresh unresolved IR from the syntax tree; classification and the split then re-run over it.
+            //
+            // The discovery phase is skipped: the gate discovery above already computed the in-scope
+            // tag-helper context for the updated set, and it walks the syntax tree (not the IR) so re-lowering
+            // does not invalidate it. Re-running discovery here would recompute the identical context.
+            codeDocument = ExecutePhases(Phases[_loweringPhaseIndex.._discoveryPhaseIndex], codeDocument, cancellationToken);
+            codeDocument = ExecutePhases(Phases[(_discoveryPhaseIndex + 1)..(_rewritePhaseIndex + 1)], codeDocument, cancellationToken);
+
+            return new SourceGeneratorRazorCodeDocument(codeDocument);
         }
 
-        codeDocument = ExecutePhases(Phases[startIndex..(_rewritePhaseIndex + 1)], codeDocument, cancellationToken);
+        codeDocument = codeDocument.WithTagHelpers(tagHelpers);
+        codeDocument = ExecutePhases(Phases[_discoveryPhaseIndex..(_rewritePhaseIndex + 1)], codeDocument, cancellationToken);
 
         return new SourceGeneratorRazorCodeDocument(codeDocument);
     }

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/SourceGeneratorProjectEngine.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/SourceGeneratorProjectEngine.cs
@@ -15,6 +15,7 @@ internal sealed class SourceGeneratorProjectEngine
 
     private readonly IRazorEnginePhase _discoveryPhase;
     private readonly int _loweringPhaseIndex = -1;
+    private readonly int _declLoweringPhaseIndex = -1;
     private readonly int _discoveryPhaseIndex = -1;
     private readonly int _rewritePhaseIndex = -1;
 
@@ -28,7 +29,7 @@ internal sealed class SourceGeneratorProjectEngine
 
         foreach (var phase in Phases)
         {
-            if (_loweringPhaseIndex >= 0 && _discoveryPhaseIndex >= 0 && _rewritePhaseIndex >= 0)
+            if (_loweringPhaseIndex >= 0 && _declLoweringPhaseIndex >= 0 && _discoveryPhaseIndex >= 0 && _rewritePhaseIndex >= 0)
             {
                 break;
             }
@@ -37,6 +38,10 @@ internal sealed class SourceGeneratorProjectEngine
             {
                 case DefaultRazorIntermediateNodeLoweringPhase:
                     _loweringPhaseIndex = index;
+                    break;
+
+                case DefaultRazorDeclCSharpLoweringPhase:
+                    _declLoweringPhaseIndex = index;
                     break;
 
                 case DefaultRazorTagHelperContextDiscoveryPhase:
@@ -54,9 +59,11 @@ internal sealed class SourceGeneratorProjectEngine
 
         Debug.Assert(_discoveryPhase is not null);
         Debug.Assert(_loweringPhaseIndex >= 0);
+        Debug.Assert(_declLoweringPhaseIndex >= 0);
         Debug.Assert(_discoveryPhaseIndex >= 0);
         Debug.Assert(_rewritePhaseIndex >= 0);
-        Debug.Assert(_loweringPhaseIndex < _discoveryPhaseIndex);
+        Debug.Assert(_loweringPhaseIndex < _declLoweringPhaseIndex);
+        Debug.Assert(_declLoweringPhaseIndex < _discoveryPhaseIndex);
         Debug.Assert(_discoveryPhaseIndex < _rewritePhaseIndex);
     }
 
@@ -110,13 +117,28 @@ internal sealed class SourceGeneratorProjectEngine
             // Re-process the document with the updated tag helpers, starting from IR lowering. Resolution
             // binds unresolved nodes to their tag helpers by mutating the IR in place, so replaying from
             // resolution over an already-resolved tree finds nothing left to bind. Re-lowering rebuilds
-            // fresh unresolved IR from the syntax tree; classification and the split then re-run over it.
+            // fresh unresolved IR from the syntax tree; classification and the markup split then re-run over
+            // it -- the split is what carves the working IR into the impl half that resolution and rewrite
+            // operate on, so it cannot be skipped.
             //
-            // The discovery phase is skipped: the gate discovery above already computed the in-scope
-            // tag-helper context for the updated set, and it walks the syntax tree (not the IR) so re-lowering
-            // does not invalidate it. Re-running discovery here would recompute the identical context.
-            codeDocument = ExecutePhases(Phases[_loweringPhaseIndex.._discoveryPhaseIndex], codeDocument, cancellationToken);
+            // Two phases in that range are skipped:
+            //  * Discovery: the gate discovery above already computed the in-scope tag-helper context for the
+            //    updated set. It walks the syntax tree (not the IR), so re-lowering does not invalidate it,
+            //    and re-running it would recompute the identical context.
+            //  * Decl C# lowering: it lowers the markup-free declaration half, whose text depends only on the
+            //    document's own source. A tag-helper change elsewhere cannot alter it, so the declaration
+            //    document from the initial parse is still valid. It is captured here and restored afterward
+            //    because nothing in the replayed range regenerates it, and it feeds the generator's output
+            //    cache comparison and declaration-diagnostic reporting.
+            var declCSharpDocument = codeDocument.GetDeclCSharpDocument();
+
+            codeDocument = ExecutePhases(Phases[_loweringPhaseIndex.._declLoweringPhaseIndex], codeDocument, cancellationToken);
             codeDocument = ExecutePhases(Phases[(_discoveryPhaseIndex + 1)..(_rewritePhaseIndex + 1)], codeDocument, cancellationToken);
+
+            if (declCSharpDocument is not null)
+            {
+                codeDocument = codeDocument.WithDeclCSharpDocument(declCSharpDocument);
+            }
 
             return new SourceGeneratorRazorCodeDocument(codeDocument);
         }


### PR DESCRIPTION
## What

Two focused, independently-measured reductions in the work the Razor source generator does when it **replays** a cached document after a project-wide tag-helper change (e.g. editing a shared component's parameters, which cascades a re-process into every in-scope consumer).

Both build on the classify-first split already in `features/sonic`. Neither changes generated output.

### 1. Skip redundant tag-helper discovery when replaying (`ed849e48fbe`)

The replay first re-runs discovery on its own to decide whether the change affects the document (the `RequiresRewrite` gate). When it does, the replay then re-ran the pipeline from IR lowering — and because discovery sits *after* lowering in the classify-first pipeline, it ran discovery a **second** time, recomputing the identical in-scope tag-helper context.

Discovery walks the syntax tree, not the lowered IR, so the gate's context survives re-lowering. The replay is split around the discovery phase and reuses the gate's result.

### 2. Skip declaration C# lowering when replaying (`56cb68f03c0`)

The replay re-lowered the markup-free **declaration** half on every in-scope consumer, even though a tag-helper change elsewhere cannot alter it (the declaration is markup-free; its text depends only on the document's own source). The first phase slice now stops before declaration C# lowering, and the declaration document computed by the initial parse is carried across the replay. The declaration source is emitted from the initial parse via pre-compilation output, not from the replay; the replay's copy only feeds the output cache comparison and declaration-diagnostic reporting, so preserving it keeps both intact.

## Measured impact

Microbenchmark: edit a shared component consumed across a 110-document app (`Razor_Edit_Dependent`), per-consumer, deterministic allocation:

| | Replay CPU | Alloc/consumer |
| --- | --- | --- |
| Skip 2nd discovery | **-21%** | -454 KB |
| Skip decl lowering | — | -828 KB |

Edit total allocation: 7626 -> 6782 KB/run. (Allocation is the deterministic signal; wall-time is too noisy on the measurement box to report.)

## Testing

`Microsoft.NET.Sdk.Razor.SourceGenerators.UnitTests` — 218 passed / 1 skipped / 0 failed, unchanged from baseline. No generated output changes.

## Notes

This is the first slice of a larger replay-perf effort. The remaining cost is the per-consumer re-run of the source-only phases (IR lowering + classifiers + markup split); removing that needs the pre-resolution IR snapshot to survive the replay, which is a follow-up.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84698)