### PR TITLE
Improve LSP project load progress messages

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.ProcessHost.UnitTests/Utilities/AbstractLanguageServerClientTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.ProcessHost.UnitTests/Utilities/AbstractLanguageServerClientTests.cs
@@ -170,6 +170,7 @@ public abstract partial class AbstractLanguageServerClientTests(ITestOutputHelpe
         {
             private readonly object _gate = new();
             private readonly List<WorkDoneProgress> _progressReports = [];
+            private readonly TaskCompletionSource<WorkDoneProgressReport> _progressSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
             private readonly TaskCompletionSource<WorkDoneProgressEnd> _endSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
             public string Token { get; } = token;
@@ -186,10 +187,16 @@ public abstract partial class AbstractLanguageServerClientTests(ITestOutputHelpe
                     if (progress is WorkDoneProgressBegin begin)
                         Title = begin.Title;
 
+                    if (progress is WorkDoneProgressReport report)
+                        _progressSource.TrySetResult(report);
+
                     if (progress is WorkDoneProgressEnd end)
                         _endSource.TrySetResult(end);
                 }
             }
+
+            public Task<WorkDoneProgressReport> WaitForProgressReportAsync()
+                => _progressSource.Task;
 
             public Task<WorkDoneProgressEnd> WaitForEndAsync()
                 => _endSource.Task;

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.ProcessHost.UnitTests/Workspaces/AutoLoadProjectsTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.ProcessHost.UnitTests/Workspaces/AutoLoadProjectsTests.cs
@@ -1,9 +1,10 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using Roslyn.LanguageServer.Protocol;
 using Roslyn.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit.Abstractions;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.ProcessHost.UnitTests.Workspaces;
@@ -28,7 +29,7 @@ public sealed class AutoLoadProjectsTests(ITestOutputHelper testOutputHelper) : 
 
         await using var testLspServer = await CreateAutoLoadLanguageServerAsync(workspaceContent);
 
-        await AssertAutoLoadCompletedAsync(testLspServer, GetLoadingProjectsMessage(projectCount: 2), GetLoadedProjectsMessage(projectCount: 2));
+        await AssertProjectsLoadedAsync(testLspServer, projectCount: 2);
     }
 
     [Fact]
@@ -40,7 +41,7 @@ public sealed class AutoLoadProjectsTests(ITestOutputHelper testOutputHelper) : 
 
         await using var testLspServer = await CreateAutoLoadLanguageServerAsync(workspaceContent);
 
-        await AssertAutoLoadCompletedAsync(testLspServer, GetLoadingFileMessage(testLspServer, "App.sln"), GetLoadedFileMessage(testLspServer, "App.sln"));
+        await AssertAutoLoadCompletedAsync(testLspServer, GetLoadingFileMessage("App.sln"), GetLoadedFileMessage("App.sln"));
     }
 
     [Fact]
@@ -52,7 +53,7 @@ public sealed class AutoLoadProjectsTests(ITestOutputHelper testOutputHelper) : 
 
         await using var testLspServer = await CreateAutoLoadLanguageServerAsync(workspaceContent);
 
-        await AssertAutoLoadCompletedAsync(testLspServer, GetLoadingFileMessage(testLspServer, "App.slnx"), GetLoadedFileMessage(testLspServer, "App.slnx"));
+        await AssertAutoLoadCompletedAsync(testLspServer, GetLoadingFileMessage("App.slnx"), GetLoadedFileMessage("App.slnx"));
     }
 
     [Fact]
@@ -65,7 +66,7 @@ public sealed class AutoLoadProjectsTests(ITestOutputHelper testOutputHelper) : 
 
         await using var testLspServer = await CreateAutoLoadLanguageServerAsync(workspaceContent);
 
-        await AssertAutoLoadCompletedAsync(testLspServer, GetLoadingProjectsMessage(projectCount: 2), GetLoadedProjectsMessage(projectCount: 2));
+        await AssertProjectsLoadedAsync(testLspServer, projectCount: 2);
     }
 
     [Fact]
@@ -79,7 +80,7 @@ public sealed class AutoLoadProjectsTests(ITestOutputHelper testOutputHelper) : 
 
         await using var testLspServer = await CreateAutoLoadLanguageServerAsync(workspaceContent);
 
