### PR TITLE
Clone the IR tree so we don't have to re-lower from syntax.

### DIFF
--- a/src/Razor/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Intermediate/IntermediateNodeCloneTest.cs
+++ b/src/Razor/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Intermediate/IntermediateNodeCloneTest.cs
@@ -43,7 +43,10 @@ public class IntermediateNodeCloneTest
             }
             """;
 
-        AssertClone(source, RazorFileKind.Component);
+        // The tree contains at least one aliased child (a tag helper's unbound HTML attribute), so the
+        // clone's alias preservation is actually exercised rather than vacuously passing.
+        var aliasCount = AssertClone(source, RazorFileKind.Component);
+        Assert.True(aliasCount > 0);
     }
 
     [Fact]
@@ -62,10 +65,31 @@ public class IntermediateNodeCloneTest
             </html>
             """;
 
+        // The tree contains at least one aliased child (a tag helper's unbound HTML attribute), so the
+        // clone's alias preservation is actually exercised rather than vacuously passing.
+        var aliasCount = AssertClone(source, RazorFileKind.Legacy);
+        Assert.True(aliasCount > 0);
+    }
+
+    [Fact]
+    public void Clone_EdgeConstructs_ProducesFaithfulDeepCopy()
+    {
+        // Malformed directives and markup-element fallback containers are lowered node kinds that the other
+        // documents don't produce; a malformed @addTagHelper yields a MalformedDirectiveIntermediateNode and
+        // the mixed literal/expression attribute value yields a MarkupElementIntermediateNode fallback.
+        var source = """
+            @addTagHelper *
+            <MyTag data-a="x @DateTime.Now y" class="c">body</MyTag>
+            """;
+
+        var kinds = CollectKinds(Lower(source, RazorFileKind.Legacy));
+        Assert.Contains(nameof(MalformedDirectiveIntermediateNode), kinds);
+        Assert.Contains(nameof(MarkupElementIntermediateNode), kinds);
+
         AssertClone(source, RazorFileKind.Legacy);
     }
 
-    private void AssertClone(string content, RazorFileKind fileKind)
+    private int AssertClone(string content, RazorFileKind fileKind)
     {
         var documentNode = Lower(content, fileKind);
 
@@ -77,6 +101,113 @@ public class IntermediateNodeCloneTest
         Assert.Same(documentNode.DeclDocumentNode, clone.DeclDocumentNode);
         Assert.Same(documentNode.Options, clone.Options);
         Assert.Same(documentNode.Target, clone.Target);
+
+        return AssertAliasesPreserved(documentNode, clone);
+    }
+
+    // A node-typed property that holds one of the node's own Children is an alias (e.g.
+    // UnresolvedAttributeIntermediateNode.HtmlAttributeNode == Children[^1]). Cloning must preserve that
+    // aliasing: the cloned property has to point at the cloned child, not an independent copy. Otherwise the
+    // clone carries two divergent instances and a phase that mutates one while walking the other sees stale
+    // state. Walk the original and clone trees in lockstep and assert every alias is preserved by reference.
+    // Returns the number of aliases verified so a test can assert the tree actually exercised one.
+    private static int AssertAliasesPreserved(IntermediateNode original, IntermediateNode clone)
+    {
+        Assert.Equal(original.GetType(), clone.GetType());
+        Assert.Equal(original.Children.Count, clone.Children.Count);
+
+        var aliasCount = 0;
+
+        foreach (var (name, node) in NodeProperties(original))
+        {
+            var index = IndexOfReference(original.Children, node);
+            if (index < 0)
+            {
+                continue;
+            }
+
+            Assert.Same(clone.Children[index], GetPropertyValue(clone, name));
+            aliasCount++;
+        }
+
+        for (var i = 0; i < original.Children.Count; i++)
+        {
+            aliasCount += AssertAliasesPreserved(original.Children[i], clone.Children[i]);
+        }
+
+        return aliasCount;
+    }
+
+    // Enumerates the node-typed properties of a node, using the same reflection/exclusion rules as the dump.
+    private static IEnumerable<(string Name, IntermediateNode Node)> NodeProperties(IntermediateNode node)
+    {
+        foreach (var property in node.GetType()
+            .GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+            .Where(p => p.CanRead && p.GetIndexParameters().Length == 0)
+            .OrderBy(p => p.Name, StringComparer.Ordinal))
+        {
+            if (property.Name is "Children" or "Parent" or "DeclDocumentNode")
+            {
+                continue;
+            }
+
+            object? value;
+            try
+            {
+                value = property.GetValue(node);
+            }
+            catch
+            {
+                continue;
+            }
+
+            if (value is IntermediateNode childNode)
+            {
+                yield return (property.Name, childNode);
+            }
+        }
+    }
+
+    private static IntermediateNode GetPropertyValue(IntermediateNode node, string name)
+        => (IntermediateNode)node.GetType()
+            .GetProperty(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(node)!;
+
+    private static int IndexOfReference(IntermediateNodeCollection children, IntermediateNode node)
+    {
+        for (var i = 0; i < children.Count; i++)
+        {
+            if (ReferenceEquals(children[i], node))
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    // Collects the distinct node-kind names present in a tree, walking node-typed side references and
+    // Children, so a test can assert a document actually exercises a given kind.
+    private static HashSet<string> CollectKinds(IntermediateNode root)
+    {
+        var kinds = new HashSet<string>();
+        Collect(root);
+        return kinds;
+
+        void Collect(IntermediateNode node)
+        {
+            kinds.Add(node.GetType().Name);
+
+            foreach (var (_, child) in NodeProperties(node))
+            {
+                Collect(child);
+            }
+
+            foreach (var child in node.Children)
+            {
+                Collect(child);
+            }
+        }
     }
 
     // Runs the engine phases up to (but not including) tag-helper discovery, producing the lowered but

--- a/src/Razor/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Intermediate/IntermediateNodeCloneTest.cs
+++ b/src/Razor/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Intermediate/IntermediateNodeCloneTest.cs
@@ -136,7 +136,7 @@ public class IntermediateNodeCloneTest
                 continue;
             }
 
-            object value;
+            object? value;
             try
             {
                 value = property.GetValue(node);
@@ -172,7 +172,7 @@ public class IntermediateNodeCloneTest
         activePath.Remove(node);
     }
 
-    private static string Format(object value)
+    private static string Format(object? value)
     {
         switch (value)
         {
@@ -184,7 +184,7 @@ public class IntermediateNodeCloneTest
                 var items = enumerable.Cast<object>().Select(Format);
                 return "[" + string.Join(", ", items) + "]";
             default:
-                return value.ToString();
+                return value.ToString() ?? "null";
         }
     }
 }

--- a/src/Razor/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Intermediate/IntermediateNodeCloneTest.cs
+++ b/src/Razor/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Intermediate/IntermediateNodeCloneTest.cs
@@ -1,0 +1,190 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.Language.Intermediate;
+
+// Verifies that IntermediateNode.Clone() produces a faithful deep copy -- every field, child, and
+// deep-cloned side reference. The dump used for the comparison reflects over every property rather than
+// reusing FormatNode (which writes only the handful of properties chosen for display), so a dropped field
+// is caught.
+public class IntermediateNodeCloneTest
+{
+    private readonly RazorProjectEngine _projectEngine = RazorProjectEngine.Create(
+        RazorConfiguration.Default,
+        RazorProjectFileSystem.Create(AppContext.BaseDirectory));
+
+    [Fact]
+    public void Clone_Component_ProducesFaithfulDeepCopy()
+    {
+        var source = """
+            @page "/counter"
+            @using System.Text
+            @inject System.IServiceProvider Services
+            @typeparam TItem
+
+            <h1 class="title" data-x="@Value">Hello @Name</h1>
+            <section>
+                <p>Line1</p>
+                <MyChild Title="@Value" @onclick="OnClick">child body</MyChild>
+            </section>
+
+            @code {
+                [Parameter] public string Name { get; set; }
+                private int Value = 1;
+                private void OnClick() { Value++; }
+            }
+            """;
+
+        AssertClone(source, RazorFileKind.Component);
+    }
+
+    [Fact]
+    public void Clone_LegacyView_ProducesFaithfulDeepCopy()
+    {
+        var source = """
+            @using System.Text
+            <!DOCTYPE html>
+            <html>
+            <head><title>Test</title></head>
+            <body>
+                <div class="c">@DateTime.Now</div>
+                @{ var x = 1; }
+                <p>value is @x</p>
+            </body>
+            </html>
+            """;
+
+        AssertClone(source, RazorFileKind.Legacy);
+    }
+
+    private void AssertClone(string content, RazorFileKind fileKind)
+    {
+        var documentNode = Lower(content, fileKind);
+
+        var clone = (DocumentIntermediateNode)documentNode.Clone();
+
+        Assert.Equal(Dump(documentNode), Dump(clone));
+
+        // The declaration subtree, options, and code target are shared by reference on purpose.
+        Assert.Same(documentNode.DeclDocumentNode, clone.DeclDocumentNode);
+        Assert.Same(documentNode.Options, clone.Options);
+        Assert.Same(documentNode.Target, clone.Target);
+    }
+
+    // Runs the engine phases up to (but not including) tag-helper discovery, producing the lowered but
+    // still unresolved intermediate tree.
+    private DocumentIntermediateNode Lower(string content, RazorFileKind fileKind)
+    {
+        var source = RazorSourceDocument.Create(content, "test.razor");
+        var codeDocument = _projectEngine.CreateCodeDocument(source, fileKind);
+
+        foreach (var phase in _projectEngine.Engine.Phases)
+        {
+            if (phase is DefaultRazorTagHelperContextDiscoveryPhase)
+            {
+                break;
+            }
+
+            codeDocument = phase.Execute(codeDocument);
+        }
+
+        return codeDocument.GetRequiredDocumentNode();
+    }
+
+    // Serializes the full state of a node tree: every readable data property, then each deep-cloned side
+    // reference, then Children. DeclDocumentNode is shared by reference (asserted separately), so it is not
+    // recursed.
+    private static string Dump(IntermediateNode root)
+    {
+        var builder = new StringBuilder();
+        DumpNode(root, builder, depth: 0, activePath: new HashSet<IntermediateNode>());
+        return builder.ToString();
+    }
+
+    // `activePath` tracks the current recursion stack so a true cycle is broken, while a node reachable from
+    // two places (incidental sharing) is still dumped fully at each site. That keeps the dump symmetric
+    // between the original (which may share an instance) and its clone (which deep-copies each reference).
+    private static void DumpNode(IntermediateNode node, StringBuilder builder, int depth, HashSet<IntermediateNode> activePath)
+    {
+        if (!activePath.Add(node))
+        {
+            builder.Append(' ', depth * 2).AppendLine("<cycle>");
+            return;
+        }
+
+        builder.Append(' ', depth * 2).Append(node.GetType().Name);
+
+        var sideReferences = new List<(string Name, IntermediateNode Node)>();
+
+        foreach (var property in node.GetType()
+            .GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+            .Where(p => p.CanRead && p.GetIndexParameters().Length == 0)
+            .OrderBy(p => p.Name, StringComparer.Ordinal))
+        {
+            if (property.Name is "Children" or "Parent" or "DeclDocumentNode" or "IsLazy")
+            {
+                // IsLazy is a content-storage detail: cloning a token materializes its lazy content into an
+                // eager string, so IsLazy legitimately differs while Content is identical.
+                continue;
+            }
+
+            object value;
+            try
+            {
+                value = property.GetValue(node);
+            }
+            catch
+            {
+                continue;
+            }
+
+            if (value is IntermediateNode childNode)
+            {
+                sideReferences.Add((property.Name, childNode));
+            }
+            else
+            {
+                builder.Append(' ').Append(property.Name).Append('=').Append(Format(value));
+            }
+        }
+
+        builder.AppendLine();
+
+        foreach (var (name, child) in sideReferences)
+        {
+            builder.Append(' ', (depth + 1) * 2).Append('.').Append(name).Append(':').AppendLine();
+            DumpNode(child, builder, depth + 2, activePath);
+        }
+
+        foreach (var child in node.Children)
+        {
+            DumpNode(child, builder, depth + 1, activePath);
+        }
+
+        activePath.Remove(node);
+    }
+
+    private static string Format(object value)
+    {
+        switch (value)
+        {
+            case null:
+                return "null";
+            case string s:
+                return "\"" + s + "\"";
+            case IEnumerable enumerable:
+                var items = enumerable.Cast<object>().Select(Format);
+                return "[" + string.Join(", ", items) + "]";
+            default:
+                return value.ToString();
+        }
+    }
+}

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentInjectIntermediateNode.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentInjectIntermediateNode.cs
@@ -47,6 +47,16 @@ internal class ComponentInjectIntermediateNode : ExtensionIntermediateNode
         AcceptExtensionNode(this, visitor);
     }
 
