### PR TITLE
File-based apps: go-to-definition for `#:include`, `#:project`, and `#:ref` directives

### DIFF
--- a/src/LanguageServer/Protocol/Handler/Definitions/GoToDefinitionHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/Definitions/GoToDefinitionHandler.cs
@@ -4,11 +4,18 @@
 
 using System;
 using System.Composition;
+using System.IO;
+using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.MetadataAsSource;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
 using LSP = Roslyn.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler;
@@ -24,6 +31,135 @@ internal sealed class GoToDefinitionHandler : AbstractGoToDefinitionHandler
     {
     }
 
-    public override Task<LSP.Location[]?> HandleRequestAsync(LSP.TextDocumentPositionParams request, RequestContext context, CancellationToken cancellationToken)
-        => GetDefinitionAsync(request, forSymbolType: false, context, cancellationToken);
+    public override async Task<LSP.Location[]?> HandleRequestAsync(LSP.TextDocumentPositionParams request, RequestContext context, CancellationToken cancellationToken)
+    {
+        if (context.Document is { } document &&
+            await TryGetFileLevelDirectiveLocationAsync(document, request.Position, cancellationToken).ConfigureAwait(false) is { } location)
+        {
+            return [location];
+        }
+
+        return await GetDefinitionAsync(request, forSymbolType: false, context, cancellationToken).ConfigureAwait(false);
+    }
+
+    internal static async Task<LSP.Location?> TryGetFileLevelDirectiveLocationAsync(
+        Document document, LSP.Position position, CancellationToken cancellationToken)
+    {
+        if (document.Project.Language != LanguageNames.CSharp ||
+            document.FilePath is null ||
+            document.Project.ParseOptions?.Features.ContainsKey("FileBasedProgram") != true)
+        {
+            return null;
+        }
+
+        var sourceText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+        var absolutePosition = sourceText.Lines.GetPosition(ProtocolConversions.PositionToLinePosition(position));
+        var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        var token = root.FindToken(absolutePosition, findInsideTrivia: true);
+        if (token.Parent is not IgnoredDirectiveTriviaSyntax { Content.RawKind: (int)SyntaxKind.StringLiteralToken } directive)
+            return null;
+
+        var content = directive.Content;
+        var contentText = content.Text;
+        var directiveNameStart = SkipWhitespace(contentText, 0);
+        var directiveNameEnd = SkipNonWhitespace(contentText, directiveNameStart);
+        var pathStart = SkipWhitespace(contentText, directiveNameEnd);
+        var pathEnd = TrimTrailingWhitespace(contentText, pathStart);
+        if (pathStart == pathEnd)
+            return null;
+
+        var directiveName = contentText.AsSpan(directiveNameStart, directiveNameEnd - directiveNameStart);
+        var isProjectDirective = directiveName.SequenceEqual("project".AsSpan());
+        if (!isProjectDirective &&
+            !directiveName.SequenceEqual("ref".AsSpan()) &&
+            !directiveName.SequenceEqual("include".AsSpan()))
+        {
+            return null;
+        }
+
+        var pathSpan = TextSpan.FromBounds(content.SpanStart + pathStart, content.SpanStart + pathEnd);
+        if (absolutePosition < pathSpan.Start || absolutePosition > pathSpan.End)
+            return null;
+
+        var sourceDirectory = Path.GetDirectoryName(document.FilePath);
+        if (sourceDirectory is null)
+            return null;
+
+        try
+        {
+            var directivePath = contentText.Substring(pathStart, pathEnd - pathStart).Replace('\\', '/');
+            var combinedPath = Path.Combine(sourceDirectory, directivePath);
+            if (!PathUtilities.IsAbsolute(combinedPath))
+                return null;
+
+            var normalizedPath = Path.GetFullPath(combinedPath);
+
+            if (isProjectDirective && Directory.Exists(normalizedPath))
+            {
+                var projectFiles = new DirectoryInfo(normalizedPath).GetFiles("*proj");
+                if (projectFiles.Length != 1)
+                    return null;
+
+                normalizedPath = projectFiles[0].FullName;
+            }
+
+            if (!File.Exists(normalizedPath))
+                return null;
+
+            return new()
+            {
+                DocumentUri = ProtocolConversions.CreateAbsoluteDocumentUri(normalizedPath),
+                Range = new()
+                {
+                    Start = new(),
+                    End = new(),
+                },
+            };
+        }
+        catch (ArgumentException)
+        {
+            return null;
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+        catch (NotSupportedException)
+        {
+            return null;
+        }
+        catch (SecurityException)
+        {
+            return null;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return null;
+        }
+
+        static int SkipWhitespace(string text, int start)
+        {
+            while (start < text.Length && char.IsWhiteSpace(text[start]))
+                start++;
+
+            return start;
+        }
+
+        static int SkipNonWhitespace(string text, int start)
+        {
+            while (start < text.Length && !char.IsWhiteSpace(text[start]))
+                start++;
+
+            return start;
+        }
+
+        static int TrimTrailingWhitespace(string text, int start)
+        {
+            var end = text.Length;
+            while (end > start && char.IsWhiteSpace(text[end - 1]))
+                end--;
+
+            return end;
+        }
+    }
 }

