### PR TITLE
Remove the warning that a branch isn't -vs-deps

### DIFF
--- a/azure-pipelines-pr-validation.yml
+++ b/azure-pipelines-pr-validation.yml
@@ -177,7 +177,7 @@ extends:
           displayName: Setup branch for insertion validation
           inputs:
             filePath: 'eng\setup-pr-validation.ps1'
-            arguments: "-sourceBranchName $(SourceBranchName) -prNumber ${{ parameters.PRNumber }} -commitSHA ${{ parameters.CommitSHA }} -enforceLatestCommit ${{ iif(parameters.EnforceLatestCommit, '1', '0') }}"
+            arguments: "-prNumber ${{ parameters.PRNumber }} -commitSHA ${{ parameters.CommitSHA }} -enforceLatestCommit ${{ iif(parameters.EnforceLatestCommit, '1', '0') }}"
           condition: succeeded()
 
         - task: Powershell@2

--- a/eng/pipelines/test-gates/roslyn-vs-integration/stage.yml
+++ b/eng/pipelines/test-gates/roslyn-vs-integration/stage.yml
@@ -105,7 +105,7 @@ stages:
         displayName: Setup branch for validation
         inputs:
           filePath: 'eng\setup-pr-validation.ps1'
-          arguments: "-sourceBranchName $(Build.SourceBranch) -prNumber ${{ parameters.prNumber }} -commitSHA ${{ parameters.sha }} -enforceLatestCommit ${{ iif(parameters.EnforceLatestCommit, '1', '0') }}"
+          arguments: "-prNumber ${{ parameters.prNumber }} -commitSHA ${{ parameters.sha }} -enforceLatestCommit ${{ iif(parameters.EnforceLatestCommit, '1', '0') }}"
         condition: succeeded()
     - powershell: |
         git fetch origin ${{ parameters.testsCommitHash }}

--- a/eng/setup-pr-validation.ps1
+++ b/eng/setup-pr-validation.ps1
@@ -1,6 +1,5 @@
 [CmdletBinding(PositionalBinding=$false)]
 param (
-  [string]$sourceBranchName,
   [string]$prNumber,
   [string]$commitSHA,
   [boolean]$enforceLatestCommit)
@@ -9,10 +8,6 @@ try {
     # name and email are only used for merge commit, it doesn't really matter what we put in there.
     git config user.name "RoslynValidation"
     git config user.email "validation@roslyn.net"
-
-    if ($sourceBranchName -notlike '*-vs-deps') {
-      Write-Host  "##vso[task.LogIssue type=warning;]The base branch for insertion validation is $sourceBranchName, which is not a vs-deps branch."
-    }
 
     if ($commitSHA.Length -lt 7) {
       Write-Host "##vso[task.LogIssue type=error;]The PR Commit SHA must be at least 7 characters long."


### PR DESCRIPTION
We haven't had one in a while, so this warning can just be removed.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84773)