+    protected override IntermediateNode CloneNode()
+    {
+        var clone = new ComponentInjectIntermediateNode(TypeName, MemberName, TypeSpan, MemberSpan)
+        {
+            IsSynthesizedHelper = IsSynthesizedHelper,
+        };
+
+        return clone;
+    }
+
     public override void WriteNode(CodeTarget target, CodeRenderingContext context)
     {
         if (target == null)

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/RouteAttributeExtensionNode.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/RouteAttributeExtensionNode.cs
@@ -14,6 +14,16 @@ internal sealed class RouteAttributeExtensionNode(string template) : ExtensionIn
 
     public override void Accept(IntermediateNodeVisitor visitor) => AcceptExtensionNode(this, visitor);
 
+    protected override IntermediateNode CloneNode()
+    {
+        var clone = new RouteAttributeExtensionNode(Template)
+        {
+            IsSynthesizedHelper = IsSynthesizedHelper,
+        };
+
+        return clone;
+    }
+
     public override void WriteNode(CodeTarget target, CodeRenderingContext context)
     {
         context.CodeWriter.Write("[global::");

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Extensions/RazorCompiledItemMetadataAttributeIntermediateNode.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Extensions/RazorCompiledItemMetadataAttributeIntermediateNode.cs
@@ -41,6 +41,19 @@ public class RazorCompiledItemMetadataAttributeIntermediateNode : ExtensionInter
         AcceptExtensionNode(this, visitor);
     }
 
+    protected override IntermediateNode CloneNode()
+    {
+        var clone = new RazorCompiledItemMetadataAttributeIntermediateNode
+        {
+            Key = Key,
+            Value = Value,
+            ValueStringSyntax = ValueStringSyntax,
+            IsSynthesizedHelper = IsSynthesizedHelper,
+        };
+
+        return clone;
+    }
+
     public override void WriteNode(CodeTarget target, CodeRenderingContext context)
     {
         if (target == null)

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Extensions/SectionIntermediateNode.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Extensions/SectionIntermediateNode.cs
@@ -25,6 +25,17 @@ public sealed class SectionIntermediateNode : ExtensionIntermediateNode
         AcceptExtensionNode<SectionIntermediateNode>(this, visitor);
     }
 
+    protected override IntermediateNode CloneNode()
+    {
+        var clone = new SectionIntermediateNode
+        {
+            SectionName = SectionName,
+            IsSynthesizedHelper = IsSynthesizedHelper,
+        };
+
+        return clone;
+    }
+
     public override void WriteNode(CodeTarget target, CodeRenderingContext context)
     {
         if (target == null)

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Extensions/TemplateIntermediateNode.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Extensions/TemplateIntermediateNode.cs
@@ -23,6 +23,16 @@ public sealed class TemplateIntermediateNode : ExtensionIntermediateNode
         AcceptExtensionNode<TemplateIntermediateNode>(this, visitor);
     }
 
+    protected override IntermediateNode CloneNode()
+    {
+        var clone = new TemplateIntermediateNode
+        {
+            IsSynthesizedHelper = IsSynthesizedHelper,
+        };
+
+        return clone;
+    }
+
     public override void WriteNode(CodeTarget target, CodeRenderingContext context)
     {
         if (target == null)

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/CSharpCodeAttributeValueIntermediateNode.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/CSharpCodeAttributeValueIntermediateNode.cs
@@ -23,6 +23,17 @@ public sealed class CSharpCodeAttributeValueIntermediateNode : IntermediateNode
         visitor.VisitCSharpCodeAttributeValue(this);
     }
 
+    protected override IntermediateNode CloneNode()
+    {
+        var clone = new CSharpCodeAttributeValueIntermediateNode
+        {
+            Prefix = Prefix,
+            IsSynthesizedHelper = IsSynthesizedHelper,
+        };
+
+        return clone;
+    }
+
     public override void FormatNode(IntermediateNodeFormatter formatter)
     {
         formatter.WriteChildren(Children);

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/CSharpCodeIntermediateNode.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/CSharpCodeIntermediateNode.cs
@@ -21,6 +21,16 @@ public sealed class CSharpCodeIntermediateNode : IntermediateNode
         visitor.VisitCSharpCode(this);
     }
 
+    protected override IntermediateNode CloneNode()
+    {
+        var clone = new CSharpCodeIntermediateNode
+        {
+            IsSynthesizedHelper = IsSynthesizedHelper,
+        };
+
+        return clone;
+    }
+
     public override void FormatNode(IntermediateNodeFormatter formatter)
     {
         formatter.WriteChildren(Children);

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/CSharpExpressionAttributeValueIntermediateNode.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/CSharpExpressionAttributeValueIntermediateNode.cs
@@ -23,6 +23,17 @@ public sealed class CSharpExpressionAttributeValueIntermediateNode : Intermediat
         visitor.VisitCSharpExpressionAttributeValue(this);
     }
 
+    protected override IntermediateNode CloneNode()
+    {
+        var clone = new CSharpExpressionAttributeValueIntermediateNode
+        {
+            Prefix = Prefix,
+            IsSynthesizedHelper = IsSynthesizedHelper,
+        };
+
+        return clone;
+    }
+
     public override void FormatNode(IntermediateNodeFormatter formatter)
     {
         formatter.WriteChildren(Children);

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/CSharpExpressionIntermediateNode.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/CSharpExpressionIntermediateNode.cs
@@ -21,6 +21,16 @@ public sealed class CSharpExpressionIntermediateNode : IntermediateNode
         visitor.VisitCSharpExpression(this);
     }
 
+    protected override IntermediateNode CloneNode()
+    {
+        var clone = new CSharpExpressionIntermediateNode
+        {
+            IsSynthesizedHelper = IsSynthesizedHelper,
+        };
+
+        return clone;
+    }
+
     public override void FormatNode(IntermediateNodeFormatter formatter)
     {
         formatter.WriteChildren(Children);

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/CSharpIntermediateToken.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/CSharpIntermediateToken.cs
@@ -14,4 +14,10 @@ public sealed class CSharpIntermediateToken : IntermediateToken
         : base(content, source)
     {
     }
+
+    protected override IntermediateNode CloneNode()
+        => new CSharpIntermediateToken(Content, Source)
+        {
+            IsSynthesizedHelper = IsSynthesizedHelper,
+        };
 }

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/ClassDeclarationIntermediateNode.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/ClassDeclarationIntermediateNode.cs
@@ -24,6 +24,23 @@ public sealed class ClassDeclarationIntermediateNode : MemberDeclarationIntermed
     public override void Accept(IntermediateNodeVisitor visitor)
         => visitor.VisitClassDeclaration(this);
 
+    protected override IntermediateNode CloneNode()
+    {
+        var clone = new ClassDeclarationIntermediateNode
+        {
+            Name = Name,
+            BaseType = BaseType,
+            Modifiers = Modifiers,
+            Interfaces = Interfaces,
+            TypeParameters = TypeParameters,
+            IsPrimaryClass = IsPrimaryClass,
+            NullableContext = NullableContext,
+            IsSynthesizedHelper = IsSynthesizedHelper,
+        };
+
+        return clone;
+    }
+
     public override void FormatNode(IntermediateNodeFormatter formatter)
     {
         formatter.WriteContent(Name);

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/DirectiveIntermediateNode.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/DirectiveIntermediateNode.cs
@@ -23,6 +23,18 @@ public sealed class DirectiveIntermediateNode : IntermediateNode
         visitor.VisitDirective(this);
     }
 
+    protected override IntermediateNode CloneNode()
+    {
+        var clone = new DirectiveIntermediateNode
+        {
+            DirectiveName = DirectiveName,
+            Directive = Directive,
+            IsSynthesizedHelper = IsSynthesizedHelper,
+        };
+
+        return clone;
+    }
+
     public override void FormatNode(IntermediateNodeFormatter formatter)
     {
         formatter.WriteContent(DirectiveName);

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/DirectiveTokenIntermediateNode.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/DirectiveTokenIntermediateNode.cs
@@ -20,6 +20,14 @@ public sealed class DirectiveTokenIntermediateNode : IntermediateNode
         visitor.VisitDirectiveToken(this);
     }
 
+    protected override IntermediateNode CloneNode()
+        => new DirectiveTokenIntermediateNode
+        {
+            Content = Content,
+            DirectiveToken = DirectiveToken,
+            IsSynthesizedHelper = IsSynthesizedHelper,
+        };
+
     public override void FormatNode(IntermediateNodeFormatter formatter)
     {
         formatter.WriteContent(Content);

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/DocumentIntermediateNode.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/DocumentIntermediateNode.cs
@@ -57,4 +57,19 @@ public sealed class DocumentIntermediateNode : IntermediateNode
 
         formatter.WriteProperty(nameof(DocumentKind), DocumentKind);
     }
+
+    protected override IntermediateNode CloneNode()
+    {
+        // The declaration subtree is already lowered and inert during replay, so it is shared by reference.
+        var clone = new DocumentIntermediateNode
+        {
+            DocumentKind = DocumentKind,
+            DeclDocumentNode = DeclDocumentNode,
+            FallbackComponentTypeName = FallbackComponentTypeName,
+            Options = Options,
+            Target = Target,
+        };
+
+        return clone;
+    }
 }

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/FieldDeclarationIntermediateNode.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/FieldDeclarationIntermediateNode.cs
@@ -20,6 +20,21 @@ public sealed class FieldDeclarationIntermediateNode : MemberDeclarationIntermed
     public override void Accept(IntermediateNodeVisitor visitor)
         => visitor.VisitFieldDeclaration(this);
 
