### PR TITLE
Unsafe evolution: fix name of ISymbol public API

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/PublicModel/PreprocessingSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PublicModel/PreprocessingSymbol.cs
@@ -127,7 +127,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.PublicModel
 
         bool ISymbol.IsImplicitlyDeclared => false;
 
-        bool ISymbol.RequiresUnsafe => false;
+        bool ISymbol.RequiresUnsafeContext => false;
 
         bool ISymbol.CanBeReferencedByName => SyntaxFacts.IsValidIdentifier(_name) && !SyntaxFacts.ContainsDroppedIdentifierCharacters(_name);
 

--- a/src/Compilers/CSharp/Portable/Symbols/PublicModel/Symbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PublicModel/Symbol.cs
@@ -246,7 +246,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.PublicModel
 
         bool ISymbol.IsImplicitlyDeclared => UnderlyingSymbol.IsImplicitlyDeclared;
 
-        bool ISymbol.RequiresUnsafe => UnderlyingSymbol.GetCallerUnsafeMode(ConsList<Symbols.FieldSymbol>.Empty) != CallerUnsafeMode.None;
+        bool ISymbol.RequiresUnsafeContext => UnderlyingSymbol.GetCallerUnsafeMode(ConsList<Symbols.FieldSymbol>.Empty) != CallerUnsafeMode.None;
 
         bool ISymbol.CanBeReferencedByName => UnderlyingSymbol.CanBeReferencedByName;
 

--- a/src/Compilers/CSharp/Test/CSharp15/UnsafeEvolutionTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/UnsafeEvolutionTests.cs
@@ -365,7 +365,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             Assert.True(symbolExpectedUnsafeMode == symbol.GetCallerUnsafeMode(ConsList<FieldSymbol>.Empty), $"Expected {symbol.GetType().Name} '{symbol.ToTestDisplayString()}' to have {nameof(CallerUnsafeMode)}.{symbolExpectedUnsafeMode} (got {symbol.GetCallerUnsafeMode(ConsList<FieldSymbol>.Empty)}).");
 
             var publicSymbol = symbol.GetPublicSymbol();
-            Assert.Equal(symbolExpectedUnsafeMode != CallerUnsafeMode.None, publicSymbol.RequiresUnsafe);
+            Assert.Equal(symbolExpectedUnsafeMode != CallerUnsafeMode.None, publicSymbol.RequiresUnsafeContext);
 
             var hasAttributeInGetAttributes = symbol.GetAttributes().Any(a => a.AttributeClass?.Name == Name);
             Assert.False(hasAttributeInGetAttributes,
@@ -15086,7 +15086,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
     }
 
     [Fact]