--- a/src/LanguageServer/ProtocolUnitTests/Definitions/GoToDefinitionTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Definitions/GoToDefinitionTests.cs
@@ -4,12 +4,16 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Immutable;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.LanguageServer.Handler;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Text;
@@ -124,6 +128,387 @@ public sealed class GoToDefinitionTests : AbstractLanguageServerProtocolTests
 
         var results = await RunGotoDefinitionAsync(testLspServer, testLspServer.GetLocations("caret").Single());
         Assert.Empty(results);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestGotoDefinitionAsync_FileBasedProgramRefDirective(bool mutatingLspWorkspace)
+    {
+        using var tempRoot = new TempRoot();
+        var referencedFile = tempRoot.CreateFile(extension: ".cs", directory: TestWorkspace.RootDirectory);
+        var referencedFileName = Path.GetFileName(referencedFile.Path);
+        var markup =
+            $$"""
+            #:ref {{referencedFileName}}{|caret:|}
+            System.Console.WriteLine();
+            """;
+        await using var testLspServer = await CreateTestLspServerAsync(
+            markup,
+            mutatingLspWorkspace,
+            new InitializationOptions
+            {
+                ParseOptions = CSharpParseOptions.Default.WithFeatures([new("FileBasedProgram", "true")]),
+            });
+
+        var results = await RunGotoDefinitionAsync(testLspServer, testLspServer.GetLocations("caret").Single());
+
+        var result = Assert.Single(results);
+        Assert.Equal(ProtocolConversions.CreateAbsoluteDocumentUri(referencedFile.Path), result.DocumentUri);
+        Assert.Equal(new LSP.Position(), result.Range.Start);
+        Assert.Equal(new LSP.Position(), result.Range.End);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestGotoDefinitionAsync_FileBasedProgramIncludeDirective(bool mutatingLspWorkspace)
+    {
+        using var tempRoot = new TempRoot();
+        var includedFile = tempRoot.CreateFile(extension: ".cs", directory: TestWorkspace.RootDirectory);
+        var includedFileName = Path.GetFileName(includedFile.Path);
+        var markup =
+            $$"""
+            #:include {{includedFileName}}{|caret:|}
+            System.Console.WriteLine();
+            """;
+        await using var testLspServer = await CreateTestLspServerAsync(
+            markup,
+            mutatingLspWorkspace,
+            new InitializationOptions
+            {
+                ParseOptions = CSharpParseOptions.Default.WithFeatures([new("FileBasedProgram", "true")]),
+            });
+
+        var results = await RunGotoDefinitionAsync(testLspServer, testLspServer.GetLocations("caret").Single());
+
+        var result = Assert.Single(results);
+        Assert.Equal(ProtocolConversions.CreateAbsoluteDocumentUri(includedFile.Path), result.DocumentUri);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestGotoDefinitionAsync_FileBasedProgramIncludeDirectiveDirectory(bool mutatingLspWorkspace)
+    {
+        using var tempRoot = new TempRoot();
+        var includedDirectory = tempRoot.CreateDirectory();
+        var includedDirectoryName = Path.GetFileName(includedDirectory.Path);
+        var markup =
+            $$"""
+            #:include {|caret:|}{{includedDirectoryName}}
+            System.Console.WriteLine();
+            """;
+        await using var testLspServer = await CreateTestLspServerAsync(
+            markup,
+            mutatingLspWorkspace,
+            new InitializationOptions
+            {
+                ParseOptions = CSharpParseOptions.Default.WithFeatures([new("FileBasedProgram", "true")]),
+            });
+
+        var results = await RunGotoDefinitionAsync(testLspServer, testLspServer.GetLocations("caret").Single());
+
+        Assert.Empty(results);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestGotoDefinitionAsync_FileBasedProgramProjectDirectiveDirectory(bool mutatingLspWorkspace)
+    {
+        using var tempRoot = new TempRoot();
+        var projectDirectory = tempRoot.CreateDirectory();
+        var projectDirectoryName = Path.GetFileName(projectDirectory.Path);
+        var projectFile = tempRoot.CreateFile(extension: ".csproj", directory: projectDirectory.Path);
+        var markup =
+            $$"""
+            #:project {|caret:|}{{projectDirectoryName}}
+            System.Console.WriteLine();
+            """;
+        await using var testLspServer = await CreateTestLspServerAsync(
+            markup,
+            mutatingLspWorkspace,
+            new InitializationOptions
+            {
+                ParseOptions = CSharpParseOptions.Default.WithFeatures([new("FileBasedProgram", "true")]),
+            });
+
+        var results = await RunGotoDefinitionAsync(testLspServer, testLspServer.GetLocations("caret").Single());
+
+        var result = Assert.Single(results);
+        Assert.Equal(ProtocolConversions.CreateAbsoluteDocumentUri(projectFile.Path), result.DocumentUri);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestGotoDefinitionAsync_FileBasedProgramProjectDirectiveDirectoryWithMultipleProjects(bool mutatingLspWorkspace)
+    {
+        using var tempRoot = new TempRoot();
+        var projectDirectory = tempRoot.CreateDirectory();
+        var projectDirectoryName = Path.GetFileName(projectDirectory.Path);
+        tempRoot.CreateFile(extension: ".csproj", directory: projectDirectory.Path);
+        tempRoot.CreateFile(extension: ".csproj", directory: projectDirectory.Path);
+        var markup =
+            $$"""
+            #:project {|caret:|}{{projectDirectoryName}}
+            System.Console.WriteLine();
+            """;
+        await using var testLspServer = await CreateTestLspServerAsync(
+            markup,
+            mutatingLspWorkspace,
+            new InitializationOptions
+            {
+                ParseOptions = CSharpParseOptions.Default.WithFeatures([new("FileBasedProgram", "true")]),
+            });
+
+        var results = await RunGotoDefinitionAsync(testLspServer, testLspServer.GetLocations("caret").Single());
+
+        Assert.Empty(results);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestGotoDefinitionAsync_FileBasedProgramProjectDirectiveFile(bool mutatingLspWorkspace)
+    {
+        using var tempRoot = new TempRoot();
+        var projectFile = tempRoot.CreateFile(extension: ".csproj", directory: TestWorkspace.RootDirectory);
+        var projectFileName = Path.GetFileName(projectFile.Path);
+        var markup =
+            $$"""
+            #:project {|caret:|}{{projectFileName}}
+            System.Console.WriteLine();
+            """;
+        await using var testLspServer = await CreateTestLspServerAsync(
+            markup,
+            mutatingLspWorkspace,
+            new InitializationOptions
+            {
+                ParseOptions = CSharpParseOptions.Default.WithFeatures([new("FileBasedProgram", "true")]),
+            });
+
+        var results = await RunGotoDefinitionAsync(testLspServer, testLspServer.GetLocations("caret").Single());
+
+        var result = Assert.Single(results);
+        Assert.Equal(ProtocolConversions.CreateAbsoluteDocumentUri(projectFile.Path), result.DocumentUri);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestGotoDefinitionAsync_FileBasedProgramDirectiveRelativeToSourceDirectory(
+        [CombinatorialValues("project", "ref", "include")] string directiveName,
+        [CombinatorialValues("/", "\\")] string directorySeparator,
+        bool mutatingLspWorkspace)
+    {
+        using var tempRoot = new TempRoot();
+        var rootDirectory = tempRoot.CreateDirectory();
+        var sourceDirectory = Directory.CreateDirectory(Path.Combine(rootDirectory.Path, "App")).FullName;
+        var targetDirectory = Directory.CreateDirectory(Path.Combine(rootDirectory.Path, "Lib")).FullName;
+        var targetFile = tempRoot.CreateFile(
+            extension: directiveName == "project" ? ".csproj" : ".cs",
+            directory: targetDirectory);
+        var directivePath = directiveName == "project"
+            ? $"..{directorySeparator}Lib"
+            : $"..{directorySeparator}Lib{directorySeparator}{Path.GetFileName(targetFile.Path)}";
+        var directiveText = $"#:{directiveName} {directivePath}";
+        var sourceText = SourceText.From($"{directiveText}{Environment.NewLine}System.Console.WriteLine();");
+
+        await using var testLspServer = await CreateTestLspServerAsync(
+            "",
+            mutatingLspWorkspace,
+            new InitializationOptions
+            {
+                ParseOptions = CSharpParseOptions.Default.WithFeatures([new("FileBasedProgram", "true")]),
+            });
+
+        var document = testLspServer.GetCurrentSolution().Projects.Single().Documents.Single()
+            .WithFilePath(Path.Combine(sourceDirectory, "Program.cs"))
+            .WithText(sourceText);
+        var position = ProtocolConversions.LinePositionToPosition(
+            sourceText.Lines.GetLinePosition(directiveText.Length));
+
+        var location = await GoToDefinitionHandler.TryGetFileLevelDirectiveLocationAsync(
+            document, position, CancellationToken.None);
+
+        Assert.NotNull(location);
+        Assert.Equal(ProtocolConversions.CreateAbsoluteDocumentUri(targetFile.Path), location.DocumentUri);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestGotoDefinitionAsync_FileBasedProgramDirectiveWithDynamicPath(
+        [CombinatorialValues("project", "ref", "include")] string directiveName,
+        bool mutatingLspWorkspace)
+    {
+        // Currently do not support navigating to path which includes an msbuild variable.
+        using var tempRoot = new TempRoot();
+        var rootDirectory = tempRoot.CreateDirectory();
+        var sourceDirectory = Directory.CreateDirectory(Path.Combine(rootDirectory.Path, "App")).FullName;
+        var targetDirectory = Directory.CreateDirectory(Path.Combine(rootDirectory.Path, "Lib")).FullName;
+        var targetFile = tempRoot.CreateFile(
+            extension: directiveName == "project" ? ".csproj" : ".cs",
+            directory: directiveName == "include" ? sourceDirectory : targetDirectory);
+        var directivePath = directiveName switch
+        {
+            "project" => "$(MSBuildProjectDirectory)/../Lib",
+            "ref" => $"$(MSBuildProjectDirectory)/../Lib/{Path.GetFileName(targetFile.Path)}",
+            "include" => "*.cs",
+            _ => throw ExceptionUtilities.Unreachable(),
+        };
+        var directiveText = $"#:{directiveName} {directivePath}";
+        var sourceText = SourceText.From($"{directiveText}{Environment.NewLine}System.Console.WriteLine();");
+
+        await using var testLspServer = await CreateTestLspServerAsync(
+            "",
+            mutatingLspWorkspace,
+            new InitializationOptions
+            {
+                ParseOptions = CSharpParseOptions.Default.WithFeatures([new("FileBasedProgram", "true")]),
+            });
+
+        var document = testLspServer.GetCurrentSolution().Projects.Single().Documents.Single()
+            .WithFilePath(Path.Combine(sourceDirectory, "Program.cs"))
+            .WithText(sourceText);
+        var position = ProtocolConversions.LinePositionToPosition(
+            sourceText.Lines.GetLinePosition(directiveText.Length));
+
+        var location = await GoToDefinitionHandler.TryGetFileLevelDirectiveLocationAsync(
+            document, position, CancellationToken.None);
+
+        Assert.Null(location);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestGotoDefinitionAsync_FileBasedProgramDirectiveOutsidePath(bool mutatingLspWorkspace)
+    {
+        // Cannot navigate to the directive name, since it's not part of the path
+        var markup =
+            """
+            #:{|caret:project|} Library.csproj
+            System.Console.WriteLine();
+            """;
+        await using var testLspServer = await CreateTestLspServerAsync(
+            markup,
+            mutatingLspWorkspace,
+            new InitializationOptions
+            {
+                ParseOptions = CSharpParseOptions.Default.WithFeatures([new("FileBasedProgram", "true")]),
+            });
+
+        var results = await RunGotoDefinitionAsync(testLspServer, testLspServer.GetLocations("caret").Single());
+
+        Assert.Empty(results);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestGotoDefinitionAsync_FileBasedProgramDirectiveMissingTarget(bool mutatingLspWorkspace)
+    {
+        // Cannot navigate to the target if it doesn't exist on disk
+        var markup =
+            """
+            #:ref Missing{|caret:.|}cs
+            System.Console.WriteLine();
+            """;
+        await using var testLspServer = await CreateTestLspServerAsync(
+            markup,
+            mutatingLspWorkspace,
+            new InitializationOptions
+            {
+                ParseOptions = CSharpParseOptions.Default.WithFeatures([new("FileBasedProgram", "true")]),
+            });
+
+        var results = await RunGotoDefinitionAsync(testLspServer, testLspServer.GetLocations("caret").Single());
+
+        Assert.Empty(results);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestGotoDefinitionAsync_FileLevelDirectiveInProjectBasedProgram(bool mutatingLspWorkspace)
+    {
+        using var tempRoot = new TempRoot();
+        var referencedFile = tempRoot.CreateFile(extension: ".cs", directory: TestWorkspace.RootDirectory);
+        var referencedFileName = Path.GetFileName(referencedFile.Path);
+        var markup =
+            $$"""
+            #:ref {|caret:|}{{referencedFileName}}
+            class C;
+            """;
+        await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace);
+
+        var results = await RunGotoDefinitionAsync(testLspServer, testLspServer.GetLocations("caret").Single());
+
+        Assert.Empty(results);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestGotoDefinitionAsync_FileBasedProgramWithRelativeDocumentPath(bool mutatingLspWorkspace)
+    {
+        // Cannot navigate when the resolved path referenced by a directive is relative.
+        var markup =
+            """
+            #:ref {|caret:|}Util.cs
+            System.Console.WriteLine();
+            """;
+        await using var testLspServer = await CreateTestLspServerAsync(
+            markup,
+            mutatingLspWorkspace,
+            new InitializationOptions
+            {
+                ParseOptions = CSharpParseOptions.Default.WithFeatures([new("FileBasedProgram", "true")]),
+            });
+
+        var document = testLspServer.GetCurrentSolution().Projects.Single().Documents.Single()
+            .WithFilePath(Path.Combine("relative", "Program.cs"));
+        var location = await GoToDefinitionHandler.TryGetFileLevelDirectiveLocationAsync(
+            document, testLspServer.GetLocations("caret").Single().Range.Start, CancellationToken.None);
+
+        Assert.Null(location);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestGotoDefinitionAsync_FileBasedProgramWithRelativeDocumentPathAndAbsoluteDirectivePath(
+        [CombinatorialValues("project", "ref", "include")] string directiveName,
+        bool mutatingLspWorkspace)
+    {
+        using var tempRoot = new TempRoot();
+        var targetDirectory = tempRoot.CreateDirectory();
+        var targetFile = tempRoot.CreateFile(
+            extension: directiveName == "project" ? ".csproj" : ".cs",
+            directory: targetDirectory.Path);
+        var directivePath = directiveName == "project" ? targetDirectory.Path : targetFile.Path;
+        var markup = $"#:{directiveName} {{|caret:|}}{directivePath}{Environment.NewLine}System.Console.WriteLine();";
+
+        await using var testLspServer = await CreateTestLspServerAsync(
+            markup,
+            mutatingLspWorkspace,
+            new InitializationOptions
+            {
+                ParseOptions = CSharpParseOptions.Default.WithFeatures([new("FileBasedProgram", "true")]),
+            });
+
+        var document = testLspServer.GetCurrentSolution().Projects.Single().Documents.Single()
+            .WithFilePath(Path.Combine("relative", "Program.cs"));
+        var location = await GoToDefinitionHandler.TryGetFileLevelDirectiveLocationAsync(
+            document, testLspServer.GetLocations("caret").Single().Range.Start, CancellationToken.None);
+
+        Assert.NotNull(location);
+        Assert.Equal(ProtocolConversions.CreateAbsoluteDocumentUri(targetFile.Path), location.DocumentUri);
+    }
+
+    [ConditionalTheory(typeof(WindowsOnly)), CombinatorialData]
+    public async Task TestGotoDefinitionAsync_FileBasedProgramWithCurrentDriveRootedDirectivePath(bool mutatingLspWorkspace)
+    {
+        // Test a Windows path case where a path is rooted but not absolute, e.g. `\Path\To\File.cs`.
+        using var tempRoot = new TempRoot();
+        await using var testLspServer = await CreateTestLspServerAsync(
+            "",
+            mutatingLspWorkspace,
+            new InitializationOptions
+            {
+                ParseOptions = CSharpParseOptions.Default.WithFeatures([new("FileBasedProgram", "true")]),
+            });
+
+        var document = testLspServer.GetCurrentSolution().Projects.Single().Documents.Single();
+        var referencedFile = tempRoot.CreateFile(extension: ".cs", directory: TestWorkspace.RootDirectory);
+
+        var currentDriveRootedPath = referencedFile.Path[2..];
+        var sourceText = SourceText.From($"#:ref {currentDriveRootedPath}");
+        document = document.WithText(sourceText);
+        var position = ProtocolConversions.LinePositionToPosition(
+            sourceText.Lines.GetLinePosition(sourceText.Length));
+
+        var location = await GoToDefinitionHandler.TryGetFileLevelDirectiveLocationAsync(
+            document, position, CancellationToken.None);
+
+        Assert.Null(location);
     }
 
     [Theory, CombinatorialData, WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1264627")]


### PR DESCRIPTION
It seemed like it would be useful to be able to go-to-def on a file path within a directive like `#:include` and simply have the editor navigate to the file being referenced, where possible.

Possibly, 'go-to-definition' is an inappropriate mechanism for doing this. I would appreciate guidance from @dotnet/roslyn-ide about that.

I think test coverage for globs is missing. ~~This is only going to work when the file path denotes exactly one file, or, for a `#:project` referencing a folder containing a single project file.~~ It was pointed out we can just use multiple results. Clearly this supports that! Being able to F12 on a glob and see all the files it matched is gonna be kinda cool.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84756)