+    protected override IntermediateNode CloneNode()
+    {
+        var clone = new FieldDeclarationIntermediateNode
+        {
+            Name = Name,
+            Type = Type,
+            Modifiers = Modifiers,
+            SuppressWarnings = SuppressWarnings,
+            IsTagHelperField = IsTagHelperField,
+            IsSynthesizedHelper = IsSynthesizedHelper,
+        };
+
+        return clone;
+    }
+
     public override void FormatNode(IntermediateNodeFormatter formatter)
     {
         formatter.WriteContent(Name);

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/HtmlAttributeIntermediateNode.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/HtmlAttributeIntermediateNode.cs
@@ -34,6 +34,22 @@ public sealed class HtmlAttributeIntermediateNode : IntermediateNode
         visitor.VisitHtmlAttribute(this);
     }
 
+    protected override IntermediateNode CloneNode()
+    {
+        var clone = new HtmlAttributeIntermediateNode
+        {
+            AttributeName = AttributeName,
+            AttributeNameExpression = (CSharpExpressionIntermediateNode)AttributeNameExpression?.Clone(),
+            Prefix = Prefix,
+            Suffix = Suffix,
+            EventUpdatesAttributeName = EventUpdatesAttributeName,
+            OriginalAttributeName = OriginalAttributeName,
+            IsSynthesizedHelper = IsSynthesizedHelper,
+        };
+
+        return clone;
+    }
+
     public override void FormatNode(IntermediateNodeFormatter formatter)
     {
         formatter.WriteContent(AttributeName);

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/HtmlAttributeValueIntermediateNode.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/HtmlAttributeValueIntermediateNode.cs
@@ -23,6 +23,17 @@ public sealed class HtmlAttributeValueIntermediateNode : IntermediateNode
         visitor.VisitHtmlAttributeValue(this);
     }
 