-    public void PublicApi_RequiresUnsafe()
+    public void PublicApi_RequiresUnsafeContext()
     {
         var source = """
             public unsafe class C
@@ -15108,20 +15108,20 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
             Diagnostic(ErrorCode.ERR_SafeModifierCannotBeUsedWithUnsafe, "safe").WithLocation(5, 12));
 
         var m1 = comp.GetMember<MethodSymbol>("C.M1").GetPublicSymbol();
-        Assert.True(m1.RequiresUnsafe);
+        Assert.True(m1.RequiresUnsafeContext);
 
         var m2 = comp.GetMember<MethodSymbol>("C.M2").GetPublicSymbol();
-        Assert.False(m2.RequiresUnsafe);
+        Assert.False(m2.RequiresUnsafeContext);
 
         var m3 = comp.GetMember<MethodSymbol>("C.M3").GetPublicSymbol();
-        Assert.True(m3.RequiresUnsafe);
+        Assert.True(m3.RequiresUnsafeContext);
 
         var m4 = comp.GetMember<MethodSymbol>("C.M4").GetPublicSymbol();
-        Assert.False(m4.RequiresUnsafe);
+        Assert.False(m4.RequiresUnsafeContext);
 
-        Assert.False(m1.ContainingAssembly.RequiresUnsafe);
-        Assert.False(m1.ContainingModule.RequiresUnsafe);
-        Assert.False(m1.ContainingType.RequiresUnsafe);
+        Assert.False(m1.ContainingAssembly.RequiresUnsafeContext);
+        Assert.False(m1.ContainingModule.RequiresUnsafeContext);
+        Assert.False(m1.ContainingType.RequiresUnsafeContext);
 
         // Module has no attributes since it is the source symbol.
         Assert.Empty(m1.ContainingModule.GetAttributes());
@@ -15130,7 +15130,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
     }
 
     [Fact]
-    public void PublicApi_RequiresUnsafe_CompatMode()
+    public void PublicApi_RequiresUnsafeContext_CompatMode()
     {
         var source = """
             public unsafe class C
@@ -15146,20 +15146,20 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
         comp.VerifyEmitDiagnostics();
 
         var m1 = comp.GetMember<MethodSymbol>("C.M1").GetPublicSymbol();
-        Assert.True(m1.RequiresUnsafe);
+        Assert.True(m1.RequiresUnsafeContext);
 
         var m2 = comp.GetMember<MethodSymbol>("C.M2").GetPublicSymbol();
-        Assert.False(m2.RequiresUnsafe);
+        Assert.False(m2.RequiresUnsafeContext);
 
         var m3 = comp.GetMember<MethodSymbol>("C.M3").GetPublicSymbol();
-        Assert.False(m3.RequiresUnsafe);
+        Assert.False(m3.RequiresUnsafeContext);
 
         var m4 = comp.GetMember<MethodSymbol>("C.M4").GetPublicSymbol();
-        Assert.True(m4.RequiresUnsafe);
+        Assert.True(m4.RequiresUnsafeContext);
 
-        Assert.False(m1.ContainingAssembly.RequiresUnsafe);
-        Assert.False(m1.ContainingModule.RequiresUnsafe);
-        Assert.False(m1.ContainingType.RequiresUnsafe);
+        Assert.False(m1.ContainingAssembly.RequiresUnsafeContext);
+        Assert.False(m1.ContainingModule.RequiresUnsafeContext);
+        Assert.False(m1.ContainingType.RequiresUnsafeContext);
 
         Assert.Empty(m1.ContainingModule.GetAttributes());
 
@@ -15167,7 +15167,7 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
     }
 
     [Theory, CombinatorialData]
