### PR TITLE
Fix Razor code block close brace indentation

### DIFF
--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpOnTypeFormattingPass.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpOnTypeFormattingPass.cs
@@ -770,6 +770,15 @@ internal sealed class CSharpOnTypeFormattingPass(
                 continue;
             }
 
+            if (owner is RazorMetaCodeSyntax { Parent: CSharpCodeBlockSyntax codeBlock } &&
+                owner == codeBlock.Children[^1] &&
+                codeBlock.Parent is RazorDirectiveBodySyntax)
+            {
+                // A code block directive's closing brace is Razor syntax, so use only its Razor/HTML indentation.
+                newIndentations[i] = razorDesiredIndentation;
+                continue;
+            }
+
             if (!lineStartIndentations.TryGetValue(lineStart, out var csharpDesiredIndentation))
             {
                 // Couldn't remap. This is probably a non-C# location.

--- a/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Cohost/Formatting/OnTypeFormattingTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Cohost/Formatting/OnTypeFormattingTest.cs
@@ -265,6 +265,28 @@ public class OnTypeFormattingTest(FormattingTestContext context, HtmlFormattingF
     }
 
     [FormattingTestFact]
+    [WorkItem("https://github.com/dotnet/razor/issues/12627")]
+    public async Task CloseCurly_Method_RestoresCodeBlockClosingBraceAsync()
+    {
+        await RunOnTypeFormattingTestAsync(
+            input: """
+                    @code {
+                        private void Test()
+                        {
+                        }$$
+                        }
+                    """,
+            expected: """
+                    @code {
+                        private void Test()
+                        {
+                        }
+                    }
+                    """,
+            triggerCharacter: '}');
+    }
+
+    [FormattingTestFact]
     public async Task CloseCurly_Property_SingleLineAsync()
     {
         await RunOnTypeFormattingTestAsync(


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/12627

Found this issue today, wish I had known about it yesterday when I fixed a very similar issue with open braces 🤦‍♂️
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84716)