+    protected override IntermediateNode CloneNode()
+    {
+        var clone = new HtmlAttributeValueIntermediateNode
+        {
+            Prefix = Prefix,
+            IsSynthesizedHelper = IsSynthesizedHelper,
+        };
+
+        return clone;
+    }
+
     public override void FormatNode(IntermediateNodeFormatter formatter)
     {
         formatter.WriteChildren(Children);

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/HtmlContentIntermediateNode.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/HtmlContentIntermediateNode.cs
@@ -23,6 +23,17 @@ public sealed class HtmlContentIntermediateNode : IntermediateNode
         visitor.VisitHtml(this);
     }
 
+    protected override IntermediateNode CloneNode()
+    {
+        var clone = new HtmlContentIntermediateNode
+        {
+            HasEncodedContent = HasEncodedContent,
+            IsSynthesizedHelper = IsSynthesizedHelper,
+        };
+
+        return clone;
+    }
+
     public override void FormatNode(IntermediateNodeFormatter formatter)
     {
         formatter.WriteChildren(Children);

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/HtmlIntermediateToken.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/HtmlIntermediateToken.cs
@@ -14,4 +14,10 @@ public sealed class HtmlIntermediateToken : IntermediateToken
         : base(content, source)
     {
     }
+
+    protected override IntermediateNode CloneNode()
+        => new HtmlIntermediateToken(Content, Source)
+        {
+            IsSynthesizedHelper = IsSynthesizedHelper,
+        };
 }

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/IntermediateNode.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/IntermediateNode.cs
@@ -85,9 +85,10 @@ public abstract class IntermediateNode
     /// <summary>
     ///  Returns a deep copy of this node and its descendants. The node-specific state is produced by
     ///  <see cref="CloneNode"/>; this method copies the common state (source span, imported flag,
-    ///  diagnostics) and deep-clones the children onto it.
+    ///  diagnostics) and deep-clones the children onto it. A node with a property that aliases one of
+    ///  its <see cref="Children"/> overrides this to re-point that property at the cloned child.
     /// </summary>
-    internal IntermediateNode Clone()
+    internal virtual IntermediateNode Clone()
     {
         var clone = CloneNode();
 

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/IntermediateNode.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/IntermediateNode.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -80,4 +81,35 @@ public abstract class IntermediateNode
     public virtual void FormatNode(IntermediateNodeFormatter formatter)
     {
     }
+
+    /// <summary>
+    ///  Returns a deep copy of this node and its descendants. The node-specific state is produced by
+    ///  <see cref="CloneNode"/>; this method copies the common state (source span, imported flag,
+    ///  diagnostics) and deep-clones the children onto it.
+    /// </summary>
+    internal IntermediateNode Clone()
+    {
+        var clone = CloneNode();
+
+        clone.Source = Source;
+        clone.IsImported = IsImported;
+        clone.AddDiagnosticsFromNode(this);
+
+        foreach (var child in Children)
+        {
+            clone.Children.Add(child.Clone());
+        }
+
+        return clone;
+    }
+
+    /// <summary>
+    ///  Creates a copy of this node carrying only its own state -- the node-specific fields (including the
+    ///  init-only <see cref="IsSynthesizedHelper"/>) and any child nodes held outside <see cref="Children"/>
+    ///  (deep-cloned). The common state and the <see cref="Children"/> are copied by <see cref="Clone"/>.
+    ///  Overridden by every node kind that can appear in an unresolved tree; the base throws so an
+    ///  unexpected kind fails loudly rather than silently producing an incomplete copy.
+    /// </summary>
+    protected virtual IntermediateNode CloneNode()
+        => throw new NotSupportedException($"{GetType().Name} does not support cloning.");
 }

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/MalformedDirectiveIntermediateNode.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/MalformedDirectiveIntermediateNode.cs
@@ -23,6 +23,18 @@ public sealed class MalformedDirectiveIntermediateNode : IntermediateNode
         visitor.VisitMalformedDirective(this);
     }
 
+    protected override IntermediateNode CloneNode()
+    {
+        var clone = new MalformedDirectiveIntermediateNode
+        {
+            DirectiveName = DirectiveName,
+            Directive = Directive,
+            IsSynthesizedHelper = IsSynthesizedHelper,
+        };
+
+        return clone;
+    }
+
     public override void FormatNode(IntermediateNodeFormatter formatter)
     {
         formatter.WriteContent(DirectiveName);

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/MarkupElementIntermediateNode.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/MarkupElementIntermediateNode.cs
@@ -42,6 +42,17 @@ public sealed class MarkupElementIntermediateNode : IntermediateNode
         visitor.VisitMarkupElement(this);
     }
 
+    protected override IntermediateNode CloneNode()
+    {
+        var clone = new MarkupElementIntermediateNode
+        {
+            TagName = TagName,
+            IsSynthesizedHelper = IsSynthesizedHelper,
+        };
+
+        return clone;
+    }
+
     public override void FormatNode(IntermediateNodeFormatter formatter)
     {
         if (formatter == null)

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/MethodDeclarationIntermediateNode.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/MethodDeclarationIntermediateNode.cs
@@ -23,6 +23,21 @@ public sealed class MethodDeclarationIntermediateNode : MemberDeclarationInterme
     public override void Accept(IntermediateNodeVisitor visitor)
         => visitor.VisitMethodDeclaration(this);
 
+    protected override IntermediateNode CloneNode()
+    {
+        var clone = new MethodDeclarationIntermediateNode
+        {
+            Name = Name,
+            ReturnType = ReturnType,
+            Modifiers = Modifiers,
+            Parameters = Parameters,
+            IsPrimaryMethod = IsPrimaryMethod,
+            IsSynthesizedHelper = IsSynthesizedHelper,
+        };
+
+        return clone;
+    }
+
     public override void FormatNode(IntermediateNodeFormatter formatter)
     {
         formatter.WriteContent(Name);

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/NamespaceDeclarationIntermediateNode.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/NamespaceDeclarationIntermediateNode.cs
@@ -20,4 +20,17 @@ public sealed class NamespaceDeclarationIntermediateNode : IntermediateNode
         formatter.WriteContent(Name);
         formatter.WriteProperty(nameof(Name), Name);
     }
+
+    protected override IntermediateNode CloneNode()
+    {
+        var clone = new NamespaceDeclarationIntermediateNode
+        {
+            Name = Name,
+            IsPrimaryNamespace = IsPrimaryNamespace,
+            IsGenericTyped = IsGenericTyped,
+            IsSynthesizedHelper = IsSynthesizedHelper,
+        };
+
+        return clone;
+    }
 }

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/PropertyDeclarationIntermediateNode.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/PropertyDeclarationIntermediateNode.cs
@@ -17,4 +17,18 @@ public sealed class PropertyDeclarationIntermediateNode : MemberDeclarationInter
 
     public override void Accept(IntermediateNodeVisitor visitor)
         => visitor.VisitPropertyDeclaration(this);
