### PR TITLE
Preserve indentation in XML doc comment CDATA sections

### DIFF
--- a/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.cs
@@ -1058,17 +1058,98 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             int substringStart = skipSpace ? 4 : 3;
+            bool inCDataSection = false;
 
             for (int start = 0; start < text.Length;)
             {
                 int newLineLength;
                 int end = IndexOfNewLine(text, start, out newLineLength);
                 int trimStart = GetIndexOfFirstNonWhitespaceChar(text, start, end) + substringStart;
-                WriteSubStringLine(text, trimStart, end - trimStart);
+                WriteFormattedCommentLine(text, trimStart, end, ref inCDataSection);
                 start = end + newLineLength;
             }
         }
 
+        /// <summary>
+        /// Writes one physical documentation comment line while preserving authored
+        /// whitespace inside CDATA sections.
+        /// </summary>
+        private void WriteFormattedCommentLine(string text, int start, int end, ref bool inCDataSection)
+        {
+            const string CDataStartString = "<![CDATA[";
+            const string CDataEndString = "]]>";
+
+            int current = start;
+            bool wroteContent = false;
+
+            while (current < end)
+            {
+                if (inCDataSection)
+                {
+                    int cDataEnd = IndexOfXmlDelimiter(text, CDataEndString, current, end);
+                    int segmentEnd = cDataEnd < 0 ? end : cDataEnd + CDataEndString.Length;
+                    WriteSubStringLine(text, current, segmentEnd - current);
+                    wroteContent = true;
+                    current = segmentEnd;
+                    inCDataSection = cDataEnd < 0;
+                }
+                else
+                {
+                    if (!wroteContent)
+                    {
+                        Write(MakeIndent(_indentDepth));
+                        wroteContent = true;
+                    }
+
+                    int cDataStart = IndexOfXmlDelimiter(text, CDataStartString, current, end);
+                    int segmentEnd = cDataStart < 0 ? end : cDataStart + CDataStartString.Length;
+                    WriteSubStringLine(text, current, segmentEnd - current);
+                    current = segmentEnd;
+                    inCDataSection = cDataStart >= 0;
+                }
+            }
+
+            if (!wroteContent && !inCDataSection)
+            {
+                Write(MakeIndent(_indentDepth));
+            }
+
+            WriteLine();
+        }
+
+        private static int IndexOfXmlDelimiter(string text, string delimiter, int start, int end)
+        {
+            Debug.Assert(start >= 0 && start <= text.Length);
+            Debug.Assert(end >= start && end <= text.Length);
+            return text.IndexOf(delimiter, start, end - start, StringComparison.Ordinal);
+        }
+
+        private void WriteLine()
+        {
+            if (_temporaryStringBuilders?.Count > 0)
+            {
+                _temporaryStringBuilders.Peek().Pooled.Builder.AppendLine();
+            }
+            else
+            {
+                _writer?.WriteLine();
+            }
+        }
+
+        private void WriteSubStringLine(string message, int start, int length)
+        {
+            if (_temporaryStringBuilders?.Count > 0)
+            {
+                _temporaryStringBuilders.Peek().Pooled.Builder.Append(message, start, length);
+            }
+            else if (_writer != null)
+            {
+                for (int i = 0; i < length; i++)
+                {
+                    _writer.Write(message[start + i]);
+                }
+            }
+        }
         /// <summary>
         /// Given the full text of a multi-line style documentation comment, broken into lines, strip off
         /// the comment punctuation (/**, */, etc) and add appropriate indentations.
@@ -1421,26 +1502,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 _writer.Write(MakeIndent(_indentDepth));
                 _writer.WriteLine(message);
-            }
-        }
-
-        private void WriteSubStringLine(string message, int start, int length)
-        {
-            if (_temporaryStringBuilders?.Count > 0)
-            {
-                StringBuilder builder = _temporaryStringBuilders.Peek().Pooled.Builder;
-                builder.Append(MakeIndent(_indentDepth));
-                builder.Append(message, start, length);
-                builder.AppendLine();
-            }
-            else if (_writer != null)
-            {
-                _writer.Write(MakeIndent(_indentDepth));
-                for (int i = 0; i < length; i++)
-                {
-                    _writer.Write(message[start + i]);
-                }
-                _writer.WriteLine();
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.cs
@@ -1065,91 +1065,50 @@ namespace Microsoft.CodeAnalysis.CSharp
                 int newLineLength;
                 int end = IndexOfNewLine(text, start, out newLineLength);
                 int trimStart = GetIndexOfFirstNonWhitespaceChar(text, start, end) + substringStart;
-                WriteFormattedCommentLine(text, trimStart, end, ref inCDataSection);
+
+                if (inCDataSection)
+                {
+                    WriteSubStringLineWithoutIndent(text, trimStart, end - trimStart);
+                }
+                else
+                {
+                    WriteSubStringLine(text, trimStart, end - trimStart);
+                }
+
+                inCDataSection = IsInCDataSectionAfter(text, trimStart, end, inCDataSection);
                 start = end + newLineLength;
             }
         }
 
         /// <summary>
