### PR TITLE
Fix type completion in static contexts for primary constructors

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -4714,6 +4714,20 @@ public sealed partial class SymbolCompletionProviderTests : AbstractCSharpComple
             }
             """, "x");
 
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/82750")]
+    public Task TypeWithSameNameAsInstancePropertyInStaticMethod()
+        => VerifyItemExistsAsync("""
+            public sealed record SourceContainer(Source Source)
+            {
+                public static SourceContainer From(string source)
+                {
+                    Sour$$
+                }
+            }
+
+            public sealed record Source(string Content);
+            """, "Source", expectedDescriptionOrNull: "record Source");
+
     [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543601")]
     public Task NoInstanceFieldsInStaticFieldInitializer()
         => VerifyItemIsAbsentAsync("""

--- a/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationServiceRunner.cs
+++ b/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationServiceRunner.cs
@@ -399,9 +399,29 @@ internal partial class CSharpRecommendationService
             }
             else
             {
-                symbols = contextNode.IsInStaticContext()
-                    ? semanticModel.LookupStaticMembers(_context.LeftToken.SpanStart)
-                    : semanticModel.LookupSymbols(_context.LeftToken.SpanStart);
+                if (contextNode.IsInStaticContext())
+                {
+                    var position = _context.LeftToken.SpanStart;
+                    symbols = semanticModel.LookupStaticMembers(position);
+
+                    // Primary constructor parameters are returned by LookupStaticMembers, but are unusable in a static
+                    // context. They can hide a namespace or type with the same name, so recover those candidates.
+                    if (symbols.Any(s => s is IParameterSymbol parameter && parameter.IsPrimaryConstructor(_cancellationToken)))
+                    {
+                        using var _ = ArrayBuilder<ISymbol>.GetInstance(out var namespaceOrTypeSymbols);
+                        foreach (var symbol in symbols)
+                        {
+                            if (symbol is IParameterSymbol parameter && parameter.IsPrimaryConstructor(_cancellationToken))
+                                namespaceOrTypeSymbols.AddRange(semanticModel.LookupNamespacesAndTypes(position, name: parameter.Name));
+                        }
+
+                        symbols = [.. symbols, .. namespaceOrTypeSymbols];
+                    }
+                }
+                else
+                {
+                    symbols = semanticModel.LookupSymbols(_context.LeftToken.SpanStart);
+                }
 
                 symbols = FilterOutUncapturableParameters(symbols, contextNode);
             }

--- a/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationServiceRunner.cs
+++ b/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationServiceRunner.cs
@@ -406,20 +406,23 @@ internal partial class CSharpRecommendationService
 
                     // Primary constructor parameters are returned by LookupStaticMembers, but are unusable in a static
                     // context. They can hide a namespace or type with the same name, so recover those candidates.
-                    using var _ = ArrayBuilder<ISymbol>.GetInstance(symbols.Length, out var staticSymbols);
-                    foreach (var symbol in symbols)
+                    if (!_context.IsInstanceContext)
                     {
-                        if (symbol is IParameterSymbol parameter && parameter.IsPrimaryConstructor(_cancellationToken))
+                        using var _ = ArrayBuilder<ISymbol>.GetInstance(symbols.Length, out var staticSymbols);
+                        foreach (var symbol in symbols)
                         {
-                            staticSymbols.AddRange(semanticModel.LookupNamespacesAndTypes(position, name: parameter.Name));
+                            if (symbol is IParameterSymbol parameter && parameter.IsPrimaryConstructor(_cancellationToken))
+                            {
+                                staticSymbols.AddRange(semanticModel.LookupNamespacesAndTypes(position, name: parameter.Name));
+                            }
+                            else
+                            {
+                                staticSymbols.Add(symbol);
+                            }
                         }
-                        else
-                        {
-                            staticSymbols.Add(symbol);
-                        }
-                    }
 
-                    symbols = staticSymbols.ToImmutableAndClear();
+                        symbols = staticSymbols.ToImmutableAndClear();
+                    }
                 }
                 else
                 {

--- a/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationServiceRunner.cs
+++ b/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationServiceRunner.cs
@@ -406,17 +406,20 @@ internal partial class CSharpRecommendationService
 
                     // Primary constructor parameters are returned by LookupStaticMembers, but are unusable in a static
                     // context. They can hide a namespace or type with the same name, so recover those candidates.
-                    if (symbols.Any(s => s is IParameterSymbol parameter && parameter.IsPrimaryConstructor(_cancellationToken)))
+                    using var _ = ArrayBuilder<ISymbol>.GetInstance(symbols.Length, out var staticSymbols);
+                    foreach (var symbol in symbols)
                     {
-                        using var _ = ArrayBuilder<ISymbol>.GetInstance(out var namespaceOrTypeSymbols);
-                        foreach (var symbol in symbols)
+                        if (symbol is IParameterSymbol parameter && parameter.IsPrimaryConstructor(_cancellationToken))
                         {
-                            if (symbol is IParameterSymbol parameter && parameter.IsPrimaryConstructor(_cancellationToken))
-                                namespaceOrTypeSymbols.AddRange(semanticModel.LookupNamespacesAndTypes(position, name: parameter.Name));
+                            staticSymbols.AddRange(semanticModel.LookupNamespacesAndTypes(position, name: parameter.Name));
                         }
-
-                        symbols = [.. symbols, .. namespaceOrTypeSymbols];
+                        else
+                        {
+                            staticSymbols.Add(symbol);
+                        }
                     }
+
+                    symbols = staticSymbols.ToImmutableAndClear();
                 }
                 else
                 {


### PR DESCRIPTION
Fixes: #82750

Restores type suggestions hidden by same name primary constructor parameters in static contexts
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84753)