+
+    protected override IntermediateNode CloneNode()
+    {
+        var clone = new PropertyDeclarationIntermediateNode
+        {
+            Name = Name,
+            Type = (IntermediateToken)Type.Clone(),
+            ExpressionBody = ExpressionBody,
+            Modifiers = Modifiers,
+            IsSynthesizedHelper = IsSynthesizedHelper,
+        };
+
+        return clone;
+    }
 }

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/UnresolvedAttributeIntermediateNode.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/UnresolvedAttributeIntermediateNode.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
+
 namespace Microsoft.AspNetCore.Razor.Language.Intermediate;
 
 /// <summary>
@@ -83,9 +85,26 @@ internal sealed class UnresolvedAttributeIntermediateNode : IntermediateNode
             AttributeNameSpan = AttributeNameSpan,
             AsTagHelperAttribute = AsTagHelperAttribute?.Clone(),
             AsMarkupAttribute = AsMarkupAttribute?.Clone(),
-            HtmlAttributeNode = (HtmlAttributeIntermediateNode?)HtmlAttributeNode?.Clone(),
             IsSynthesizedHelper = IsSynthesizedHelper,
         };
+
+        return clone;
+    }
+
+    internal override IntermediateNode Clone()
+    {
+        var clone = (UnresolvedAttributeIntermediateNode)base.Clone();
+
+        // HtmlAttributeNode aliases one of Children, so point the clone at its cloned child rather than
+        // an independent copy. Cloning it separately would leave the clone's HtmlAttributeNode and its
+        // Children entry as two divergent instances, so a phase that mutates one and walks the other
+        // would see stale state.
+        if (HtmlAttributeNode is { } htmlAttributeNode)
+        {
+            var index = Children.IndexOf(htmlAttributeNode);
+            Debug.Assert(index >= 0, "HtmlAttributeNode is expected to be one of Children.");
+            clone.HtmlAttributeNode = (HtmlAttributeIntermediateNode)clone.Children[index];
+        }
 
         return clone;
     }

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/UnresolvedAttributeIntermediateNode.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/UnresolvedAttributeIntermediateNode.cs
@@ -71,6 +71,25 @@ internal sealed class UnresolvedAttributeIntermediateNode : IntermediateNode
         visitor.VisitDefault(this);
     }
 
+    protected override IntermediateNode CloneNode()
+    {
+        var clone = new UnresolvedAttributeIntermediateNode
+        {
+            AttributeName = AttributeName,
+            IsMinimized = IsMinimized,
+            ValueContent = ValueContent,
+            ValueSourceSpan = ValueSourceSpan,
+            AttributeStructure = AttributeStructure,
+            AttributeNameSpan = AttributeNameSpan,
+            AsTagHelperAttribute = AsTagHelperAttribute?.Clone(),
+            AsMarkupAttribute = AsMarkupAttribute?.Clone(),
+            HtmlAttributeNode = (HtmlAttributeIntermediateNode?)HtmlAttributeNode?.Clone(),
+            IsSynthesizedHelper = IsSynthesizedHelper,
+        };
+
+        return clone;
+    }
+
     public override void FormatNode(IntermediateNodeFormatter formatter)
     {
         formatter.WriteContent(AttributeName);

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/UnresolvedAttributeValueIntermediateNode.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/UnresolvedAttributeValueIntermediateNode.cs
@@ -28,6 +28,17 @@ internal sealed class UnresolvedAttributeValueIntermediateNode : IntermediateNod
         visitor.VisitDefault(this);
     }
 
+    protected override IntermediateNode CloneNode()
+    {
+        var clone = new UnresolvedAttributeValueIntermediateNode
+        {
+            Prefix = Prefix,
+            IsSynthesizedHelper = IsSynthesizedHelper,
+        };
+
+        return clone;
+    }
+
     public override void FormatNode(IntermediateNodeFormatter formatter)
     {
         formatter.WriteChildren(Children);

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/UnresolvedElementIntermediateNode.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/UnresolvedElementIntermediateNode.cs
@@ -73,6 +73,32 @@ internal sealed class UnresolvedElementIntermediateNode : IntermediateNode
         visitor.VisitDefault(this);
     }
 
+    protected override IntermediateNode CloneNode()
+    {
+        var clone = new UnresolvedElementIntermediateNode
+        {
+            TagName = TagName,
+            IsComponent = IsComponent,
+            IsEscaped = IsEscaped,
+            IsSelfClosing = IsSelfClosing,
+            HasEndTag = HasEndTag,
+            EndTagName = EndTagName,
+            EndTagSpan = EndTagSpan,
+            IsVoidElement = IsVoidElement,
+            StartTagNameSpan = StartTagNameSpan,
+            StartTagSpan = StartTagSpan,
+            AttributeData = AttributeData,
+            HasMissingCloseAngle = HasMissingCloseAngle,
+            HasDynamicExpressionChild = HasDynamicExpressionChild,
+            HasMissingEndCloseAngle = HasMissingEndCloseAngle,
+            StartTagEndIndex = StartTagEndIndex,
+            BodyEndIndex = BodyEndIndex,
+            IsSynthesizedHelper = IsSynthesizedHelper,
+        };
+
+        return clone;
+    }
+
     public override void FormatNode(IntermediateNodeFormatter formatter)
     {
         formatter.WriteContent(TagName);

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/UnresolvedExpressionAttributeValueIntermediateNode.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/UnresolvedExpressionAttributeValueIntermediateNode.cs
@@ -35,6 +35,18 @@ internal sealed class UnresolvedExpressionAttributeValueIntermediateNode : Inter
         visitor.VisitDefault(this);
     }
 
+    protected override IntermediateNode CloneNode()
+    {
+        var clone = new UnresolvedExpressionAttributeValueIntermediateNode
+        {
+            Prefix = Prefix,
+            ContainsExpression = ContainsExpression,
+            IsSynthesizedHelper = IsSynthesizedHelper,
+        };
+
+        return clone;
+    }
+
     public override void FormatNode(IntermediateNodeFormatter formatter)
     {
         formatter.WriteChildren(Children);

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/UsingDirectiveIntermediateNode.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/UsingDirectiveIntermediateNode.cs
@@ -27,6 +27,19 @@ public sealed class UsingDirectiveIntermediateNode : IntermediateNode
         visitor.VisitUsingDirective(this);
     }
 