-        /// Writes one physical documentation comment line while preserving authored
-        /// whitespace inside CDATA sections.
+        /// Returns whether the text is inside a CDATA section after the given line.
+        /// This only tracks the section state; it writes nothing.
         /// </summary>
-        private void WriteFormattedCommentLine(string text, int start, int end, ref bool inCDataSection)
+        private static bool IsInCDataSectionAfter(string text, int start, int end, bool inCDataSection)
         {
             const string CDataStartString = "<![CDATA[";
             const string CDataEndString = "]]>";
 
-            int current = start;
-            bool wroteContent = false;
-
-            while (current < end)
-            {
-                if (inCDataSection)
-                {
-                    int cDataEnd = IndexOfXmlDelimiter(text, CDataEndString, current, end);
-                    int segmentEnd = cDataEnd < 0 ? end : cDataEnd + CDataEndString.Length;
-                    WriteSubStringLine(text, current, segmentEnd - current);
-                    wroteContent = true;
-                    current = segmentEnd;
-                    inCDataSection = cDataEnd < 0;
-                }
-                else
-                {
-                    if (!wroteContent)
-                    {
-                        Write(MakeIndent(_indentDepth));
-                        wroteContent = true;
-                    }
-
-                    int cDataStart = IndexOfXmlDelimiter(text, CDataStartString, current, end);
-                    int segmentEnd = cDataStart < 0 ? end : cDataStart + CDataStartString.Length;
-                    WriteSubStringLine(text, current, segmentEnd - current);
-                    current = segmentEnd;
-                    inCDataSection = cDataStart >= 0;
-                }
-            }
-
-            if (!wroteContent && !inCDataSection)
-            {
-                Write(MakeIndent(_indentDepth));
-            }
-
-            WriteLine();
-        }
-
-        private static int IndexOfXmlDelimiter(string text, string delimiter, int start, int end)
-        {
             Debug.Assert(start >= 0 && start <= text.Length);
             Debug.Assert(end >= start && end <= text.Length);
-            return text.IndexOf(delimiter, start, end - start, StringComparison.Ordinal);
-        }
 
-        private void WriteLine()
-        {
-            if (_temporaryStringBuilders?.Count > 0)
+            int current = start;
+            while (current < end)
             {
-                _temporaryStringBuilders.Peek().Pooled.Builder.AppendLine();
-            }
-            else
-            {
-                _writer?.WriteLine();
-            }
-        }
-
-        private void WriteSubStringLine(string message, int start, int length)
-        {
-            if (_temporaryStringBuilders?.Count > 0)
-            {
-                _temporaryStringBuilders.Peek().Pooled.Builder.Append(message, start, length);
-            }
-            else if (_writer != null)
-            {
-                for (int i = 0; i < length; i++)
+                string delimiter = inCDataSection ? CDataEndString : CDataStartString;
+                int index = text.IndexOf(delimiter, current, end - current, StringComparison.Ordinal);
+                if (index < 0)
                 {
-                    _writer.Write(message[start + i]);
+                    break;
                 }
+
+                inCDataSection = !inCDataSection;
+                current = index + delimiter.Length;
             }
+
+            return inCDataSection;
         }
+
         /// <summary>
         /// Given the full text of a multi-line style documentation comment, broken into lines, strip off
         /// the comment punctuation (/**, */, etc) and add appropriate indentations.
@@ -1502,6 +1461,48 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 _writer.Write(MakeIndent(_indentDepth));
                 _writer.WriteLine(message);
