### PR TITLE
Remove dotnet-format tool from dotnet-tools.json

### DIFF
--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -1,13 +1,6 @@
 {
   "isRoot": true,
   "tools": {
-    "dotnet-format": {
-      "version": "7.0.360304",
-      "commands": [
-        "dotnet-format"
-      ],
-      "rollForward": false
-    },
     "powershell": {
       "version": "7.6.0",
       "commands": [

--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -3,7 +3,6 @@
     <!-- Versions used by several individual references below -->
     <MicrosoftCodeAnalysisTestingVersion>1.1.3-beta1.26059.1</MicrosoftCodeAnalysisTestingVersion>
     <_BasicReferenceAssembliesVersion>1.8.8</_BasicReferenceAssembliesVersion>
-    <!-- CodeStyleAnalyzerVersion should we updated together with version of dotnet-format in dotnet-tools.json -->
     <CodeStyleAnalyzerVersion>4.8.0-3.final</CodeStyleAnalyzerVersion>
     <VisualStudioEditorPackagesVersion>18.9.179</VisualStudioEditorPackagesVersion>
     <ILAsmPackageVersion>9.0.0-rc.2.24462.10</ILAsmPackageVersion>

--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -3,7 +3,8 @@
     <!-- Versions used by several individual references below -->
     <MicrosoftCodeAnalysisTestingVersion>1.1.3-beta1.26059.1</MicrosoftCodeAnalysisTestingVersion>
     <_BasicReferenceAssembliesVersion>1.8.8</_BasicReferenceAssembliesVersion>
-    <CodeStyleAnalyzerVersion>4.8.0-3.final</CodeStyleAnalyzerVersion>
+   <!-- CodeStyleAnalyzerVersion should we updated together with version of SDK in global.json -->
+    <CodeStyleAnalyzerVersion>5.6.0</CodeStyleAnalyzerVersion>
     <VisualStudioEditorPackagesVersion>18.9.179</VisualStudioEditorPackagesVersion>
     <ILAsmPackageVersion>9.0.0-rc.2.24462.10</ILAsmPackageVersion>
     <ILDAsmPackageVersion>6.0.0-rtm.21518.12</ILDAsmPackageVersion>

--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -3,7 +3,7 @@
     <!-- Versions used by several individual references below -->
     <MicrosoftCodeAnalysisTestingVersion>1.1.3-beta1.26059.1</MicrosoftCodeAnalysisTestingVersion>
     <_BasicReferenceAssembliesVersion>1.8.8</_BasicReferenceAssembliesVersion>
-   <!-- CodeStyleAnalyzerVersion should we updated together with version of SDK in global.json -->
+    <!-- CodeStyleAnalyzerVersion should we updated together with version of SDK in global.json -->
     <CodeStyleAnalyzerVersion>5.6.0</CodeStyleAnalyzerVersion>
     <VisualStudioEditorPackagesVersion>18.9.179</VisualStudioEditorPackagesVersion>
     <ILAsmPackageVersion>9.0.0-rc.2.24462.10</ILAsmPackageVersion>

--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -3,7 +3,7 @@
     <!-- Versions used by several individual references below -->
     <MicrosoftCodeAnalysisTestingVersion>1.1.3-beta1.26059.1</MicrosoftCodeAnalysisTestingVersion>
     <_BasicReferenceAssembliesVersion>1.8.8</_BasicReferenceAssembliesVersion>
-    <!-- CodeStyleAnalyzerVersion should we updated together with version of SDK in global.json -->
+    <!-- CodeStyleAnalyzerVersion should be updated together with version of SDK in global.json -->
     <CodeStyleAnalyzerVersion>5.6.0</CodeStyleAnalyzerVersion>
     <VisualStudioEditorPackagesVersion>18.9.179</VisualStudioEditorPackagesVersion>
     <ILAsmPackageVersion>9.0.0-rc.2.24462.10</ILAsmPackageVersion>

--- a/eng/test-build-correctness.ps1
+++ b/eng/test-build-correctness.ps1
@@ -72,7 +72,7 @@ try {
   # Verify the state of our generated syntax files
   Write-Host "Checking generated compiler files"
   Exec-DotNet "run --file eng/generate-compiler-code.cs -- -test -configuration $configuration"
-  Exec-DotNet "tool run dotnet-format whitespace . --folder --include-generated --include src/Compilers/CSharp/Portable/Generated/ src/Compilers/VisualBasic/Portable/Generated/ src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/Generated/ --verify-no-changes"
+  Exec-DotNet "format whitespace . --folder --include-generated --include src/Compilers/CSharp/Portable/Generated/ src/Compilers/VisualBasic/Portable/Generated/ src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/Generated/ --verify-no-changes"
   Write-Host ""
 
   ExitWithExitCode 0

--- a/eng/validate-code-formatting.ps1
+++ b/eng/validate-code-formatting.ps1
@@ -11,7 +11,7 @@ try {
   Push-Location $RepoRoot
   $prepareMachine = $ci
 
-  Exec-DotNet "tool run dotnet-format -v detailed whitespace $rootDirectory --folder --include-generated --include $includeDirectories --verify-no-changes"
+  Exec-DotNet "format -v detailed whitespace $rootDirectory --folder --include-generated --include $includeDirectories --verify-no-changes"
 
   ExitWithExitCode 0
 }

--- a/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Main.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Main.Generated.cs
@@ -10,6 +10,7 @@ using Roslyn.Utilities;
 using CoreSyntax = Microsoft.CodeAnalysis.Syntax.InternalSyntax;
 
 namespace Microsoft.CodeAnalysis.CSharp;
+
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 

--- a/src/Tools/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/SourceWriter.cs
+++ b/src/Tools/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/SourceWriter.cs
@@ -136,6 +136,7 @@ namespace CSharpSyntaxGenerator
         {
             WriteFileHeader();
             WriteLine("namespace Microsoft.CodeAnalysis.CSharp;");
+            WriteLine();
             WriteLine("using System.Diagnostics.CodeAnalysis;");
             WriteLine("using Microsoft.CodeAnalysis.CSharp.Syntax;");
             this.WriteRedVisitors();


### PR DESCRIPTION
dotnet-format ships with the SDK and the pinned version is so old it wouldn't format our source correctly.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84728)