+    protected override IntermediateNode CloneNode()
+    {
+        var clone = new UsingDirectiveIntermediateNode
+        {
+            AppendLineDefaultAndHidden = AppendLineDefaultAndHidden,
+            Content = Content,
+            HasExplicitSemicolon = HasExplicitSemicolon,
+            IsSynthesizedHelper = IsSynthesizedHelper,
+        };
+
+        return clone;
+    }
+
     public override void FormatNode(IntermediateNodeFormatter formatter)
     {
         formatter.WriteContent(Content);

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorCodeDocument.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorCodeDocument.cs
@@ -36,6 +36,7 @@ public sealed partial class RazorCodeDocument
     private readonly DocumentIntermediateNode? _documentNode;
     private readonly RazorCSharpDocument? _csharpDocument;
     private readonly RazorCSharpDocument? _declCSharpDocument;
+    private readonly DocumentIntermediateNode? _unresolvedDocumentNode;
     private readonly ImmutableArray<DirectiveTagHelperContribution> _directiveTagHelperContributions;
 
     private RazorCodeDocument(
@@ -52,7 +53,8 @@ public sealed partial class RazorCodeDocument
         DocumentIntermediateNode? documentNode,
         RazorCSharpDocument? csharpDocument,
         RazorCSharpDocument? declCSharpDocument,
-        ImmutableArray<DirectiveTagHelperContribution> directiveTagHelperContributions)
+        ImmutableArray<DirectiveTagHelperContribution> directiveTagHelperContributions,
+        DocumentIntermediateNode? unresolvedDocumentNode)
     {
         Source = source;
         Imports = imports.NullToEmpty();
@@ -70,6 +72,7 @@ public sealed partial class RazorCodeDocument
         _csharpDocument = csharpDocument;
         _declCSharpDocument = declCSharpDocument;
         _directiveTagHelperContributions = directiveTagHelperContributions.NullToEmpty();
+        _unresolvedDocumentNode = unresolvedDocumentNode;
     }
 
     public static RazorCodeDocument Create(
@@ -100,7 +103,8 @@ public sealed partial class RazorCodeDocument
             documentNode: null,
             csharpDocument: null,
             declCSharpDocument: null,
-            directiveTagHelperContributions: default);
+            directiveTagHelperContributions: default,
+            unresolvedDocumentNode: null);
     }
 
     internal bool TryGetTagHelpers([NotNullWhen(true)] out TagHelperCollection? result)
@@ -121,7 +125,7 @@ public sealed partial class RazorCodeDocument
         {
             return this;
         }
-        return new RazorCodeDocument(Source, Imports, ParserOptions, CodeGenerationOptions, value, _referencedTagHelpers, _syntaxTree, _tagHelperRewrittenSyntaxTree, _importSyntaxTrees, _tagHelperContext, _documentNode, _csharpDocument, _declCSharpDocument, _directiveTagHelperContributions);
+        return new RazorCodeDocument(Source, Imports, ParserOptions, CodeGenerationOptions, value, _referencedTagHelpers, _syntaxTree, _tagHelperRewrittenSyntaxTree, _importSyntaxTrees, _tagHelperContext, _documentNode, _csharpDocument, _declCSharpDocument, _directiveTagHelperContributions, _unresolvedDocumentNode);
     }
 
     internal bool TryGetReferencedTagHelpers([NotNullWhen(true)] out TagHelperCollection? result)
@@ -142,7 +146,7 @@ public sealed partial class RazorCodeDocument
         {
             return this;
         }
-        return new RazorCodeDocument(Source, Imports, ParserOptions, CodeGenerationOptions, _tagHelpers, value, _syntaxTree, _tagHelperRewrittenSyntaxTree, _importSyntaxTrees, _tagHelperContext, _documentNode, _csharpDocument, _declCSharpDocument, _directiveTagHelperContributions);
+        return new RazorCodeDocument(Source, Imports, ParserOptions, CodeGenerationOptions, _tagHelpers, value, _syntaxTree, _tagHelperRewrittenSyntaxTree, _importSyntaxTrees, _tagHelperContext, _documentNode, _csharpDocument, _declCSharpDocument, _directiveTagHelperContributions, _unresolvedDocumentNode);
     }
 
     internal bool TryGetSyntaxTree([NotNullWhen(true)] out RazorSyntaxTree? result)
@@ -164,7 +168,7 @@ public sealed partial class RazorCodeDocument
         {
             return this;
         }
-        return new RazorCodeDocument(Source, Imports, ParserOptions, CodeGenerationOptions, _tagHelpers, _referencedTagHelpers, value, _tagHelperRewrittenSyntaxTree, _importSyntaxTrees, _tagHelperContext, _documentNode, _csharpDocument, _declCSharpDocument, _directiveTagHelperContributions);
+        return new RazorCodeDocument(Source, Imports, ParserOptions, CodeGenerationOptions, _tagHelpers, _referencedTagHelpers, value, _tagHelperRewrittenSyntaxTree, _importSyntaxTrees, _tagHelperContext, _documentNode, _csharpDocument, _declCSharpDocument, _directiveTagHelperContributions, _unresolvedDocumentNode);
     }
 
     internal bool TryGetTagHelperRewrittenSyntaxTree([NotNullWhen(true)] out RazorSyntaxTree? result)
@@ -186,7 +190,7 @@ public sealed partial class RazorCodeDocument
         {
             return this;
         }
-        return new RazorCodeDocument(Source, Imports, ParserOptions, CodeGenerationOptions, _tagHelpers, _referencedTagHelpers, _syntaxTree, value, _importSyntaxTrees, _tagHelperContext, _documentNode, _csharpDocument, _declCSharpDocument, _directiveTagHelperContributions);
+        return new RazorCodeDocument(Source, Imports, ParserOptions, CodeGenerationOptions, _tagHelpers, _referencedTagHelpers, _syntaxTree, value, _importSyntaxTrees, _tagHelperContext, _documentNode, _csharpDocument, _declCSharpDocument, _directiveTagHelperContributions, _unresolvedDocumentNode);
     }
 
     internal bool TryGetImportSyntaxTrees(out ImmutableArray<RazorSyntaxTree> result)
@@ -213,7 +217,7 @@ public sealed partial class RazorCodeDocument
         {
             return this;
         }
-        return new RazorCodeDocument(Source, Imports, ParserOptions, CodeGenerationOptions, _tagHelpers, _referencedTagHelpers, _syntaxTree, _tagHelperRewrittenSyntaxTree, value, _tagHelperContext, _documentNode, _csharpDocument, _declCSharpDocument, _directiveTagHelperContributions);
+        return new RazorCodeDocument(Source, Imports, ParserOptions, CodeGenerationOptions, _tagHelpers, _referencedTagHelpers, _syntaxTree, _tagHelperRewrittenSyntaxTree, value, _tagHelperContext, _documentNode, _csharpDocument, _declCSharpDocument, _directiveTagHelperContributions, _unresolvedDocumentNode);
     }
 
     internal bool TryGetTagHelperContext([NotNullWhen(true)] out TagHelperDocumentContext? result)
@@ -236,7 +240,7 @@ public sealed partial class RazorCodeDocument
         {
             return this;
         }
-        return new RazorCodeDocument(Source, Imports, ParserOptions, CodeGenerationOptions, _tagHelpers, _referencedTagHelpers, _syntaxTree, _tagHelperRewrittenSyntaxTree, _importSyntaxTrees, value, _documentNode, _csharpDocument, _declCSharpDocument, _directiveTagHelperContributions);
+        return new RazorCodeDocument(Source, Imports, ParserOptions, CodeGenerationOptions, _tagHelpers, _referencedTagHelpers, _syntaxTree, _tagHelperRewrittenSyntaxTree, _importSyntaxTrees, value, _documentNode, _csharpDocument, _declCSharpDocument, _directiveTagHelperContributions, _unresolvedDocumentNode);
     }
 
     internal bool TryGetDocumentNode([NotNullWhen(true)] out DocumentIntermediateNode? result)
@@ -258,7 +262,20 @@ public sealed partial class RazorCodeDocument
         {
             return this;
         }
-        return new RazorCodeDocument(Source, Imports, ParserOptions, CodeGenerationOptions, _tagHelpers, _referencedTagHelpers, _syntaxTree, _tagHelperRewrittenSyntaxTree, _importSyntaxTrees, _tagHelperContext, value, _csharpDocument, _declCSharpDocument, _directiveTagHelperContributions);
+        return new RazorCodeDocument(Source, Imports, ParserOptions, CodeGenerationOptions, _tagHelpers, _referencedTagHelpers, _syntaxTree, _tagHelperRewrittenSyntaxTree, _importSyntaxTrees, _tagHelperContext, value, _csharpDocument, _declCSharpDocument, _directiveTagHelperContributions, _unresolvedDocumentNode);
+    }
+
+    internal DocumentIntermediateNode? GetUnresolvedDocumentNode()
+        => _unresolvedDocumentNode;
+
+    internal RazorCodeDocument WithUnresolvedDocumentNode(DocumentIntermediateNode value)
+    {
+        Debug.Assert(value is not null);
+        if (ReferenceEquals(value, _unresolvedDocumentNode))
+        {
+            return this;
+        }
+        return new RazorCodeDocument(Source, Imports, ParserOptions, CodeGenerationOptions, _tagHelpers, _referencedTagHelpers, _syntaxTree, _tagHelperRewrittenSyntaxTree, _importSyntaxTrees, _tagHelperContext, _documentNode, _csharpDocument, _declCSharpDocument, _directiveTagHelperContributions, value);
     }
 
     internal RazorCSharpDocument? GetCSharpDocument(bool declarationDocument)