-        await AssertAutoLoadCompletedAsync(testLspServer, GetLoadingProjectsMessage(projectCount: 2), GetLoadedProjectsMessage(projectCount: 2));
+        await AssertProjectsLoadedAsync(testLspServer, projectCount: 2);
     }
 
     [Fact]
@@ -97,7 +98,7 @@ public sealed class AutoLoadProjectsTests(ITestOutputHelper testOutputHelper) : 
 
         await using var testLspServer = await CreateAutoLoadLanguageServerAsync(workspaceContent);
 
-        await AssertAutoLoadCompletedAsync(testLspServer, GetLoadingFileMessage(testLspServer, "Solutions/App.slnx"), GetLoadedFileMessage(testLspServer, "Solutions/App.slnx"));
+        await AssertAutoLoadCompletedAsync(testLspServer, GetLoadingFileMessage("App.slnx"), GetLoadedFileMessage("App.slnx"));
     }
 
     [Fact]
@@ -114,7 +115,7 @@ public sealed class AutoLoadProjectsTests(ITestOutputHelper testOutputHelper) : 
             new LspServerLaunchOptions(),
             CreateWorkDoneProgressClientCapabilities());
 
-        await AssertAutoLoadCompletedAsync(testLspServer, GetLoadingFileMessage(testLspServer, "App.sln"), GetLoadedFileMessage(testLspServer, "App.sln"));
+        await AssertAutoLoadCompletedAsync(testLspServer, GetLoadingFileMessage("App.sln"), GetLoadedFileMessage("App.sln"));
     }
 
     [Fact]
@@ -130,7 +131,7 @@ public sealed class AutoLoadProjectsTests(ITestOutputHelper testOutputHelper) : 
             new LspServerLaunchOptions(),
             CreateWorkDoneProgressClientCapabilities());
 
-        await AssertAutoLoadCompletedAsync(testLspServer, GetLoadingProjectsMessage(projectCount: 1), GetLoadedProjectsMessage(projectCount: 1));
+        await AssertProjectsLoadedAsync(testLspServer, projectCount: 1, assertInitialProgressReport: true);
     }
 
     [Fact]
@@ -178,13 +179,29 @@ public sealed class AutoLoadProjectsTests(ITestOutputHelper testOutputHelper) : 
     private static LspWorkspaceContent CreateAutoLoadWorkspace()
         => LspWorkspaceContent.Empty.WithRestore();
 
-    private static async Task AssertAutoLoadCompletedAsync(TestLspClient testLspServer, string expectedStartMessage, string expectedEndMessage)
+    private static async Task AssertAutoLoadCompletedAsync(TestLspClient testLspServer, string expectedTitle, string expectedEndMessage)
     {
-        var unit = await testLspServer.WorkDoneProgress.WaitForWorkDoneProgressCreation(expectedStartMessage).WaitAsync(TimeSpan.FromMinutes(2));
+        var unit = await testLspServer.WorkDoneProgress.WaitForWorkDoneProgressCreation(expectedTitle).WaitAsync(TestHelpers.HangMitigatingTimeout);
         Assert.NotNull(unit.CreateParams.Token.Value);
 
-        var end = await unit.WaitForEndAsync().WaitAsync(TimeSpan.FromMinutes(2));
+        var end = await unit.WaitForEndAsync().WaitAsync(TestHelpers.HangMitigatingTimeout);
         Assert.Equal(expectedEndMessage, end.Message);
+    }
+
+    private static async Task AssertProjectsLoadedAsync(TestLspClient testLspServer, int projectCount, bool assertInitialProgressReport = false)
+    {
+        var unit = await testLspServer.WorkDoneProgress.WaitForWorkDoneProgressCreation(LanguageServerResources.Loading_projects).WaitAsync(TestHelpers.HangMitigatingTimeout);
+        Assert.NotNull(unit.CreateParams.Token.Value);
+
+        if (assertInitialProgressReport)
+        {
+            var initialProgress = await unit.WaitForProgressReportAsync().WaitAsync(TestHelpers.HangMitigatingTimeout);
+            Assert.Equal(GetLoadingProjectsMessage(projectCount), initialProgress.Message);
+            Assert.Equal(0, initialProgress.Percentage);
+        }
+
+        var end = await unit.WaitForEndAsync().WaitAsync(TestHelpers.HangMitigatingTimeout);
+        Assert.Equal(GetLoadedProjectsMessage(projectCount), end.Message);
     }
 
     private static string GetLoadingProjectsMessage(int projectCount)