-    public void PublicApi_RequiresUnsafe_VisualBasic(bool useMetadata)
+    public void PublicApi_RequiresUnsafeContext_VisualBasic(bool useMetadata)
     {
         var source = """
             Public Class C
@@ -15183,6 +15183,6 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
 
         comp.VerifyDiagnostics();
         var method = comp.GetTypeByMetadataName("C")!.GetMember("M");
-        Assert.False(method.RequiresUnsafe);
+        Assert.False(method.RequiresUnsafeContext);
     }
 }

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -6,7 +6,7 @@ Microsoft.CodeAnalysis.Text.SourceHashAlgorithm.Sha512 = 4 -> Microsoft.CodeAnal
 [RSEXPERIMENTAL006]Microsoft.CodeAnalysis.ClosedDerivedTypeInfo.IsComplete.get -> bool
 [RSEXPERIMENTAL006]Microsoft.CodeAnalysis.ITypeSymbol.GetClosedDerivedTypeInfo(System.Threading.CancellationToken cancellationToken) -> Microsoft.CodeAnalysis.ClosedDerivedTypeInfo
 [RSEXPERIMENTAL006]Microsoft.CodeAnalysis.ITypeSymbol.IsClosed.get -> bool
-[RSEXPERIMENTAL006]Microsoft.CodeAnalysis.ISymbol.RequiresUnsafe.get -> bool
+[RSEXPERIMENTAL006]Microsoft.CodeAnalysis.ISymbol.RequiresUnsafeContext.get -> bool
 [RSEXPERIMENTAL006]Microsoft.CodeAnalysis.OperationKind.CollectionExpressionElementsPlaceholder = 129 -> Microsoft.CodeAnalysis.OperationKind
 [RSEXPERIMENTAL006]Microsoft.CodeAnalysis.Operations.ICollectionExpressionOperation.ConstructArguments.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.IOperation!>
 [RSEXPERIMENTAL006]Microsoft.CodeAnalysis.Operations.ICollectionExpressionElementsPlaceholderOperation

--- a/src/Compilers/Core/Portable/Symbols/ISymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/ISymbol.cs
@@ -159,13 +159,12 @@ namespace Microsoft.CodeAnalysis
         bool IsImplicitlyDeclared { get; }
 
         /// <summary>
-        /// Whether this symbol is considered requires-<see langword="unsafe"/> under the updated memory safety rules,
-        /// i.e., the symbol requires an <see langword="unsafe"/> context at its use site.
+        /// Whether this symbol is considered requires-unsafe, i.e., the symbol requires an <see langword="unsafe"/> context at its use site.
         /// This can be either a symbol compiled with the updated memory safety rules which has <see langword="unsafe"/> in its signature,
         /// or a symbol compiled with the legacy memory safety rules which has pointers in its signature.
         /// </summary>
         [Experimental(RoslynExperiments.PreviewLanguageFeatureApi, UrlFormat = "https://github.com/dotnet/roslyn/issues/82789")]
-        bool RequiresUnsafe { get; }
+        bool RequiresUnsafeContext { get; }
 
         /// <summary>
         /// Returns true if this symbol can be referenced by its name in code.

--- a/src/Compilers/VisualBasic/Portable/Symbols/Symbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Symbol.vb
@@ -1335,7 +1335,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Get
         End Property
 
-        Private ReadOnly Property ISymbol_RequiresUnsafe As Boolean Implements ISymbol.RequiresUnsafe
+        Private ReadOnly Property ISymbol_RequiresUnsafeContext As Boolean Implements ISymbol.RequiresUnsafeContext
             Get
                 Return False
             End Get

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.AbstractWrappedSymbol.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.AbstractWrappedSymbol.cs
@@ -74,7 +74,7 @@ internal abstract partial class AbstractMetadataAsSourceService
 
         public bool HasUnsupportedMetadata => _symbol.HasUnsupportedMetadata;
 
-        public bool RequiresUnsafe => _symbol.RequiresUnsafe;
+        public bool RequiresUnsafeContext => _symbol.RequiresUnsafeContext;
 
         public void Accept(SymbolVisitor visitor)
             => _symbol.Accept(visitor);

--- a/src/Tools/SemanticSearch/ReferenceAssemblies/Apis/Microsoft.CodeAnalysis.txt
+++ b/src/Tools/SemanticSearch/ReferenceAssemblies/Apis/Microsoft.CodeAnalysis.txt
@@ -1451,7 +1451,7 @@ Microsoft.CodeAnalysis.ISymbol.get_MetadataName
 Microsoft.CodeAnalysis.ISymbol.get_MetadataToken
 Microsoft.CodeAnalysis.ISymbol.get_Name
 Microsoft.CodeAnalysis.ISymbol.get_OriginalDefinition
-Microsoft.CodeAnalysis.ISymbol.get_RequiresUnsafe
+Microsoft.CodeAnalysis.ISymbol.get_RequiresUnsafeContext
 Microsoft.CodeAnalysis.ISymbolExtensions
 Microsoft.CodeAnalysis.ISymbolExtensions.GetConstructedReducedFrom(Microsoft.CodeAnalysis.IMethodSymbol)
 Microsoft.CodeAnalysis.ISyntaxContextReceiver

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/Symbols/CodeGenerationSymbol.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/Symbols/CodeGenerationSymbol.cs
@@ -132,7 +132,7 @@ internal abstract class CodeGenerationSymbol : ISymbol
 
     // CA1822 suppression is needed until all projects using this file are updated to newest Roslyn which has this member on ISymbol.
 #pragma warning disable CA1822 // Mark members as static
-    public bool RequiresUnsafe => false;
+    public bool RequiresUnsafeContext => false;
 #pragma warning restore CA1822
 
     public bool CanBeReferencedByName => true;


### PR DESCRIPTION
Follow up on https://github.com/dotnet/roslyn/pull/84674 where I accidentally implemented the API under the originally proposed name instead of the actually approved name.
Public API issue: https://github.com/dotnet/roslyn/issues/82791
Test plan: https://github.com/dotnet/roslyn/issues/81207
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84784)