@@ -295,7 +312,7 @@ public sealed partial class RazorCodeDocument
         {
             return this;
         }
-        return new RazorCodeDocument(Source, Imports, ParserOptions, CodeGenerationOptions, _tagHelpers, _referencedTagHelpers, _syntaxTree, _tagHelperRewrittenSyntaxTree, _importSyntaxTrees, _tagHelperContext, _documentNode, value, _declCSharpDocument, _directiveTagHelperContributions);
+        return new RazorCodeDocument(Source, Imports, ParserOptions, CodeGenerationOptions, _tagHelpers, _referencedTagHelpers, _syntaxTree, _tagHelperRewrittenSyntaxTree, _importSyntaxTrees, _tagHelperContext, _documentNode, value, _declCSharpDocument, _directiveTagHelperContributions, _unresolvedDocumentNode);
     }
 
 #if SONICDEV
@@ -311,7 +328,7 @@ public sealed partial class RazorCodeDocument
         {
             return this;
         }
-        return new RazorCodeDocument(Source, Imports, ParserOptions, CodeGenerationOptions, _tagHelpers, _referencedTagHelpers, _syntaxTree, _tagHelperRewrittenSyntaxTree, _importSyntaxTrees, _tagHelperContext, _documentNode, _csharpDocument, value, _directiveTagHelperContributions);
+        return new RazorCodeDocument(Source, Imports, ParserOptions, CodeGenerationOptions, _tagHelpers, _referencedTagHelpers, _syntaxTree, _tagHelperRewrittenSyntaxTree, _importSyntaxTrees, _tagHelperContext, _documentNode, _csharpDocument, value, _directiveTagHelperContributions, _unresolvedDocumentNode);
     }
 
     internal ImmutableArray<DirectiveTagHelperContribution> GetDirectiveTagHelperContributions()
@@ -324,7 +341,7 @@ public sealed partial class RazorCodeDocument
             return this;
         }
 
-        return new RazorCodeDocument(Source, Imports, ParserOptions, CodeGenerationOptions, _tagHelpers, _referencedTagHelpers, _syntaxTree, _tagHelperRewrittenSyntaxTree, _importSyntaxTrees, _tagHelperContext, _documentNode, _csharpDocument, _declCSharpDocument, value);
+        return new RazorCodeDocument(Source, Imports, ParserOptions, CodeGenerationOptions, _tagHelpers, _referencedTagHelpers, _syntaxTree, _tagHelperRewrittenSyntaxTree, _importSyntaxTrees, _tagHelperContext, _documentNode, _csharpDocument, _declCSharpDocument, value, _unresolvedDocumentNode);
     }
 
     // In general documents will have a relative path (relative to the project root).

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Mvc/InjectIntermediateNode.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Mvc/InjectIntermediateNode.cs
@@ -34,6 +34,21 @@ public class InjectIntermediateNode : ExtensionIntermediateNode
         AcceptExtensionNode<InjectIntermediateNode>(this, visitor);
     }
 
+    protected override IntermediateNode CloneNode()
+    {
+        var clone = new InjectIntermediateNode
+        {
+            TypeName = TypeName,
+            TypeSource = TypeSource,
+            MemberName = MemberName,
+            MemberSource = MemberSource,
+            IsMalformed = IsMalformed,
+            IsSynthesizedHelper = IsSynthesizedHelper,
+        };
+
+        return clone;
+    }
+
     public override void WriteNode(CodeTarget target, CodeRenderingContext context)
     {
         if (target == null)

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/SourceGeneratorProjectEngine.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/SourceGeneratorProjectEngine.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Intermediate;
 using Microsoft.CodeAnalysis.Razor.Compiler.CSharp;
 using System;
 using System.Diagnostics;
@@ -14,8 +15,6 @@ internal sealed class SourceGeneratorProjectEngine
     private readonly RazorProjectEngine _projectEngine;
 
     private readonly IRazorEnginePhase _discoveryPhase;
-    private readonly int _loweringPhaseIndex = -1;
-    private readonly int _declLoweringPhaseIndex = -1;
     private readonly int _discoveryPhaseIndex = -1;
     private readonly int _rewritePhaseIndex = -1;
 
@@ -29,21 +28,13 @@ internal sealed class SourceGeneratorProjectEngine
 
         foreach (var phase in Phases)
         {
-            if (_loweringPhaseIndex >= 0 && _declLoweringPhaseIndex >= 0 && _discoveryPhaseIndex >= 0 && _rewritePhaseIndex >= 0)
+            if (_discoveryPhaseIndex >= 0 && _rewritePhaseIndex >= 0)
             {
                 break;
             }
 
             switch (phase)
             {
-                case DefaultRazorIntermediateNodeLoweringPhase:
-                    _loweringPhaseIndex = index;
-                    break;
-
-                case DefaultRazorDeclCSharpLoweringPhase:
-                    _declLoweringPhaseIndex = index;
-                    break;
-
                 case DefaultRazorTagHelperContextDiscoveryPhase:
                     _discoveryPhase = phase;
                     _discoveryPhaseIndex = index;
@@ -58,12 +49,8 @@ internal sealed class SourceGeneratorProjectEngine
         }
 
         Debug.Assert(_discoveryPhase is not null);
-        Debug.Assert(_loweringPhaseIndex >= 0);
-        Debug.Assert(_declLoweringPhaseIndex >= 0);
         Debug.Assert(_discoveryPhaseIndex >= 0);
         Debug.Assert(_rewritePhaseIndex >= 0);
-        Debug.Assert(_loweringPhaseIndex < _declLoweringPhaseIndex);
-        Debug.Assert(_declLoweringPhaseIndex < _discoveryPhaseIndex);
         Debug.Assert(_discoveryPhaseIndex < _rewritePhaseIndex);
     }
 
@@ -73,11 +60,18 @@ internal sealed class SourceGeneratorProjectEngine
 
         codeDocument = ExecutePhases(Phases[.._discoveryPhaseIndex], codeDocument, cancellationToken);
 
-        // By this point, DefaultRazorParsingPhase has set the canonical syntax tree (_syntaxTree)
-        // so that discovery and subsequent phases can read it via GetSyntaxTree().
         return new SourceGeneratorRazorCodeDocument(codeDocument);
     }
 
+    /// <summary>
+    ///  Runs tag-helper discovery, resolution and rewrite for a document. The generator calls this twice per
+    ///  document: first with <paramref name="checkForIdempotency"/> <see langword="false"/> to do the initial
+    ///  pass, then again with <see langword="true"/>. The second call is an incremental gate -- its inputs
+    ///  include the project-wide tag-helper set, so it re-runs whenever that set changes, but it returns the
+    ///  document unchanged unless the change actually affects this document (a used descriptor was added or
+    ///  removed). Only then does it replay resolution. The first call's inputs deliberately exclude the
+    ///  tag-helper set, so it re-runs only when the document itself changes.
+    /// </summary>
     public SourceGeneratorRazorCodeDocument ProcessTagHelpers(
         SourceGeneratorRazorCodeDocument sgDocument, 
         TagHelperCollection tagHelpers, 
@@ -114,39 +108,32 @@ internal sealed class SourceGeneratorProjectEngine
                 return sgDocument;
             }
 