+            }
+        }
+
+        private void WriteSubStringLine(string message, int start, int length)
+        {
+            if (_temporaryStringBuilders?.Count > 0)
+            {
+                StringBuilder builder = _temporaryStringBuilders.Peek().Pooled.Builder;
+                builder.Append(MakeIndent(_indentDepth));
+                builder.Append(message, start, length);
+                builder.AppendLine();
+            }
+            else if (_writer != null)
+            {
+                _writer.Write(MakeIndent(_indentDepth));
+                for (int i = 0; i < length; i++)
+                {
+                    _writer.Write(message[start + i]);
+                }
+                _writer.WriteLine();
+            }
+        }
+
+        /// <summary>
+        /// Same as <see cref="WriteSubStringLine"/> without the generated indent, for
+        /// lines whose leading whitespace is authored content rather than formatting.
+        /// </summary>
+        private void WriteSubStringLineWithoutIndent(string message, int start, int length)
+        {
+            if (_temporaryStringBuilders?.Count > 0)
+            {
+                StringBuilder builder = _temporaryStringBuilders.Peek().Pooled.Builder;
+                builder.Append(message, start, length);
+                builder.AppendLine();
+            }
+            else if (_writer != null)
+            {
+                for (int i = 0; i < length; i++)
+                {
+                    _writer.Write(message[start + i]);
+                }
+                _writer.WriteLine();
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.cs
@@ -1066,16 +1066,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 int end = IndexOfNewLine(text, start, out newLineLength);
                 int trimStart = GetIndexOfFirstNonWhitespaceChar(text, start, end) + substringStart;
 
-                if (inCDataSection)
-                {
-                    WriteSubStringLineWithoutIndent(text, trimStart, end - trimStart);
-                }
-                else
-                {
-                    WriteSubStringLine(text, trimStart, end - trimStart);
-                }
+                // Whitespace inside a CDATA section is authored character data, so the generated
+                // member indent must not be prepended to lines that start inside one.
+                WriteSubStringLine(text, trimStart, end - trimStart, indent: !inCDataSection);
 
-                inCDataSection = IsInCDataSectionAfter(text, trimStart, end, inCDataSection);
+                inCDataSection = IsInCDataSectionAfter(text.AsSpan(trimStart, end - trimStart), inCDataSection);
                 start = end + newLineLength;
             }
         }
@@ -1084,26 +1079,22 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Returns whether the text is inside a CDATA section after the given line.
         /// This only tracks the section state; it writes nothing.
         /// </summary>