@@ -193,14 +210,11 @@ public sealed class AutoLoadProjectsTests(ITestOutputHelper testOutputHelper) : 
     private static string GetLoadedProjectsMessage(int projectCount)
         => string.Format(LanguageServerResources.Loaded_0_projects, projectCount);
 
-    private static string GetLoadingFileMessage(TestLspClient testLspServer, string relativePath)
-        => string.Format(LanguageServerResources.Loading_0, GetFullPath(testLspServer, relativePath));
+    private static string GetLoadingFileMessage(string fileName)
+        => string.Format(LanguageServerResources.Loading_0, fileName);
 
-    private static string GetLoadedFileMessage(TestLspClient testLspServer, string relativePath)
-        => string.Format(LanguageServerResources.Loaded_0, GetFullPath(testLspServer, relativePath));
-
-    private static string GetFullPath(TestLspClient testLspServer, string relativePath)
-        => PathUtilities.CombinePathsUnchecked(testLspServer.WorkspaceRootPath, LspWorkspaceContent.NormalizePath(relativePath).Replace(PathUtilities.AltDirectorySeparatorChar, PathUtilities.DirectorySeparatorChar));
+    private static string GetLoadedFileMessage(string fileName)
+        => string.Format(LanguageServerResources.Loaded_0, fileName);
 
     private static string CreateSolutionXFile(params string[] projectPaths)
         => """

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/AutoLoadProjectsInitializer.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/AutoLoadProjectsInitializer.cs
@@ -68,10 +68,12 @@ internal sealed class AutoLoadProjectsInitializer(
         else if (solutionPath is not null)
         {
             _logger.LogInformation("Using VS Code settings to auto load solution {SolutionFile}", solutionPath);
+            var solutionFileName = Path.GetFileName(solutionPath);
             await StartAndReportProgressAsync(
                 (reporter) => projectSystem.OpenSolutionAsync(solutionPath, reporter),
-                startMessage: string.Format(LanguageServerResources.Loading_0, solutionPath),
-                endMessage: string.Format(LanguageServerResources.Loaded_0, solutionPath));
+                title: string.Format(LanguageServerResources.Loading_0, solutionFileName),
+                startMessage: string.Empty,
+                endMessage: string.Format(LanguageServerResources.Loaded_0, solutionFileName));
             return;
         }
 
@@ -88,10 +90,12 @@ internal sealed class AutoLoadProjectsInitializer(
                 if (solutionFiles.Length == 1)
                 {
                     _logger.LogInformation("Found single solution file {SolutionFile} to auto load", solutionFiles[0]);
+                    var solutionFileName = Path.GetFileName(solutionFiles[0]);
                     await StartAndReportProgressAsync(
                         (reporter) => projectSystem.OpenSolutionAsync(solutionFiles[0], reporter),
-                        startMessage: string.Format(LanguageServerResources.Loading_0, solutionFiles[0]),
-                        endMessage: string.Format(LanguageServerResources.Loaded_0, solutionFiles[0]));
+                        title: string.Format(LanguageServerResources.Loading_0, solutionFileName),
+                        startMessage: string.Empty,
+                        endMessage: string.Format(LanguageServerResources.Loaded_0, solutionFileName));
                     return;
                 }
             }
@@ -131,16 +135,17 @@ internal sealed class AutoLoadProjectsInitializer(
 
         await StartAndReportProgressAsync(
             (reporter) => projectSystem.OpenProjectsAsync(projectFiles.ToImmutable(), reporter),
-            startMessage: string.Format(LanguageServerResources.Loading_0_projects, projectFiles.Count),
+            title: LanguageServerResources.Loading_projects,
+            startMessage: string.Empty,
             endMessage: string.Format(LanguageServerResources.Loaded_0_projects, projectFiles.Count));
 
-        async Task StartAndReportProgressAsync(Func<IWorkDoneProgressReporter, Task> loadOperation, string startMessage, string endMessage)
+        async Task StartAndReportProgressAsync(Func<IWorkDoneProgressReporter, Task> loadOperation, string title, string startMessage, string endMessage)
         {
             var workDoneProgressManager = context.GetRequiredLspService<WorkDoneProgressManager>();
 
             // We will await for the client to know that we are starting work...
             var progressReporter = await workDoneProgressManager.CreateWorkDoneProgressAsync(reportProgressToClient: true,
-                title: startMessage,
+                title: title,
                 startMessage: startMessage,
                 endMessage: endMessage,
                 clientCanCancel: false,

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
@@ -654,6 +654,12 @@ internal abstract class LanguageServerProjectLoader : IDisposable
                 ReportProgressAsync,
                 listener ?? AsynchronousOperationListenerProvider.NullListener,
                 CancellationToken.None);
+
+            reporter.Report(new LSP.WorkDoneProgressReport
+            {
+                Message = string.Format(LanguageServerResources.Loading_0_projects, totalItems),
+                Percentage = 0,
+            });
         }
 
         public void OnItemProcessed()

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/OpenProjectsHandler.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/OpenProjectsHandler.cs
@@ -43,7 +43,7 @@ internal sealed class OpenProjectHandler : ILspService, ILspServiceNotificationH
     async Task INotificationHandler<NotificationParams, RequestContext>.HandleNotificationAsync(NotificationParams request, RequestContext requestContext, CancellationToken cancellationToken)
     {
         var projectsLength = request.Projects.Length;
-        var loadingMessage = string.Format(LanguageServerResources.Loading_0_projects, projectsLength);
+        var loadingMessage = LanguageServerResources.Loading_projects;
         await using var progressReporter = await _workDoneProgressManager.CreateWorkDoneProgressAsync(
             reportProgressToClient: true,
             title: loadingMessage,

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/OpenSolutionHandler.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/OpenSolutionHandler.cs
@@ -42,13 +42,14 @@ internal sealed class OpenSolutionHandler : ILspService, ILspServiceNotification
     async Task INotificationHandler<NotificationParams, RequestContext>.HandleNotificationAsync(NotificationParams request, RequestContext requestContext, CancellationToken cancellationToken)
     {
         var solutionPath = request.Solution.GetDocumentFilePathFromUri();
+        var solutionFileName = Path.GetFileName(solutionPath);
 
-        var loadingMessage = string.Format(LanguageServerResources.Loading_0, solutionPath);
+        var loadingMessage = string.Format(LanguageServerResources.Loading_0, solutionFileName);
         await using var progressReporter = await _workDoneProgressManager.CreateWorkDoneProgressAsync(
             reportProgressToClient: true,
             title: loadingMessage,
             startMessage: loadingMessage,
-            endMessage: string.Format(LanguageServerResources.Loaded_0, solutionPath),
+            endMessage: string.Format(LanguageServerResources.Loaded_0, solutionFileName),
             clientCanCancel: false,
             serverCancellationToken: cancellationToken);
 

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServerResources.resx
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServerResources.resx
@@ -168,6 +168,9 @@
     <value>Loaded {0}</value>
     <comment>The placeholder is a name of a file</comment>
   </data>
+  <data name="Loading_projects" xml:space="preserve">
+    <value>Loading projects...</value>
+  </data>
   <data name="Loading_0_projects" xml:space="preserve">
     <value>Loading {0} project(s)...</value>
     <comment>The placeholder is the number of projects</comment>

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.cs.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.cs.xlf
@@ -107,6 +107,11 @@
         <target state="translated">Načítají se projekty (celkem {0})...</target>
         <note>The placeholder is the number of projects</note>
       </trans-unit>
+      <trans-unit id="Loading_projects">
+        <source>Loading projects...</source>
+        <target state="new">Loading projects...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Message">
         <source>Message</source>
         <target state="translated">Zpráva</target>

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.de.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.de.xlf
@@ -107,6 +107,11 @@
         <target state="translated">{0} Projekte werden geladen...</target>
         <note>The placeholder is the number of projects</note>
       </trans-unit>
+      <trans-unit id="Loading_projects">
+        <source>Loading projects...</source>
+        <target state="new">Loading projects...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Message">
         <source>Message</source>
         <target state="translated">Nachricht</target>

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.es.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.es.xlf
@@ -107,6 +107,11 @@
         <target state="translated">Cargando {0} proyecto(s)...</target>
         <note>The placeholder is the number of projects</note>
       </trans-unit>
+      <trans-unit id="Loading_projects">
+        <source>Loading projects...</source>
+        <target state="new">Loading projects...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Message">
         <source>Message</source>
         <target state="translated">Mensaje</target>

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.fr.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.fr.xlf
@@ -107,6 +107,11 @@
         <target state="translated">Chargement de {0} projet(s)...</target>
         <note>The placeholder is the number of projects</note>
       </trans-unit>
+      <trans-unit id="Loading_projects">
+        <source>Loading projects...</source>
+        <target state="new">Loading projects...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Message">
         <source>Message</source>
         <target state="translated">Message</target>

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.it.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.it.xlf
@@ -107,6 +107,11 @@
         <target state="translated">Caricamento di {0} progetti in corso...</target>
         <note>The placeholder is the number of projects</note>
       </trans-unit>
+      <trans-unit id="Loading_projects">
+        <source>Loading projects...</source>
+        <target state="new">Loading projects...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Message">
         <source>Message</source>
         <target state="translated">Messaggio</target>

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ja.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ja.xlf
@@ -107,6 +107,11 @@
         <target state="translated">{0} 件のプロジェクトを読み込んでいます...</target>
         <note>The placeholder is the number of projects</note>
       </trans-unit>
+      <trans-unit id="Loading_projects">
+        <source>Loading projects...</source>
+        <target state="new">Loading projects...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Message">
         <source>Message</source>
         <target state="translated">メッセージ</target>

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ko.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ko.xlf
@@ -107,6 +107,11 @@
         <target state="translated">{0} 프로젝트를 로드하는 중...</target>
         <note>The placeholder is the number of projects</note>
       </trans-unit>
+      <trans-unit id="Loading_projects">
+        <source>Loading projects...</source>
+        <target state="new">Loading projects...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Message">
         <source>Message</source>
         <target state="translated">메시지</target>

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.pl.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.pl.xlf
@@ -107,6 +107,11 @@
         <target state="translated">Trwa ładowanie {0} projektów...</target>
         <note>The placeholder is the number of projects</note>
       </trans-unit>
+      <trans-unit id="Loading_projects">
+        <source>Loading projects...</source>
+        <target state="new">Loading projects...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Message">
         <source>Message</source>
         <target state="translated">Komunikat</target>

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.pt-BR.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.pt-BR.xlf
@@ -107,6 +107,11 @@
         <target state="translated">Carregando {0} projeto(s)...</target>
         <note>The placeholder is the number of projects</note>
       </trans-unit>
+      <trans-unit id="Loading_projects">
+        <source>Loading projects...</source>
+        <target state="new">Loading projects...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Message">
         <source>Message</source>
         <target state="translated">Mensagem</target>

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ru.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.ru.xlf
@@ -107,6 +107,11 @@
         <target state="translated">Загрузка проектов: {0}...</target>
         <note>The placeholder is the number of projects</note>
       </trans-unit>
+      <trans-unit id="Loading_projects">
+        <source>Loading projects...</source>
+        <target state="new">Loading projects...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Message">
         <source>Message</source>
         <target state="translated">Сообщение</target>

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.tr.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.tr.xlf
@@ -107,6 +107,11 @@
         <target state="translated">{0} proje yükleniyor...</target>
         <note>The placeholder is the number of projects</note>
       </trans-unit>
+      <trans-unit id="Loading_projects">
+        <source>Loading projects...</source>
+        <target state="new">Loading projects...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Message">
         <source>Message</source>
         <target state="translated">İleti</target>

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.zh-Hans.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.zh-Hans.xlf
@@ -107,6 +107,11 @@
         <target state="translated">正在加载 {0} 个项目...</target>
         <note>The placeholder is the number of projects</note>
       </trans-unit>
+      <trans-unit id="Loading_projects">
+        <source>Loading projects...</source>
+        <target state="new">Loading projects...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Message">
         <source>Message</source>
         <target state="translated">消息</target>

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.zh-Hant.xlf
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/xlf/LanguageServerResources.zh-Hant.xlf
@@ -107,6 +107,11 @@
         <target state="translated">正在載入 {0} 專案...</target>
         <note>The placeholder is the number of projects</note>
       </trans-unit>
+      <trans-unit id="Loading_projects">
+        <source>Loading projects...</source>
+        <target state="new">Loading projects...</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Message">
         <source>Message</source>
         <target state="translated">訊息</target>


### PR DESCRIPTION
The current progress event title and message are duplicated. This updates them to be unique. Providing more detail in the message while keeping the title short and relevant.

Current:
Title: Loading C:\Users\JoeRob\Source\roslyn\main\roslyn.slnx
Message: Loading C:\Users\JoeRob\Source\roslyn\main\roslyn.slnx

After:
Title: Loading roslyn.slnx
Message Loading xxx projects