-            // Re-process the document with the updated tag helpers, starting from IR lowering. Resolution
-            // binds unresolved nodes to their tag helpers by mutating the IR in place, so replaying from
-            // resolution over an already-resolved tree finds nothing left to bind. Re-lowering rebuilds
-            // fresh unresolved IR from the syntax tree; classification and the markup split then re-run over
-            // it -- the split is what carves the working IR into the impl half that resolution and rewrite
-            // operate on, so it cannot be skipped.
-            //
-            // Two phases in that range are skipped:
-            //  * Discovery: the gate discovery above already computed the in-scope tag-helper context for the
-            //    updated set. It walks the syntax tree (not the IR), so re-lowering does not invalidate it,
-            //    and re-running it would recompute the identical context.
-            //  * Decl C# lowering: it lowers the markup-free declaration half, whose text depends only on the
-            //    document's own source. A tag-helper change elsewhere cannot alter it, so the declaration
-            //    document from the initial parse is still valid. It is captured here and restored afterward
-            //    because nothing in the replayed range regenerates it, and it feeds the generator's output
-            //    cache comparison and declaration-diagnostic reporting.
-            var declCSharpDocument = codeDocument.GetDeclCSharpDocument();
-
-            codeDocument = ExecutePhases(Phases[_loweringPhaseIndex.._declLoweringPhaseIndex], codeDocument, cancellationToken);
-            codeDocument = ExecutePhases(Phases[(_discoveryPhaseIndex + 1)..(_rewritePhaseIndex + 1)], codeDocument, cancellationToken);
-
-            if (declCSharpDocument is not null)
-            {
-                codeDocument = codeDocument.WithDeclCSharpDocument(declCSharpDocument);
-            }
+            codeDocument = ResolveTagHelpers(codeDocument);
 
             return new SourceGeneratorRazorCodeDocument(codeDocument);
         }
 
         codeDocument = codeDocument.WithTagHelpers(tagHelpers);
-        codeDocument = ExecutePhases(Phases[_discoveryPhaseIndex..(_rewritePhaseIndex + 1)], codeDocument, cancellationToken);
+        codeDocument = _discoveryPhase.Execute(codeDocument, cancellationToken);
+        codeDocument = ResolveTagHelpers(codeDocument);
 
         return new SourceGeneratorRazorCodeDocument(codeDocument);
+
+        RazorCodeDocument ResolveTagHelpers(RazorCodeDocument codeDocument)
+        {
+            // Capture the unresolved node on the first pass (discovery doesn't mutate it), then resolve a
+            // clone of it every time. Resolution binds tag helpers by mutating the IR in place, so cloning
+            // keeps the stored node pristine for later replays -- which start from it instead of re-lowering.
+            var unresolvedDocumentNode = codeDocument.GetUnresolvedDocumentNode();
+            if (unresolvedDocumentNode is null)
+            {
+                unresolvedDocumentNode = codeDocument.GetRequiredDocumentNode();
+                codeDocument = codeDocument.WithUnresolvedDocumentNode(unresolvedDocumentNode);
+            }
+
+            codeDocument = codeDocument.WithDocumentNode((DocumentIntermediateNode)unresolvedDocumentNode.Clone());
+            return ExecutePhases(Phases[(_discoveryPhaseIndex + 1)..(_rewritePhaseIndex + 1)], codeDocument, cancellationToken);
+        }
     }
 
     private static bool RequiresRewrite(

--- a/src/Razor/src/Compiler/perf/Microsoft.AspNetCore.Razor.Microbenchmarks.Generator/RazorBenchmarks.cs
+++ b/src/Razor/src/Compiler/perf/Microsoft.AspNetCore.Razor.Microbenchmarks.Generator/RazorBenchmarks.cs
@@ -16,6 +16,9 @@ public class RazorBenchmarks : AbstractBenchmark
     public GeneratorDriver Razor_Edit_Independent() => RunRazorBenchmark(Independent, "\\0.razor");
 
     [Benchmark]
+    public GeneratorDriver Razor_Edit_IndependentIgnorable() => RunRazorBenchmark(IndependentIgnorable, "\\0.razor");
+
+    [Benchmark]
     public GeneratorDriver Razor_Remove_Independent() => RunRazorBenchmark(null, "\\0.razor");
 
     [Benchmark]
@@ -55,7 +58,16 @@ public class RazorBenchmarks : AbstractBenchmark
     });
 
 
+    // Replacing the file body without an @page directive drops the route from the component's declaration,
+    // so this is a public-surface (signature) change: it invalidates whole-compilation tag-helper discovery.
     private const string Independent = "<h1>Independent file</h1>";
+
+    // Keeps the file's @page route (its declaration/public surface), changing only the markup body, so the
+    // decl stays byte-identical and discovery is not re-run -- the common "edit a leaf's body" case.
+    private const string IndependentIgnorable = """
+        @page "/0"
+        <h1>Independent file</h1>
+        """;
 
     private const string DependentIgnorable = """
         @page "/counter"

--- a/src/Razor/src/Compiler/perf/Microsoft.AspNetCore.Razor.Microbenchmarks.Generator/RazorTests.cs
+++ b/src/Razor/src/Compiler/perf/Microsoft.AspNetCore.Razor.Microbenchmarks.Generator/RazorTests.cs
@@ -87,6 +87,28 @@ public class RazorTests
     }
 
     [Fact(Skip = "https://github.com/dotnet/razor/issues/7982")]
+    public void Razor_Edit_IndependentIgnorable()
+    {
+        // arrange
+        var razorBenchmarks = new RazorBenchmarks();
+        razorBenchmarks.Setup();
+
+        // check the contents of the generated 0 page
+        var initialResults = razorBenchmarks.Project!.GeneratorDriver.GetRunResult();
+        Assert.Contains("<h1>Page 0 </h1>", initialResults.Results[0].GeneratedSources.Single(r => r.HintName == "Pages_Generated_0_razor.g.cs").SourceText.ToString());
+
+        // act
+        var driver = razorBenchmarks.Razor_Edit_IndependentIgnorable();
+
+        // assert: the markup body changed, but the @page route (declaration) is preserved, so this is an
+        // impl-only edit -- the counterpart to Razor_Edit_DependentIgnorable.
+        var results = driver.GetRunResult();
+        Assert.Empty(results.Diagnostics);
+        var page = results.Results[0].GeneratedSources.Single(r => r.HintName == "Pages_Generated_0_razor.g.cs").SourceText.ToString();
+        Assert.Contains("<h1>Independent file</h1>", page);
+    }
+
+    [Fact(Skip = "https://github.com/dotnet/razor/issues/7982")]
     public void Razor_Remove_Independent()
     {
         // arrange


### PR DESCRIPTION
Due to the reordering of phases in sonic, tag helper lowering happens later in the process. This means if we need to replay back to a point earlier in the process because a TagHelper changed, the IR tree has been mutated and instead we have to perform the initial relowering from syntax again.

This PR introduces a `.Clone()` mechanism to IR nodes, so that we can clone the `DocumentNode` before it gets mutated. This means we can just start from that point again instead of having to start over from syntax.

The first commit is big-ish, but also almost entirely mechanical, so you can probably mostly glance over it. Commit 2 uses the clone to keep a copy of the IR tree and restore it when needed. Commit 3 just adds an extra benchmark because during testing I realized we had two different scenarios that we were equating as one and want to be able to measure them independently.

At some point I plan to make the IR nodes fully immutable, so we don't have to worry about cloning to avoid mutation, but this was the expedient way to get it working without an even bigger change.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84715)