### PR TITLE
Handle textDocument/didChange notifications that don't pass across the range

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/ServerInitializationTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/ServerInitializationTests.cs
@@ -39,7 +39,7 @@ public sealed class ServerInitializationTests(ITestOutputHelper testOutputHelper
             TextDocument = document,
             ContentChanges =
             [
-               new TextDocumentContentChangeEvent
+               new TextDocumentContentChangePartial
                {
                    Range = new Roslyn.LanguageServer.Protocol.Range { Start = new Position(0, 0), End = new Position(0, 0) },
                    Text = "Console."

--- a/src/LanguageServer/Protocol.TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
+++ b/src/LanguageServer/Protocol.TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
@@ -534,14 +534,17 @@ public abstract partial class AbstractLanguageServerProtocolTests
 
     private static LSP.DidChangeTextDocumentParams CreateDidChangeTextDocumentParams(
         DocumentUri documentUri,
-        ImmutableArray<(LSP.Range Range, string Text)> changes,
+        ImmutableArray<(LSP.Range? Range, string Text)> changes,
         int version = 0)
     {
-        var changeEvents = changes.Select(change => new LSP.TextDocumentContentChangeEvent
+        var changeEvents = new LSP.SumType<LSP.TextDocumentContentChangePartial, LSP.TextDocumentContentChangeWholeDocument>[changes.Length];
+        for (var i = 0; i < changes.Length; i++)
         {
-            Text = change.Text,
-            Range = change.Range,
-        }).ToArray();
+            var (range, text) = changes[i];
+            changeEvents[i] = range != null
+                ? new LSP.TextDocumentContentChangePartial { Text = text, Range = range }
+                : new LSP.TextDocumentContentChangeWholeDocument { Text = text };
+        }
 
         return new LSP.DidChangeTextDocumentParams()
         {
@@ -800,7 +803,7 @@ public abstract partial class AbstractLanguageServerProtocolTests
             await WaitForWorkspaceOperationsAsync(TestWorkspace);
         }
 
-        public Task ReplaceTextAsync(DocumentUri documentUri, int version, params (LSP.Range Range, string Text)[] changes)
+        public Task ReplaceTextAsync(DocumentUri documentUri, int version, params (LSP.Range? Range, string Text)[] changes)
         {
             var didChangeParams = CreateDidChangeTextDocumentParams(
                 documentUri,
@@ -809,18 +812,27 @@ public abstract partial class AbstractLanguageServerProtocolTests
             return ExecuteRequestAsync<LSP.DidChangeTextDocumentParams, object>(LSP.Methods.TextDocumentDidChangeName, didChangeParams, CancellationToken.None);
         }
 
-        public Task ReplaceTextAsync(DocumentUri documentUri, params (LSP.Range Range, string Text)[] changes)
+        public Task ReplaceTextAsync(DocumentUri documentUri, params (LSP.Range? Range, string Text)[] changes)
         {
             return ReplaceTextAsync(documentUri, version: 0, changes);
         }
 
-        public Task InsertTextAsync(DocumentUri documentUri, int version, params (int Line, int Column, string Text)[] changes)
+        public Task InsertTextAsync(DocumentUri documentUri, int version, params (int? Line, int? Column, string Text)[] changes)
         {
-            return ReplaceTextAsync(documentUri, version, [.. changes.Select(change => (new LSP.Range
+            var rangeChanges = new List<(LSP.Range? Range, string Text)>();
+            foreach (var (line, column, text) in changes)
             {
-                Start = new LSP.Position { Line = change.Line, Character = change.Column },
-                End = new LSP.Position { Line = change.Line, Character = change.Column }
-            }, change.Text))]);
+                var range = (line is null || column is null)
+                    ? null
+                    : new LSP.Range
+                    {
+                        Start = new LSP.Position { Line = line.Value, Character = column.Value },
+                        End = new LSP.Position { Line = line.Value, Character = column.Value }
+                    };
+                rangeChanges.Add((range, text));
+            }
+
+            return ReplaceTextAsync(documentUri, version, [.. rangeChanges]);
         }
 
         public Task InsertTextAsync(DocumentUri documentUri, params (int Line, int Column, string Text)[] changes)

--- a/src/LanguageServer/Protocol.TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
+++ b/src/LanguageServer/Protocol.TestUtilities/LanguageServer/AbstractLanguageServerProtocolTests.cs
@@ -835,7 +835,7 @@ public abstract partial class AbstractLanguageServerProtocolTests
             return ReplaceTextAsync(documentUri, version, [.. rangeChanges]);
         }
 
-        public Task InsertTextAsync(DocumentUri documentUri, params (int Line, int Column, string Text)[] changes)
+        public Task InsertTextAsync(DocumentUri documentUri, params (int? Line, int? Column, string Text)[] changes)
         {
             return InsertTextAsync(documentUri, version: 0, changes);
         }

--- a/src/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
+++ b/src/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
@@ -394,7 +394,7 @@ internal static partial class ProtocolConversions
     public static TextChange TextEditToTextChange(LSP.TextEdit edit, SourceText oldText)
         => new(RangeToTextSpan(edit.Range, oldText), edit.NewText);
 
-    public static TextChange ContentChangeEventToTextChange(LSP.TextDocumentContentChangeEvent changeEvent, SourceText text)
+    public static TextChange ContentChangeEventToTextChange(LSP.TextDocumentContentChangePartial changeEvent, SourceText text)
         => new(RangeToTextSpan(changeEvent.Range, text), changeEvent.Text);
 
     public static LSP.Position LinePositionToPosition(LinePosition linePosition)

--- a/src/LanguageServer/Protocol/Handler/DocumentChanges/DidChangeHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/DocumentChanges/DidChangeHandler.cs
@@ -89,9 +89,9 @@ internal class DidChangeHandler() : ILspServiceDocumentRequestHandler<DidChangeT
 
     private static (ImmutableArray<TextDocumentContentChangePartial>, SourceText) GetUpdatedSourceTextAndChangesAfterFullTextReplacementHandled(SumType<TextDocumentContentChangePartial, TextDocumentContentChangeWholeDocument>[] contentChanges, SourceText text)
     {
-        // Per the LSP spec, each content change can be either a TextDocumentContentChangeEvent or TextDocumentContentChangeFullReplacementEvent.
-        // The former is a range-based change while the latter is a full text replacement. If a TextDocumentContentChangeFullReplacementEvent is found,
-        // then make a full text replacement for that and return all subsequent changes as remaining range-based changes.
+        // Per the LSP spec, each content change is either a range-based change (TextDocumentContentChangePartial)
+        // or a full document text replacement (TextDocumentContentChangeWholeDocument). If a full replacement is found,
+        // apply it and return only the subsequent range-based changes to be processed normally.
         var lastFullTextChangeEventIndex = contentChanges.Length - 1;
         for (; lastFullTextChangeEventIndex >= 0; lastFullTextChangeEventIndex--)
         {

--- a/src/LanguageServer/Protocol/Handler/DocumentChanges/DidChangeHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/DocumentChanges/DidChangeHandler.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
 using System.Threading;
@@ -37,7 +38,7 @@ internal class DidChangeHandler() : ILspServiceDocumentRequestHandler<DidChangeT
         return null;
     }
 
-    internal static bool AreChangesInReverseOrder(TextDocumentContentChangeEvent[] contentChanges)
+    internal static bool AreChangesInReverseOrder(ImmutableArray<TextDocumentContentChangePartial> contentChanges)
     {
         for (var i = 1; i < contentChanges.Length; i++)
         {
@@ -53,8 +54,14 @@ internal class DidChangeHandler() : ILspServiceDocumentRequestHandler<DidChangeT
         return true;
     }
 
-    private static SourceText GetUpdatedSourceText(TextDocumentContentChangeEvent[] contentChanges, SourceText text)
+    private static SourceText GetUpdatedSourceText(SumType<TextDocumentContentChangePartial, TextDocumentContentChangeWholeDocument>[] contentChanges, SourceText text)
     {
+        (var remainingContentChanges, text) = GetUpdatedSourceTextAndChangesAfterFullTextReplacementHandled(contentChanges, text);
+
+        // No range-based changes to apply.
+        if (remainingContentChanges.IsEmpty)
+            return text;
+
         // Per the LSP spec, each text change builds upon the previous, so we don't need to translate any text
         // positions between changes. See
         // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#didChangeTextDocumentParams
@@ -63,20 +70,41 @@ internal class DidChangeHandler() : ILspServiceDocumentRequestHandler<DidChangeT
         // If the host sends us changes in a way such that no earlier change can affect the position of a later change,
         // then we can merge the changes into a single TextChange, allowing creation of only a single new
         // source text.
-        if (AreChangesInReverseOrder(contentChanges))
+        if (AreChangesInReverseOrder(remainingContentChanges))
         {
             // The changes were in reverse document order, so we can merge them into a single operation on the source text.
             // Note that the WithChanges implementation works more efficiently with it's input in forward document order.
-            var newChanges = contentChanges.Reverse().SelectAsArray(change => ProtocolConversions.ContentChangeEventToTextChange(change, text));
+            var newChanges = remainingContentChanges.Reverse().SelectAsArray(change => ProtocolConversions.ContentChangeEventToTextChange(change, text));
             text = text.WithChanges(newChanges);
         }
         else
         {
             // The host didn't send us the items ordered, so we'll apply each one independently.
-            foreach (var change in contentChanges)
+            foreach (var change in remainingContentChanges)
                 text = text.WithChanges(ProtocolConversions.ContentChangeEventToTextChange(change, text));
         }
 
         return text;
+    }
+
+    private static (ImmutableArray<TextDocumentContentChangePartial>, SourceText) GetUpdatedSourceTextAndChangesAfterFullTextReplacementHandled(SumType<TextDocumentContentChangePartial, TextDocumentContentChangeWholeDocument>[] contentChanges, SourceText text)
+    {
+        // Per the LSP spec, each content change can be either a TextDocumentContentChangeEvent or TextDocumentContentChangeFullReplacementEvent.
+        // The former is a range-based change while the latter is a full text replacement. If a TextDocumentContentChangeFullReplacementEvent is found,
+        // then make a full text replacement for that and return all subsequent changes as remaining range-based changes.
+        var lastFullTextChangeEventIndex = contentChanges.Length - 1;
+        for (; lastFullTextChangeEventIndex >= 0; lastFullTextChangeEventIndex--)
+        {
+            var change = contentChanges[lastFullTextChangeEventIndex];
+            if (change.Value is TextDocumentContentChangeWholeDocument onlyTextEvent)
+            {
+                // Found a full text replacement. Create the new text and stop processing.
+                text = text.WithChanges([new TextChange(new TextSpan(0, text.Length), onlyTextEvent.Text)]);
+                break;
+            }
+        }
+
+        var remainingContentChanges = contentChanges.Skip(lastFullTextChangeEventIndex + 1).SelectAsArray(c => c.First);
+        return (remainingContentChanges, text);
     }
 }

--- a/src/LanguageServer/Protocol/Protocol/DidChangeTextDocumentParams.cs
+++ b/src/LanguageServer/Protocol/Protocol/DidChangeTextDocumentParams.cs
@@ -45,7 +45,7 @@ internal sealed class DidChangeTextDocumentParams : ITextDocumentParams
     /// </summary>
     [JsonPropertyName("contentChanges")]
     [JsonRequired]
-    public TextDocumentContentChangeEvent[] ContentChanges
+    public SumType<TextDocumentContentChangePartial, TextDocumentContentChangeWholeDocument>[] ContentChanges
     {
         get;
         set;

--- a/src/LanguageServer/Protocol/Protocol/Notebook/NotebookDocumentChangeCellsText.cs
+++ b/src/LanguageServer/Protocol/Protocol/Notebook/NotebookDocumentChangeCellsText.cs
@@ -27,5 +27,5 @@ internal sealed class NotebookDocumentChangeCellsText
     /// </summary>
     [JsonPropertyName("changes")]
     [JsonRequired]
-    public TextDocumentContentChangeEvent[] Changes { get; init; }
+    public SumType<TextDocumentContentChangePartial, TextDocumentContentChangeWholeDocument>[] Changes { get; init; }
 }

--- a/src/LanguageServer/Protocol/Protocol/TextDocumentContentChangePartial.cs
+++ b/src/LanguageServer/Protocol/Protocol/TextDocumentContentChangePartial.cs
@@ -7,17 +7,18 @@ namespace Roslyn.LanguageServer.Protocol;
 using System.Text.Json.Serialization;
 
 /// <summary>
-/// Class which encapsulates a text document changed event.
+/// Class which encapsulates a partial text document changed event.
 /// <para>
-/// See the <see href="https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocumentContentChangeEvent">Language Server Protocol specification</see> for additional information.
+/// See the <see href="https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocumentContentChangePartial">Language Server Protocol specification</see> for additional information.
 /// </para>
 /// </summary>
-internal sealed class TextDocumentContentChangeEvent
+internal sealed class TextDocumentContentChangePartial
 {
     /// <summary>
     /// Gets or sets the range of the text that was changed.
     /// </summary>
     [JsonPropertyName("range")]
+    [JsonRequired]
     public Range Range
     {
         get;
@@ -39,6 +40,7 @@ internal sealed class TextDocumentContentChangeEvent
     /// Gets or sets the new text of the range/document.
     /// </summary>
     [JsonPropertyName("text")]
+    [JsonRequired]
     public string Text
     {
         get;

--- a/src/LanguageServer/Protocol/Protocol/TextDocumentContentChangeWholeDocument.cs
+++ b/src/LanguageServer/Protocol/Protocol/TextDocumentContentChangeWholeDocument.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Roslyn.LanguageServer.Protocol;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Class which encapsulates a whole text document changed event.
+/// <para>
+/// See the <see href="https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocumentContentChangeWholeDocument">Language Server Protocol specification</see> for additional information.
+/// </para>
+/// </summary>
+internal sealed class TextDocumentContentChangeWholeDocument
+{
+    /// <summary>
+    /// Gets or sets the new text of the document.
+    /// </summary>
+    [JsonPropertyName("text")]
+    [JsonRequired]
+    public string Text
+    {
+        get;
+        set;
+    }
+}

--- a/src/LanguageServer/ProtocolUnitTests/DocumentChanges/DocumentChangesTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/DocumentChanges/DocumentChangesTests.cs
@@ -363,9 +363,9 @@ public sealed partial class DocumentChangesTests(ITestOutputHelper testOutputHel
         }
     }
 
-    private LSP.TextDocumentContentChangeEvent CreateTextDocumentContentChangeEvent(int startLine, int startCol, int endLine, int endCol, string newText)
+    private LSP.TextDocumentContentChangePartial CreateTextDocumentContentChangeEvent(int startLine, int startCol, int endLine, int endCol, string newText)
     {
-        return new LSP.TextDocumentContentChangeEvent()
+        return new LSP.TextDocumentContentChangePartial()
         {
             Range = new LSP.Range()
             {
@@ -379,9 +379,9 @@ public sealed partial class DocumentChangesTests(ITestOutputHelper testOutputHel
     [Fact]
     public void DidChange_AreChangesInReverseOrder_True()
     {
-        LSP.TextDocumentContentChangeEvent change1 = CreateTextDocumentContentChangeEvent(startLine: 0, startCol: 7, endLine: 0, endCol: 9, newText: "test3");
-        LSP.TextDocumentContentChangeEvent change2 = CreateTextDocumentContentChangeEvent(startLine: 0, startCol: 5, endLine: 0, endCol: 7, newText: "test2");
-        LSP.TextDocumentContentChangeEvent change3 = CreateTextDocumentContentChangeEvent(startLine: 0, startCol: 1, endLine: 0, endCol: 3, newText: "test1");
+        LSP.TextDocumentContentChangePartial change1 = CreateTextDocumentContentChangeEvent(startLine: 0, startCol: 7, endLine: 0, endCol: 9, newText: "test3");
+        LSP.TextDocumentContentChangePartial change2 = CreateTextDocumentContentChangeEvent(startLine: 0, startCol: 5, endLine: 0, endCol: 7, newText: "test2");
+        LSP.TextDocumentContentChangePartial change3 = CreateTextDocumentContentChangeEvent(startLine: 0, startCol: 1, endLine: 0, endCol: 3, newText: "test1");
 
         Assert.True(DidChangeHandler.AreChangesInReverseOrder([change1, change2, change3]));
     }
@@ -389,9 +389,9 @@ public sealed partial class DocumentChangesTests(ITestOutputHelper testOutputHel
     [Fact]
     public void DidChange_AreChangesInReverseOrder_InForwardOrder()
     {
-        LSP.TextDocumentContentChangeEvent change1 = CreateTextDocumentContentChangeEvent(startLine: 0, startCol: 1, endLine: 0, endCol: 3, newText: "test1");
-        LSP.TextDocumentContentChangeEvent change2 = CreateTextDocumentContentChangeEvent(startLine: 0, startCol: 5, endLine: 0, endCol: 7, newText: "test2");
-        LSP.TextDocumentContentChangeEvent change3 = CreateTextDocumentContentChangeEvent(startLine: 0, startCol: 7, endLine: 0, endCol: 9, newText: "test3");
+        LSP.TextDocumentContentChangePartial change1 = CreateTextDocumentContentChangeEvent(startLine: 0, startCol: 1, endLine: 0, endCol: 3, newText: "test1");
+        LSP.TextDocumentContentChangePartial change2 = CreateTextDocumentContentChangeEvent(startLine: 0, startCol: 5, endLine: 0, endCol: 7, newText: "test2");
+        LSP.TextDocumentContentChangePartial change3 = CreateTextDocumentContentChangeEvent(startLine: 0, startCol: 7, endLine: 0, endCol: 9, newText: "test3");
 
         Assert.False(DidChangeHandler.AreChangesInReverseOrder([change1, change2, change3]));
     }
@@ -399,9 +399,9 @@ public sealed partial class DocumentChangesTests(ITestOutputHelper testOutputHel
     [Fact]
     public void DidChange_AreChangesInReverseOrder_Overlapping()
     {
-        LSP.TextDocumentContentChangeEvent change1 = CreateTextDocumentContentChangeEvent(startLine: 0, startCol: 1, endLine: 0, endCol: 3, newText: "test1");
-        LSP.TextDocumentContentChangeEvent change2 = CreateTextDocumentContentChangeEvent(startLine: 0, startCol: 2, endLine: 0, endCol: 4, newText: "test2");
-        LSP.TextDocumentContentChangeEvent change3 = CreateTextDocumentContentChangeEvent(startLine: 0, startCol: 3, endLine: 0, endCol: 5, newText: "test3");
+        LSP.TextDocumentContentChangePartial change1 = CreateTextDocumentContentChangeEvent(startLine: 0, startCol: 1, endLine: 0, endCol: 3, newText: "test1");
+        LSP.TextDocumentContentChangePartial change2 = CreateTextDocumentContentChangeEvent(startLine: 0, startCol: 2, endLine: 0, endCol: 4, newText: "test2");
+        LSP.TextDocumentContentChangePartial change3 = CreateTextDocumentContentChangeEvent(startLine: 0, startCol: 3, endLine: 0, endCol: 5, newText: "test3");
 
         Assert.False(DidChangeHandler.AreChangesInReverseOrder([change1, change2, change3]));
     }
@@ -469,6 +469,38 @@ public sealed partial class DocumentChangesTests(ITestOutputHelper testOutputHel
         }
     }
 
+    [Theory, CombinatorialData]
+    public async Task DidChange_MultipleRequestsIncludingTextOnly(bool mutatingLspWorkspace)
+    {
+
+        var (testLspServer, locationTyped, _) = await GetTestLspServerAndLocationAsync("""
+            {|type:|}
+            """, mutatingLspWorkspace);
+
+        await using (testLspServer)
+        {
+            await DidOpen(testLspServer, locationTyped.DocumentUri, version: 0);
+
+            var changes = new (int? line, int? column, string text)[]
+            {
+                (0, 0, "// hi"),
+                (null, null, "/*  */"),
+                (0, 3, "hello"),
+                (null, null, "/*  */"),
+                (0, 3, "test"),
+            };
+
+            await DidChange(testLspServer, locationTyped.DocumentUri, version: 1, changes);
+
+            var document = testLspServer.GetTrackedTexts().FirstOrDefault();
+
+            Assert.NotNull(document);
+            Assert.Equal((string?)"""
+            /* test */
+            """, document.ToString());
+        }
+    }
+
     private async Task<(TestLspServer, LSP.Location, string)> GetTestLspServerAndLocationAsync(string source, bool mutatingLspWorkspace)
     {
         var testLspServer = await CreateTestLspServerAsync(source, mutatingLspWorkspace, CapabilitiesWithVSExtensions);
@@ -480,10 +512,10 @@ public sealed partial class DocumentChangesTests(ITestOutputHelper testOutputHel
 
     private static Task DidOpen(TestLspServer testLspServer, DocumentUri uri, int version = 0) => testLspServer.OpenDocumentAsync(uri, version: version);
 
-    private static async Task DidChange(TestLspServer testLspServer, DocumentUri uri, int version, params (int line, int column, string text)[] changes)
+    private static async Task DidChange(TestLspServer testLspServer, DocumentUri uri, int version, params (int? line, int? column, string text)[] changes)
         => await testLspServer.InsertTextAsync(uri, version, changes);
 
-    private static Task DidChange(TestLspServer testLspServer, DocumentUri uri, params (int line, int column, string text)[] changes)
+    private static Task DidChange(TestLspServer testLspServer, DocumentUri uri, params (int? line, int? column, string text)[] changes)
         => DidChange(testLspServer, uri, version: 0, changes);
 
     private static async Task DidClose(TestLspServer testLspServer, DocumentUri uri) => await testLspServer.CloseDocumentAsync(uri);


### PR DESCRIPTION
Bringing back the changes from #78165. Updated names to match 3.18 spec.


Resolved https://github.com/dotnet/roslyn/issues/84679
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84714)