### PR TITLE
Generate Documentation - incorrect buffer bug

### DIFF
--- a/src/EditorFeatures/Core/DocumentationComments/CopilotGenerateDocumentationCommentManager.cs
+++ b/src/EditorFeatures/Core/DocumentationComments/CopilotGenerateDocumentationCommentManager.cs
@@ -68,7 +68,7 @@ internal sealed class CopilotGenerateDocumentationCommentManager
         _inlinePromptService!.Show(
             textView,
             caret,
-            onAcceptAsync: dismissToken => GenerateAndApplyDocumentationAsync(document, snippet, snapshot, textView, dismissToken),
+            onAcceptAsync: dismissToken => GenerateAndApplyDocumentationAsync(document, snippet, snapshot, dismissToken),
             new InlinePromptOptions
             {
                 ProviderName = GenerateDocumentationProviderName,
@@ -81,7 +81,7 @@ internal sealed class CopilotGenerateDocumentationCommentManager
     }
 
     private async Task GenerateAndApplyDocumentationAsync(Document document,
-        DocumentationCommentSnippet snippet, ITextSnapshot snapshot, ITextView textView, CancellationToken cancellationToken)
+        DocumentationCommentSnippet snippet, ITextSnapshot snapshot, CancellationToken cancellationToken)
     {
         // Re-check Copilot availability / file-exclusion at accept time; degrade quietly otherwise.
         var copilotService = await IsGenerateDocumentationAvailableAsync(document, snippet.MemberNode, cancellationToken).ConfigureAwait(false);

--- a/src/EditorFeatures/Core/DocumentationComments/CopilotGenerateDocumentationCommentManager.cs
+++ b/src/EditorFeatures/Core/DocumentationComments/CopilotGenerateDocumentationCommentManager.cs
@@ -107,7 +107,7 @@ internal sealed class CopilotGenerateDocumentationCommentManager
         // Apply the edit fire-and-forget: returning tears the session down (cancelling the token), so the write
         // must run afterward and not flow that token.
         var token = _asyncListener.BeginAsyncOperation(nameof(ApplyDocumentationEditsAsync));
-        _ = ApplyDocumentationEditsAsync(textView.TextBuffer, snapshot, edits).CompletesAsyncOperation(token);
+        _ = ApplyDocumentationEditsAsync(snapshot.TextBuffer, snapshot, edits).CompletesAsyncOperation(token);
     }
 
     private async Task ApplyDocumentationEditsAsync(ITextBuffer buffer, ITextSnapshot snapshot, ImmutableArray<DocumentationCommentEdit> edits)


### PR DESCRIPTION
`ApplyDocumentationEditsAsync` is invoked with `textView.TextBuffer`, but the edit spans are based on the snapshot passed in (captured from the subject buffer in the command handler). In projection scenarios these buffers can differ, and translating spans across snapshots from different buffers will fail. Use the buffer associated with the captured snapshot when applying edits.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84709)