-        private static bool IsInCDataSectionAfter(string text, int start, int end, bool inCDataSection)
+        private static bool IsInCDataSectionAfter(ReadOnlySpan<char> line, bool inCDataSection)
         {
             const string CDataStartString = "<![CDATA[";
             const string CDataEndString = "]]>";
 
-            Debug.Assert(start >= 0 && start <= text.Length);
-            Debug.Assert(end >= start && end <= text.Length);
-
-            int current = start;
-            while (current < end)
+            while (line.Length > 0)
             {
                 string delimiter = inCDataSection ? CDataEndString : CDataStartString;
-                int index = text.IndexOf(delimiter, current, end - current, StringComparison.Ordinal);
+                int index = line.IndexOf(delimiter.AsSpan());
                 if (index < 0)
                 {
                     break;
                 }
 
                 inCDataSection = !inCDataSection;
-                current = index + delimiter.Length;
+                line = line[(index + delimiter.Length)..];
             }
 
             return inCDataSection;
@@ -1464,40 +1455,28 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private void WriteSubStringLine(string message, int start, int length)
+        /// <param name="indent">
+        /// Whether to prepend the generated indent. Pass <see langword="false"/> for lines whose
+        /// leading whitespace is authored content rather than formatting.
+        /// </param>
+        private void WriteSubStringLine(string message, int start, int length, bool indent = true)
         {
             if (_temporaryStringBuilders?.Count > 0)
             {
                 StringBuilder builder = _temporaryStringBuilders.Peek().Pooled.Builder;
-                builder.Append(MakeIndent(_indentDepth));
-                builder.Append(message, start, length);
-                builder.AppendLine();
-            }
-            else if (_writer != null)
-            {
-                _writer.Write(MakeIndent(_indentDepth));
-                for (int i = 0; i < length; i++)
+                if (indent)
                 {
-                    _writer.Write(message[start + i]);
+                    builder.Append(MakeIndent(_indentDepth));
                 }
-                _writer.WriteLine();
-            }
-        }
-
-        /// <summary>
-        /// Same as <see cref="WriteSubStringLine"/> without the generated indent, for
-        /// lines whose leading whitespace is authored content rather than formatting.
-        /// </summary>
-        private void WriteSubStringLineWithoutIndent(string message, int start, int length)
-        {
-            if (_temporaryStringBuilders?.Count > 0)
-            {
-                StringBuilder builder = _temporaryStringBuilders.Peek().Pooled.Builder;
                 builder.Append(message, start, length);
                 builder.AppendLine();
             }
             else if (_writer != null)
             {
+                if (indent)
+                {
+                    _writer.Write(MakeIndent(_indentDepth));
+                }
                 for (int i = 0; i < length; i++)
                 {
                     _writer.Write(message[start + i]);

--- a/src/Compilers/CSharp/Test/Symbol/DocumentationComments/DocumentationCommentCompilerTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/DocumentationComments/DocumentationCommentCompilerTests.cs
@@ -9076,5 +9076,72 @@ record Rec(string Item)
 </doc>";
             AssertEx.Equal(expected, actual);
         }
+
+        [Fact]
+        [WorkItem(27150, "https://github.com/dotnet/roslyn/issues/27150")]
+        public void CDataInCodeElementPreservesAuthoredIndentation()
+        {
+            var source = """
+                /// <summary>This is the Summary</summary>
+                /// <example>
+                /// <code language="c#">
+                /// <![CDATA[
+                /// // No Indent
+                ///     // four spaces
+                ///         // eight spaces
+                /// ]]>
+                /// </code>
+                /// </example>
+                public class C
+                {
+                }
+                """;
+
+            var compilation = CreateCompilation(
+                source,
+                assemblyName: "csdoccomment",
+                options: TestOptions.ReleaseDll);
+
+            using var peStream = new MemoryStream();
+            using var xmlStream = new MemoryStream();
+
+            var emitResult = compilation.Emit(
+                peStream: peStream,
+                xmlDocumentationStream: xmlStream);
+
+            emitResult.Diagnostics.Verify();
+            Assert.True(emitResult.Success);
+
+            static string normalizeLineEndings(string value) =>
+                value.Replace("\r\n", "\n").Replace('\r', '\n');
+
+            var actual = normalizeLineEndings(
+                System.Text.Encoding.UTF8.GetString(xmlStream.ToArray()));
+
+            var expected = normalizeLineEndings("""
+                <?xml version="1.0"?>
+                <doc>
+                    <assembly>
+                        <name>csdoccomment</name>
+                    </assembly>
+                    <members>
+                        <member name="T:C">
+                            <summary>This is the Summary</summary>
+                            <example>
+                            <code language="c#">
+                            <![CDATA[
+                // No Indent
+                    // four spaces
+                        // eight spaces
+                ]]>
+                            </code>
+                            </example>
+                        </member>
+                    </members>
+                </doc>
+                """) + "\n";
+
+            AssertEx.Equal(expected, actual);
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/DocumentationComments/DocumentationCommentCompilerTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/DocumentationComments/DocumentationCommentCompilerTests.cs
@@ -9097,32 +9097,13 @@ record Rec(string Item)
                 }
                 """;
 
-            var compilation = CreateCompilation(
-                source,
-                assemblyName: "csdoccomment",
-                options: TestOptions.ReleaseDll);
-
-            using var peStream = new MemoryStream();
-            using var xmlStream = new MemoryStream();
-
-            var emitResult = compilation.Emit(
-                peStream: peStream,
-                xmlDocumentationStream: xmlStream);
-
-            emitResult.Diagnostics.Verify();
-            Assert.True(emitResult.Success);
-
-            static string normalizeLineEndings(string value) =>
-                value.Replace("\r\n", "\n").Replace('\r', '\n');
-
-            var actual = normalizeLineEndings(
-                System.Text.Encoding.UTF8.GetString(xmlStream.ToArray()));
-
-            var expected = normalizeLineEndings("""
+            var comp = CreateCompilationUtil(source);
+            var actual = GetDocumentationCommentText(comp).NormalizeLineEndings();
+            var expected = """
                 <?xml version="1.0"?>
                 <doc>
                     <assembly>
-                        <name>csdoccomment</name>
+                        <name>Test</name>
                     </assembly>
                     <members>
                         <member name="T:C">
@@ -9139,7 +9120,7 @@ record Rec(string Item)
                         </member>
                     </members>
                 </doc>
-                """) + "\n";
+                """.NormalizeLineEndings();
 
             AssertEx.Equal(expected, actual);
         }


### PR DESCRIPTION
Fixes #27150

## Summary

XML documentation formatting currently applies member indentation to every physical `///` line, including content inside a CDATA section. Since whitespace inside CDATA is character data, this changes the authored indentation of code samples.

This change:

- tracks CDATA boundaries while formatting single-line (`///`) documentation  comments;
- avoids adding compiler-generated indentation to CDATA content;
- preserves the existing formatting behavior outside CDATA sections;
- adds a regression test that compares the exact emitted XML documentation text.

## Testing

- `CDataInCodeElementPreservesAuthoredIndentation`
- `DocumentationCommentCompilerTests` on `net10.0`
- `Microsoft.CodeAnalysis.CSharp.Symbol.UnitTests` on `net10.0`
- Compiler test suite on CoreCLR via `Compilers.slnf`
- `Compilers.slnf` build on Linux
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84750)