### PR TITLE
Fix on-type and code action formatting on Razor explicit statements

### DIFF
--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpOnTypeFormattingPass.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpOnTypeFormattingPass.cs
@@ -756,9 +756,17 @@ internal sealed class CSharpOnTypeFormattingPass(
             var line = context.SourceText.Lines[i];
             var lineStart = line.GetFirstNonWhitespacePosition() ?? line.Start;
             var lineStartSpan = new TextSpan(lineStart, 0);
-            if (!ShouldFormatLine(context, lineStartSpan, allowImplicitStatements: true))
+            if (!ShouldFormatLine(context, lineStartSpan, allowImplicitStatements: true, out var owner))
             {
                 // We don't care about this line as it lies in an area we don't want to format.
+                continue;
+            }
+
+            var razorDesiredIndentation = context.GetIndentationOffsetForLevel(indentations[i].IndentationLevel);
+            if (owner is CSharpTransitionSyntax { Parent: CSharpStatementSyntax })
+            {
+                // An explicit statement delimiter has no C# source mapping, so use only its Razor/HTML indentation.
+                newIndentations[i] = razorDesiredIndentation;
                 continue;
             }
 
@@ -820,7 +828,6 @@ internal sealed class CSharpOnTypeFormattingPass(
             }
 
             var effectiveCSharpDesiredIndentation = csharpDesiredIndentation - minCSharpIndentation;
-            var razorDesiredIndentation = context.GetIndentationOffsetForLevel(indentations[i].IndentationLevel);
             if (indentations[i].StartsInHtmlContext)
             {
                 // This is a non-C# line.
@@ -857,8 +864,8 @@ internal sealed class CSharpOnTypeFormattingPass(
     private static bool ShouldFormat(FormattingContext context, TextSpan mappingSpan, bool allowImplicitStatements, out RazorSyntaxNode? foundOwner)
         => ShouldFormat(context, mappingSpan, new ShouldFormatOptions(allowImplicitStatements, isLineRequest: false), out foundOwner);
 
-    private static bool ShouldFormatLine(FormattingContext context, TextSpan mappingSpan, bool allowImplicitStatements)
-        => ShouldFormat(context, mappingSpan, new ShouldFormatOptions(allowImplicitStatements, isLineRequest: true), out _);
+    private static bool ShouldFormatLine(FormattingContext context, TextSpan mappingSpan, bool allowImplicitStatements, out RazorSyntaxNode? foundOwner)
+        => ShouldFormat(context, mappingSpan, new ShouldFormatOptions(allowImplicitStatements, isLineRequest: true), out foundOwner);
 
     private static bool ShouldFormat(FormattingContext context, TextSpan mappingSpan, ShouldFormatOptions options, out RazorSyntaxNode? foundOwner)
     {

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/CodeActions/CSharpCodeActionTests.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/CodeActions/CSharpCodeActionTests.cs
@@ -71,7 +71,7 @@ public class CSharpCodeActionTests(ITestOutputHelper testOutputHelper) : CohostC
         var expected = """
             @(booleanValue ?@<br /> : @<br />)
 
-                        @{
+            @{
                 if (false)
                 {
                     // false

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/CodeActions/CSharpCodeActionTests.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/CodeActions/CSharpCodeActionTests.cs
@@ -46,6 +46,55 @@ public class CSharpCodeActionTests(ITestOutputHelper testOutputHelper) : CohostC
     }
 
     [Fact]
+    public async Task InvertIf_ExplicitStatement()
+    {
+        var input = """
+            @(booleanValue ?@<br /> : @<br />)
+
+            @{
+                [||]if (true)
+                {
+                    // true
+                }
+                else
+                {
+                    // false
+                }
+            }
+
+            @code
+            {
+                private bool booleanValue = true;
+            }
+            """;
+
+        var expected = """
+            @(booleanValue ?@<br /> : @<br />)
+
+                        @{
+                if (false)
+                {
+                    // false
+                }
+                else
+                {
+                    // true
+                }
+            }
+
+            @code
+            {
+                private bool booleanValue = true;
+            }
+            """;
+
+        var advancedSettings = ClientSettingsManager.GetClientSettings().AdvancedSettings;
+        ClientSettingsManager.Update(advancedSettings with { ShowAllCSharpCodeActions = true });
+
+        await VerifyCodeActionAsync(input, expected, PredefinedCodeRefactoringProviderNames.InvertIf);
+    }
+
+    [Fact]
     public async Task GenerateConstructor()
     {
         var input = """

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Formatting/DocumentFormattingTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Formatting/DocumentFormattingTest.cs
@@ -7183,6 +7183,136 @@ public class DocumentFormattingTest(ITestOutputHelper testOutput) : DocumentForm
     }
 
     [Fact]
+    public async Task ExplicitStatement_ShiftedOpeningBrace()
+    {
+        await RunFormattingTestAsync(
+            input: """
+                @(booleanValue ?@<br /> : @<br />)
+
+                            @{
+                    if (false)
+                    {
+                        // false
+                    }
+                    else
+                    {
+                        // true
+                    }
+                }
+
+                @code
+                {
+                    private bool booleanValue = true;
+                }
+                """,
+            htmlFormatted: """
+                @(booleanValue ?@
+                <br /> : @
+                <br />)
+
+                            @{
+                    if (false)
+                    {
+                        // false
+                    }
+                    else
+                    {
+                        // true
+                    }
+                }
+
+                @code
+                {
+                    private bool booleanValue = true;
+                }
+                """,
+            expected: """
+                @(booleanValue ?@<br /> : @<br />)
+
+                @{
+                    if (false)
+                    {
+                        // false
+                    }
+                    else
+                    {
+                        // true
+                    }
+                }
+
+                @code
+                {
+                    private bool booleanValue = true;
+                }
+                """);
+    }
+
+    [Fact]
+    public async Task ExplicitStatement_AlreadyFormatted()
+    {
+        await RunFormattingTestAsync(
+            input: """
+                @(booleanValue ?@<br /> : @<br />)
+
+                @{
+                    if (false)
+                    {
+                        // false
+                    }
+                    else
+                    {
+                        // true
+                    }
+                }
+
+                @code
+                {
+                    private bool booleanValue = true;
+                }
+                """,
+            htmlFormatted: """
+                @(booleanValue ?@
+                <br /> : @
+                <br />)
+
+                @{
+                    if (false)
+                    {
+                        // false
+                    }
+                    else
+                    {
+                        // true
+                    }
+                }
+
+                @code
+                {
+                    private bool booleanValue = true;
+                }
+                """,
+            expected: """
+                @(booleanValue ?@<br /> : @<br />)
+
+                @{
+                    if (false)
+                    {
+                        // false
+                    }
+                    else
+                    {
+                        // true
+                    }
+                }
+
+                @code
+                {
+                    private bool booleanValue = true;
+                }
+                """);
+    }
+
+    [Fact]
     public async Task Formats_NonCodeBlockDirectives()
     {
         await RunFormattingTestAsync(

--- a/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Cohost/Formatting/OnTypeFormattingTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Cohost/Formatting/OnTypeFormattingTest.cs
@@ -53,6 +53,51 @@ public class OnTypeFormattingTest(FormattingTestContext context, HtmlFormattingF
     }
 
     [FormattingTestFact]
+    public async Task CloseCurly_ExplicitStatement_PreservesOpeningBraceAsync()
+    {
+        await RunOnTypeFormattingTestAsync(
+            input: """
+                    @(booleanValue ?@<br /> : @<br />)
+
+                    @{
+                        if (false)
+                        {
+                            // false
+                        }
+                        else
+                        {
+                            // true
+                        }$$
+                    }
+
+                    @code
+                    {
+                        private bool booleanValue = true;
+                    }
+                    """,
+            expected: """
+                    @(booleanValue ?@<br /> : @<br />)
+
+                    @{
+                        if (false)
+                        {
+                            // false
+                        }
+                        else
+                        {
+                            // true
+                        }
+                    }
+
+                    @code
+                    {
+                        private bool booleanValue = true;
+                    }
+                    """,
+            triggerCharacter: '}');
+    }
+
+    [FormattingTestFact]
     public async Task FormatsIfStatementInComponent()
     {
         await RunOnTypeFormattingTestAsync(


### PR DESCRIPTION
Noticed this today while testing something completely unrelated.

Review commit at a time if you want to see the current behaviour versus the fix, but its not a huge PR so up to you whether you care :)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84699)