### PR TITLE
Support loading cached project data from .lscache files

### DIFF
--- a/Roslyn.slnx
+++ b/Roslyn.slnx
@@ -426,6 +426,11 @@
     <Project Path="src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/VisualBasicWorkspaceExtensions.shproj" />
   </Folder>
   <Project Path="src/Deployment/RoslynDeployment.csproj" />
+  <Folder Name="/LanguageServer/ProjectData/">
+    <Project Path="src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Generators/Microsoft.NET.ProjectData.Generators.csproj" />
+    <Project Path="src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Tests/Microsoft.NET.ProjectData.Tests.csproj" />
+    <Project Path="src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/Microsoft.NET.ProjectData.csproj" />
+  </Folder>
   <Folder Name="/Razor/" />
   <Folder Name="/Razor/benchmarks/">
     <Project Path="src/Razor/src/Compiler/perf/Microbenchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks.Compiler.csproj" />

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectLoader.cs
@@ -252,6 +252,9 @@ internal abstract class LanguageServerProjectLoader : IDisposable
     protected abstract Task<RemoteProjectLoadResult?> TryLoadProjectInMSBuildHostAsync(
         BuildHostProcessManager buildHostProcessManager, string projectPath, CancellationToken cancellationToken);
 
+    protected virtual async Task<(ImmutableArray<ProjectFileInfo>, ProjectSystemProjectFactory)?> TryLoadProjectFromCacheAsync(string projectPath, CancellationToken cancellationToken)
+        => null;
+
     /// <returns>The project file path that needs a NuGet restore, if any.</returns>
     private async Task<string?> ReloadProjectAsync(ProjectToLoad projectToLoad, ToastErrorReporter toastErrorReporter, BuildHostProcessManager buildHostProcessManager, CancellationToken cancellationToken)
     {
@@ -311,19 +314,24 @@ internal abstract class LanguageServerProjectLoader : IDisposable
             using (await _gate.DisposableWaitAsync(cancellationToken))
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                if (!_loadedProjects.TryGetValue(projectPath, out var currentLoadState))
+                if (!_loadedProjects.TryGetValue(projectPath, out var startingLoadState))
                 {
                     // Project was unloaded. Do not proceed with reloading it.
                     return null;
                 }
 
-                var previousProjectTargets = currentLoadState is ProjectLoadState.LoadedTargets loaded ? loaded.LoadedProjectTargets : [];
-                var newProjectTargetsBuilder = ArrayBuilder<LoadedProject>.GetInstance(loadedProjectInfos.Length);
+                if (startingLoadState is ProjectLoadState.Primordial)
+                {
+                    // Transition from Primordial to LoadedTargets state, so that we can add real targets to it.
+                    _loadedProjects[projectPath] = new ProjectLoadState.LoadedTargets(LoadedProjectTargets: []);
+                }
+
+                var currentTargets = ArrayBuilder<LoadedProject>.GetInstance(loadedProjectInfos.Length);
+
                 foreach (var loadedProjectInfo in loadedProjectInfos)
                 {
-                    var (target, targetAlreadyExists) = await GetOrCreateProjectTargetAsync(previousProjectTargets, projectFactory, loadedProjectInfo);
-                    newProjectTargetsBuilder.Add(target);
-
+                    var (target, targetAlreadyExists) = await GetOrCreateProjectTargetAsync(projectToLoad, projectFactory, loadedProjectInfo, cancellationToken);
+                    currentTargets.Add(target);
                     var (outputKind, metadataReferences, targetNeedsRestore) = await target.UpdateWithNewProjectInfoAsync(loadedProjectInfo, isMiscellaneousFile, remoteProjectLoadResult.HasAllInformation, _logger);
                     if (targetNeedsRestore)
                     {
@@ -345,14 +353,13 @@ internal abstract class LanguageServerProjectLoader : IDisposable
                     }
                 }
 
-                var newProjectTargets = newProjectTargetsBuilder.ToImmutableAndFree();
-                foreach (var target in previousProjectTargets)
+                // If this wasn't our first time loading, we might have old projects we can unload
+                if (startingLoadState is ProjectLoadState.LoadedTargets startingLoadedTargets)
                 {
-                    // Unload targets which were present in a past design-time build, but absent in the current one.
-                    if (!newProjectTargets.Contains(target))
-                    {
-                        target.Dispose();
-                    }
+                    foreach (var staleTarget in startingLoadedTargets.LoadedProjectTargets.Except(currentTargets))
+                        staleTarget.Dispose();
+
+                    _loadedProjects[projectPath] = new ProjectLoadState.LoadedTargets(LoadedProjectTargets: currentTargets.ToImmutableAndFree());
                 }
 
                 if (projectToLoad.ReportTelemetry)
@@ -360,19 +367,13 @@ internal abstract class LanguageServerProjectLoader : IDisposable
                     await _projectLoadTelemetryReporter.ReportProjectLoadTelemetryAsync(telemetryInfos, projectToLoad, cancellationToken);
                 }
 
-                if (currentLoadState is ProjectLoadState.Primordial primordial)
+                if (startingLoadState is ProjectLoadState.Primordial primordial)
                 {
                     // Remove the primordial project from the workspace now that the design-time build has produced real targets.
                     await primordial.PrimordialProjectFactory.ApplyChangeToWorkspaceAsync(
                         workspace => workspace.OnProjectRemoved(primordial.PrimordialProjectId),
                         cancellationToken);
                 }
-
-                // At this point we expect that all the loaded projects are now in the project factory returned, and any previous ones have been removed.
-                // this is a Debug.Assert() because if this expectation fails, the user's probably still in a state where things will work just fine;
-                // throwing here would mean we don't remember the LoadedProjects we created, and the next update will create more and things will get really broken.
-                Debug.Assert(newProjectTargets.All(target => target.ProjectFactory == projectFactory));
-                _loadedProjects[projectPath] = new ProjectLoadState.LoadedTargets(newProjectTargets);
             }
 
             if (diagnosticLogItems.Any())
@@ -394,39 +395,6 @@ internal abstract class LanguageServerProjectLoader : IDisposable
             await LogDiagnosticsAsync([diagnosticLogItem]);
 
             return null;
-        }
-
-        async Task<(LoadedProject, bool alreadyExists)> GetOrCreateProjectTargetAsync(ImmutableArray<LoadedProject> previousProjectTargets, ProjectSystemProjectFactory projectFactory, ProjectFileInfo loadedProjectInfo)
-        {
-            var existingProject = previousProjectTargets.FirstOrDefault(p => p.GetTargetFramework() == loadedProjectInfo.TargetFramework && p.ProjectFactory == projectFactory);
-            if (existingProject != null)
-            {
-                return (existingProject, alreadyExists: true);
-            }
-
-            var targetFramework = loadedProjectInfo.TargetFramework;
-            var projectSystemName = targetFramework is null ? projectPath : $"{projectPath} (${targetFramework})";
-
-            var projectCreationInfo = new ProjectSystemProjectCreationInfo
-            {
-                AssemblyName = projectSystemName,
-                // Note: the project file might be for a virtual file that doesn't exist on disk.
-                // In this case, we don't want to pass its path through here, as this will result in trying to take file system timestamps for it, watch it for changes, etc.
-                FilePath = PathUtilities.IsAbsolute(projectPath) && File.Exists(projectPath) ? projectPath : null,
-                CompilationOutputAssemblyFilePath = loadedProjectInfo.IntermediateOutputFilePath,
-            };
-
-            var projectSystemProject = await projectFactory.CreateAndAddToWorkspaceAsync(
-                projectSystemName,
-                loadedProjectInfo.Language,
-                projectCreationInfo,
-                _workspaceFactory.ProjectSystemHostInfo,
-                cancellationToken).ConfigureAwait(false);
-
-            var loadedProject = new LoadedProject(projectSystemProject, projectFactory, _fileChangeWatcher, _projectTargetFrameworkManager);
-            loadedProject.NeedsReload += (_, _) =>
-                _projectsToReload.AddWork(projectToLoad with { ReportTelemetry = false, ProgressTracker = null });
-            return (loadedProject, alreadyExists: false);
         }
 
         async Task LogDiagnosticsAsync(ImmutableArray<DiagnosticLogItem> diagnosticLogItems)
@@ -498,11 +466,54 @@ internal abstract class LanguageServerProjectLoader : IDisposable
         }
     }
 
+    private async Task<(LoadedProject, bool alreadyExists)> GetOrCreateProjectTargetAsync(ProjectToLoad projectToLoad, ProjectSystemProjectFactory projectFactory, ProjectFileInfo loadedProjectInfo, CancellationToken cancellationToken)
+    {
+        var projectPath = projectToLoad.Path;
+        Contract.ThrowIfFalse(_loadedProjects.TryGetValue(projectPath, out var projectLoadState), $"We should already have had a state before calling {nameof(GetOrCreateProjectTargetAsync)}");
+        Contract.ThrowIfFalse(projectLoadState is ProjectLoadState.LoadedTargets, "We should already have transitioned this to ProjectLoadState.LoadedTargets since we're creating real projects.");
+
+        var existingProjects = ((ProjectLoadState.LoadedTargets)projectLoadState).LoadedProjectTargets;
+
+        var existingProject = existingProjects.FirstOrDefault(p => p.GetTargetFramework() == loadedProjectInfo.TargetFramework && p.ProjectFactory == projectFactory);
+        if (existingProject != null)
+        {
+            return (existingProject, alreadyExists: true);
+        }
+
+        var targetFramework = loadedProjectInfo.TargetFramework;
+        var projectSystemName = targetFramework is null ? projectPath : $"{projectPath} (${targetFramework})";
+
+        var projectCreationInfo = new ProjectSystemProjectCreationInfo
+        {
+            AssemblyName = projectSystemName,
+            // Note: the project file might be for a virtual file that doesn't exist on disk.
+            // In this case, we don't want to pass its path through here, as this will result in trying to take file system timestamps for it, watch it for changes, etc.
+            FilePath = PathUtilities.IsAbsolute(projectPath) && File.Exists(projectPath) ? projectPath : null,
+            CompilationOutputAssemblyFilePath = loadedProjectInfo.IntermediateOutputFilePath,
+        };
+
+        var projectSystemProject = await projectFactory.CreateAndAddToWorkspaceAsync(
+            projectSystemName,
+            loadedProjectInfo.Language,
+            projectCreationInfo,
+            _workspaceFactory.ProjectSystemHostInfo,
+            cancellationToken).ConfigureAwait(false);
+
+        var loadedProject = new LoadedProject(projectSystemProject, projectFactory, _fileChangeWatcher, _projectTargetFrameworkManager);
+        loadedProject.NeedsReload += (_, _) =>
+            _projectsToReload.AddWork(projectToLoad with { ReportTelemetry = false, ProgressTracker = null });
+
+        _loadedProjects[projectPath] = new ProjectLoadState.LoadedTargets(existingProjects.Add(loadedProject));
+        return (loadedProject, alreadyExists: false);
+    }
+
     /// <summary>
     /// Begins loading a project. If the project has already begun loading, returns without doing any additional work.
     /// </summary>
     protected async Task BeginLoadingProjectAsync(string projectPath, string? projectGuid, WorkDoneProgressTracker? progressTracker = null)
     {
+        var projectToLoad = new ProjectToLoad(Path: projectPath, ProjectGuid: projectGuid, ReportTelemetry: true, ProgressTracker: progressTracker);
+
         using (await _gate.DisposableWaitAsync(CancellationToken.None))
         {
             Contract.ThrowIfTrue(_isDisposed, "Project loader is already disposed");
@@ -514,7 +525,41 @@ internal abstract class LanguageServerProjectLoader : IDisposable
             }
 
             _loadedProjects.Add(projectPath, new ProjectLoadState.LoadedTargets(LoadedProjectTargets: []));
-            _projectsToReload.AddWork(new ProjectToLoad(Path: projectPath, ProjectGuid: projectGuid, ReportTelemetry: true, ProgressTracker: progressTracker));
+            _projectsToReload.AddWork(projectToLoad);
+        }
+
+        // Try to load the contents from the project cache if we have one; we'll do this outside the lock
+        try
+        {
+            var cachedProjectStateAndFactory = await TryLoadProjectFromCacheAsync(projectPath, CancellationToken.None);
+
+            if (cachedProjectStateAndFactory is not null)
+            {
+                var (cachedProjectState, projectFactory) = cachedProjectStateAndFactory.Value;
+
+                // We've loaded state, so acquire the lock again
+                using (await _gate.DisposableWaitAsync(CancellationToken.None))
+                {
+                    if (_isDisposed)
+                        return;
+
+                    // We will only apply the cached data if we still haven't loaded anything for this project
+                    if (_loadedProjects.TryGetValue(projectPath, out var loadState) && loadState is ProjectLoadState.LoadedTargets { LoadedProjectTargets: [] })
+                    {
+                        foreach (var cachedProject in cachedProjectState)
+                        {
+                            (var loadedProject, bool alreadyLoaded) = await GetOrCreateProjectTargetAsync(projectToLoad, projectFactory, cachedProject, CancellationToken.None);
+                            await loadedProject.UpdateWithNewProjectInfoAsync(cachedProject, isMiscellaneousFile: false, hasAllInformation: true, _logger);
+                        }
+
+                        _logger.LogInformation("Loaded {ProjectPath} from the cache.", projectPath);
+                    }
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            _logger.LogWarning(e, "Exception encountered while trying to load cached state for {ProjectPath}", projectPath);
         }
     }
 

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectSystem.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectSystem.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Workspaces.ProjectSystem;
 using Microsoft.CommonLanguageServerProtocol.Framework;
 using Microsoft.Extensions.Logging;
+using Microsoft.NET.ProjectData;
 using Roslyn.Utilities;
 using LSP = Roslyn.LanguageServer.Protocol;
 
@@ -188,5 +189,60 @@ internal sealed class LanguageServerProjectSystem : LanguageServerProjectLoader,
             PreferredBuildHostKind = preferredBuildHostKind,
             ActualBuildHostKind = actualBuildHostKind
         };
+    }
+
+    protected override async Task<(ImmutableArray<ProjectFileInfo>, ProjectSystemProjectFactory)?> TryLoadProjectFromCacheAsync(string projectPath, CancellationToken cancellationToken)
+    {
+        if (!_projectFileExtensionRegistry.TryGetLanguageNameFromProjectPath(projectPath, DiagnosticReportingMode.Ignore, out var languageName))
+            return null;
+
+        var projectSnapshots = await CacheFileReader.ReadProjectDataSnapshotsAsync(
+            projectPath, cacheInProject: false, solutionPath: _hostProjectFactory.SolutionPath, cancellationToken: cancellationToken);
+
+        if (projectSnapshots.IsEmpty)
+            return null;
+
+        return (projectSnapshots.SelectAsArray(snapshot =>
+        {
+            return new ProjectFileInfo
+            {
+                IsEmpty = false,
+                Language = languageName,
+                FilePath = snapshot.ProjectPath,
+                OutputFilePath = snapshot.Properties["TargetPath"],
+                OutputRefFilePath = snapshot.Properties["TargetRefPath"],
+                IntermediateOutputFilePath = snapshot.Properties["IntermediateAssembly"],
+                GeneratedFilesOutputDirectory = snapshot.Properties["CompilerGeneratedFilesOutputPath"],
+                DefaultNamespace = snapshot.Properties["RootNamespace"],
+                TargetFramework = snapshot.Properties["TargetFramework"],
+                TargetFrameworkIdentifier = snapshot.Properties["TargetFrameworkIdentifier"],
+                TargetFrameworkVersion = snapshot.Properties["TargetFrameworkVersion"],
+                ProjectAssetsFilePath = snapshot.Properties["ProjectAssetsFile"],
+                CommandLineArgs = GetItems("CommandLineArgument").Select(static item => item.ItemSpec).ToArray(),
+                Documents = GetItems("Compile").Select(CreateDocumentFileInfo).ToArray(),
+                AdditionalDocuments = GetItems("AdditionalFile").Select(CreateDocumentFileInfo).ToArray(),
+                AnalyzerConfigDocuments = GetItems("AnalyzerConfigFile").Select(CreateDocumentFileInfo).ToArray(),
+                ProjectReferences = GetItems("ProjectReference").Select(item =>
+                    new ProjectFileReference(item.ItemSpec, GetAliases(item), referenceOutputAssembly: true)).ToArray(),
+                MetadataReferences = GetItems("MetadataReference").Select(item =>
+                    new MetadataReferenceItem(item.ItemSpec, GetAliases(item))).ToArray(),
+                ProjectCapabilities = [.. snapshot.Capabilities],
+                ContentFilePaths = [],
+                PackageReferences = [],
+                FileGlobs = [],
+            };
+
+            ImmutableArray<ProjectDataItem> GetItems(string itemType)
+                => snapshot.ItemsByType.TryGetValue(itemType, out var items) ? items : [];
+
+            static DocumentFileInfo CreateDocumentFileInfo(ProjectDataItem item)
+            {
+                var link = item.Metadata["Link"];
+                return new DocumentFileInfo(item.ItemSpec, link ?? item.ItemSpec, isLinked: link is not null, isGenerated: false, folders: []);
+            }
+
+            static string[] GetAliases(ProjectDataItem item)
+                => item.Metadata["aliases"] is string aliases ? aliases.Split(',') : [];
+        }), _hostProjectFactory);
     }
 }

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
@@ -62,6 +62,7 @@
     <!-- An extern alias is necessary to prevent ambiguity between shared projects linked to both Workspace and BuildHost -->
     <ProjectReference Include="..\..\Workspaces\MSBuild\Core\Microsoft.CodeAnalysis.Workspaces.MSBuild.csproj" Aliases="MSBuildWorkspaces" />
     <ProjectReference Include="..\..\Workspaces\MSBuild\Contracts\Microsoft.CodeAnalysis.Workspaces.MSBuild.Contracts.csproj" Aliases="MSBuildWorkspacesContracts" />
+    <ProjectReference Include="..\ProjectData\Microsoft.NET.ProjectData\Microsoft.NET.ProjectData.csproj" />
 
     <ProjectReference Include="..\Protocol\Microsoft.CodeAnalysis.LanguageServer.Protocol.csproj" />
 

--- a/src/LanguageServer/ProjectData/.editorconfig
+++ b/src/LanguageServer/ProjectData/.editorconfig
@@ -1,5 +1,7 @@
 [*.cs]
 
+indent_style = tab
+
 # CS1591: Missing XML comment for publicly visible type or member
 dotnet_diagnostic.CS1591.severity = none
 

--- a/src/LanguageServer/ProjectData/.editorconfig
+++ b/src/LanguageServer/ProjectData/.editorconfig
@@ -1,0 +1,7 @@
+[*.cs]
+
+# CS1591: Missing XML comment for publicly visible type or member
+dotnet_diagnostic.CS1591.severity = none
+
+# VSTHRD012: Provide JoinableTaskFactory where allowed
+dotnet_diagnostic.VSTHRD012.severity = none

--- a/src/LanguageServer/ProjectData/AssemblyInfo.cs
+++ b/src/LanguageServer/ProjectData/AssemblyInfo.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Runtime.InteropServices;
 

--- a/src/LanguageServer/ProjectData/AssemblyInfo.cs
+++ b/src/LanguageServer/ProjectData/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System.Runtime.InteropServices;
+
+[assembly: DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]

--- a/src/LanguageServer/ProjectData/BannedSymbols.txt
+++ b/src/LanguageServer/ProjectData/BannedSymbols.txt
@@ -1,0 +1,23 @@
+# Banned MessagePack APIs.
+# Use [DataContract] with [DataMember] for serialization contracts instead.
+T:MessagePack.MessagePackObjectAttribute;Use [DataContract] with [DataMember] instead
+T:MessagePack.Resolvers.StandardResolverAllowPrivate;Uses Reflection.Emit — not AOT-compatible
+T:MessagePack.Resolvers.DynamicObjectResolverAllowPrivate;Uses Reflection.Emit — not AOT-compatible
+# Banned descriptor APIs — use ServiceJsonRpcPolyTypeDescriptor via ServiceRpcDescriptorUtility instead.
+T:StreamJsonRpc.ServiceJsonRpcDescriptor;Not AOT-compatible — uses Reflection.Emit for proxy generation. Subclass ServiceJsonRpcPolyTypeDescriptor instead, or use ServiceRpcDescriptorUtility.CreateDescriptor
+P:StreamJsonRpc.MessagePackFormatter.DefaultUserDataSerializationOptions;Not AOT-compatible — uses dynamic code. Use NerdbankMessagePackFormatter via ServiceJsonRpcPolyTypeDescriptor instead
+# Banned TraceSource APIs — use Logger instead.
+M:System.Diagnostics.TraceSource.TraceInformation(System.String);Use logger.Info?.Trace() instead
+M:System.Diagnostics.TraceSource.TraceInformation(System.String,System.Object[]);Use logger.Info?.Trace() instead
+# Banned MEF import options — all imports are statically satisfied by the source-generated composition.
+P:System.ComponentModel.Composition.ImportAttribute.AllowDefault;All imports are statically satisfied by the source-generated composition — use non-nullable parameter types instead
+# Banned Newtonsoft.Json APIs — the server is published as NativeAOT, which disables
+# reflection-based serialization. Use System.Text.Json with [JsonPropertyName] and
+# source-generated JsonSerializerContext instead.
+N:Newtonsoft.Json;Use System.Text.Json with [JsonPropertyName] and source-generated JsonSerializerContext instead (NativeAOT compatibility)
+N:Newtonsoft.Json.Linq;Use System.Text.Json instead (NativeAOT compatibility)
+N:Newtonsoft.Json.Serialization;Use System.Text.Json instead (NativeAOT compatibility)
+N:Newtonsoft.Json.Converters;Use System.Text.Json instead (NativeAOT compatibility)
+
+
+

--- a/src/LanguageServer/ProjectData/BannedSymbols.txt
+++ b/src/LanguageServer/ProjectData/BannedSymbols.txt
@@ -1,4 +1,5 @@
-# Banned MessagePack APIs.
+
+# Banned MessagePack APIs.
 # Use [DataContract] with [DataMember] for serialization contracts instead.
 T:MessagePack.MessagePackObjectAttribute;Use [DataContract] with [DataMember] instead
 T:MessagePack.Resolvers.StandardResolverAllowPrivate;Uses Reflection.Emit — not AOT-compatible

--- a/src/LanguageServer/ProjectData/Directory.Build.props
+++ b/src/LanguageServer/ProjectData/Directory.Build.props
@@ -15,4 +15,8 @@
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove($(MSBuildThisFile), $(MSBuildThisFileDirectory)..))" />
 
+  <PropertyGroup>
+    <TargetFramework>$(NetVSCode)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
 </Project>

--- a/src/LanguageServer/ProjectData/Directory.Build.props
+++ b/src/LanguageServer/ProjectData/Directory.Build.props
@@ -1,0 +1,18 @@
+<Project>
+
+  <!-- Include and reference README in nuget package, if a README is in the project directory. -->
+  <PropertyGroup>
+    <PackageReadmeFile Condition="Exists('README.md')">README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Condition="Exists('README.md')" Include="README.md" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="CSDevKit.Tests" Key="$(VsPublicKey)" />
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove($(MSBuildThisFile), $(MSBuildThisFileDirectory)..))" />
+
+</Project>

--- a/src/LanguageServer/ProjectData/Directory.Build.targets
+++ b/src/LanguageServer/ProjectData/Directory.Build.targets
@@ -1,0 +1,16 @@
+<Project>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)AssemblyInfo.cs" Condition=" '$(Language)'=='C#' " />
+    <Compile Include="$(MSBuildThisFileDirectory)AssemblyInfo.vb" Condition=" '$(Language)'=='VB' " />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" PrivateAssets="all" />
+  </ItemGroup>
+  <ItemGroup>
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)BannedSymbols.txt" Condition="!Exists('BannedSymbols.txt')" />
+    <AdditionalFiles Include="BannedSymbols.txt" Condition="Exists('BannedSymbols.txt')" />
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove($(MSBuildThisFile), $(MSBuildThisFileDirectory)..))" />
+</Project>

--- a/src/LanguageServer/ProjectData/Directory.Build.targets
+++ b/src/LanguageServer/ProjectData/Directory.Build.targets
@@ -5,9 +5,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" PrivateAssets="all" />
-  </ItemGroup>
-  <ItemGroup>
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)BannedSymbols.txt" Condition="!Exists('BannedSymbols.txt')" />
     <AdditionalFiles Include="BannedSymbols.txt" Condition="Exists('BannedSymbols.txt')" />
   </ItemGroup>

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Generators.Tests/DataModelSchemaGeneratorTests.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Generators.Tests/DataModelSchemaGeneratorTests.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
+using Xunit;
+
+namespace Microsoft.NET.ProjectData.Generators.Tests;
+
+public sealed class DataModelSchemaGeneratorTests
+{
+	[Fact]
+	public void DataModelSchemaGenerator_EmitsSha256SourceHashes()
+	{
+		CSharpCompilation compilation = CSharpCompilation.Create(
+			"Microsoft.NET.ProjectData.Tasks",
+			references: GetReferences(),
+			options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+		DataModelSchemaGenerator generator = new();
+		GeneratorDriver driver = CSharpGeneratorDriver.Create(generator)
+			.AddAdditionalTexts([new TestAdditionalText("project-data-schema.json", """
+				{
+				  "properties": {
+				    "required": [
+				      { "name": "ProjectPath", "description": "Project path." }
+				    ],
+				    "optional": [
+				      { "name": "TargetFramework", "description": "Target framework." }
+				    ]
+				  },
+				  "items": {
+				    "Compile": {
+				      "description": "Compile items.",
+				      "required": true,
+				      "metadata": [ "fullPath" ]
+				    }
+				  },
+				  "cacheFormat": {
+				    "versionHeader": "version=2",
+				    "hashHeaderPrefix": "hash=",
+				    "sliceSeparator": "---",
+				    "sectionOpen": "[",
+				    "sectionClose": "]",
+				    "commentChar": "#",
+				    "projectHeaderPrefix": "project=",
+				    "languagePrefix": "language=",
+				    "primaryMarker": "primary",
+				    "lastDtbSucceededMarker": "lastDtbSucceeded",
+				    "sections": [
+				      { "name": "project", "description": "Project header." }
+				    ]
+				  },
+				  "pathSentinels": {
+				    "path": "<PATH>"
+				  }
+				}
+				""")]);
+
+		driver = driver.RunGenerators(compilation, TestContext.Current.CancellationToken);
+		GeneratorRunResult result = Assert.Single(driver.GetRunResult().Results);
+
+		Assert.NotEmpty(result.GeneratedSources);
+		Assert.All(result.GeneratedSources, static source => Assert.Equal(SourceHashAlgorithm.Sha256, source.SourceText.ChecksumAlgorithm));
+	}
+
+	private static IEnumerable<MetadataReference> GetReferences()
+	{
+		string trustedPlatformAssemblies = (string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") ?? string.Empty;
+		return trustedPlatformAssemblies
+			.Split(Path.PathSeparator)
+			.Where(static path => !string.IsNullOrWhiteSpace(path))
+			.Select(static path => MetadataReference.CreateFromFile(path));
+	}
+
+	private sealed class TestAdditionalText(string path, string text) : AdditionalText
+	{
+		public override string Path { get; } = path;
+
+		public override SourceText GetText(CancellationToken cancellationToken = default)
+			=> SourceText.From(text);
+	}
+}

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Generators.Tests/DataModelSchemaGeneratorTests.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Generators.Tests/DataModelSchemaGeneratorTests.cs
@@ -57,7 +57,8 @@ public sealed class DataModelSchemaGeneratorTests
 				}
 				""")]);
 
-		driver = driver.RunGenerators(compilation, TestContext.Current.CancellationToken);
+		// Roslyn is still on xunit v2, so must CancellationToken.None instead of the TestContext's CancellationToken
+		driver = driver.RunGenerators(compilation, CancellationToken.None);
 		GeneratorRunResult result = Assert.Single(driver.GetRunResult().Results);
 
 		Assert.NotEmpty(result.GeneratedSources);

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Generators.Tests/Microsoft.NET.ProjectData.Generators.Tests.csproj
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Generators.Tests/Microsoft.NET.ProjectData.Generators.Tests.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <!-- Roslyn expects all unit test projects end with "UnitTests" -->
+    <AssemblyName>Microsoft.NET.ProjectData.Generators.UnitTests</AssemblyName>
     <RootNamespace>Microsoft.NET.ProjectData.Generators.Tests</RootNamespace>
     <IsPackable>false</IsPackable>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
@@ -9,14 +11,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Microsoft.NET.ProjectData.Generators\Microsoft.NET.ProjectData.Generators.csproj" />
+    <ProjectReference Include="..\Microsoft.NET.ProjectData.Generators\Microsoft.NET.ProjectData.Generators.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit.v3" />
-    <PackageReference Include="xunit.runner.visualstudio" />
+    <ProjectReference Include="..\..\..\Compilers\Test\Core\Microsoft.CodeAnalysis.Test.Utilities.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Generators.Tests/Microsoft.NET.ProjectData.Generators.Tests.csproj
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Generators.Tests/Microsoft.NET.ProjectData.Generators.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Microsoft.NET.ProjectData.Generators.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.NET.ProjectData.Generators\Microsoft.NET.ProjectData.Generators.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+</Project>

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Generators/DataModelSchemaGenerator.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Generators/DataModelSchemaGenerator.cs
@@ -1,0 +1,470 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System.Collections.Immutable;
+using System.Text;
+using System.Text.Json;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.NET.ProjectData.Generators;
+
+/// <summary>
+/// Reads <c>project-data-schema.json</c> and generates strongly-typed constants
+/// and accessors for the Data Model schema.
+/// </summary>
+[Generator(LanguageNames.CSharp)]
+public sealed class DataModelSchemaGenerator : IIncrementalGenerator
+{
+	private const string SchemaFileName = "project-data-schema.json";
+
+	public void Initialize(IncrementalGeneratorInitializationContext context)
+	{
+		IncrementalValueProvider<(ImmutableArray<AdditionalText> Left, Compilation Right)> schemaAndCompilation = context.AdditionalTextsProvider.Collect()
+			.Combine(context.CompilationProvider);
+
+		context.RegisterSourceOutput(schemaAndCompilation, static (ctx, input) =>
+		{
+			ImmutableArray<AdditionalText> files = input.Left;
+			Microsoft.CodeAnalysis.Compilation compilation = input.Right;
+
+			AdditionalText? schemaFile = null;
+			foreach (AdditionalText file in files)
+			{
+				if (Path.GetFileName(file.Path).Equals(SchemaFileName, StringComparison.OrdinalIgnoreCase))
+				{
+					schemaFile = file;
+					break;
+				}
+			}
+
+			if (schemaFile is null)
+				return;
+
+			string? text = schemaFile.GetText(ctx.CancellationToken)?.ToString();
+			if (text is null)
+				return;
+
+			Schema? schema = ParseSchema(text);
+			if (schema is null)
+				return;
+
+			// Derive namespace from the consuming project's assembly name.
+			// CSDevKit → CSDevKit.Contracts.DataModel (its existing brokered DTO convention)
+			// ProjectData reader/tasks → their root namespace
+			string assemblyName = compilation.AssemblyName ?? "";
+			string ns = assemblyName switch
+			{
+				"CSDevKit" => "CSDevKit.Contracts.DataModel",
+				_ => assemblyName,
+			};
+
+			ctx.AddSource("ProjectProperties.g.cs", GeneratorSourceText.From(GenerateProjectProperties(schema, ns)));
+			ctx.AddSource("ProjectItems.g.cs", GeneratorSourceText.From(GenerateProjectItems(schema, ns)));
+
+			// Wire-format constants for the on-disk .lscache file. Emitted into the same
+			// namespace as the other generated constants so the writer and reader can
+			// reference a single source of truth and a rename cannot silently drop a
+			// section.
+			ctx.AddSource("CacheFormat.g.cs", GeneratorSourceText.From(GenerateCacheFormat(schema, ns)));
+			ctx.AddSource("PathSentinels.g.cs", GeneratorSourceText.From(GeneratePathSentinels(schema.PathSentinels, ns)));
+
+			// Only emit TypedProperties when the consuming project has KeyValueCollection;
+			// the generated accessors cannot compile without the immutable model types.
+			bool hasKeyValueCollection = compilation.GetTypeByMetadataName(
+				$"{ns}.KeyValueCollection") is not null;
+			if (hasKeyValueCollection)
+			{
+				ctx.AddSource("TypedProperties.g.cs", GeneratorSourceText.From(GenerateTypedProperties(schema, ns)));
+			}
+		});
+	}
+
+	private static PropertyDef ParseProperty(JsonElement p)
+	{
+		string name = p.GetProperty("name").GetString()!;
+		string description = p.TryGetProperty("description", out JsonElement d) ? d.GetString() ?? "" : "";
+		return new(name, description);
+	}
+
+	private static Schema? ParseSchema(string json)
+	{
+		try
+		{
+			using JsonDocument doc = JsonDocument.Parse(json);
+			JsonElement root = doc.RootElement;
+
+			List<PropertyDef> required = [];
+			List<PropertyDef> optional = [];
+
+			if (root.TryGetProperty("properties", out JsonElement propsEl))
+			{
+				if (propsEl.TryGetProperty("required", out JsonElement reqEl))
+					foreach (JsonElement p in reqEl.EnumerateArray())
+						required.Add(ParseProperty(p));
+				if (propsEl.TryGetProperty("optional", out JsonElement optEl))
+					foreach (JsonElement p in optEl.EnumerateArray())
+						optional.Add(ParseProperty(p));
+			}
+
+			List<ItemDef> items = [];
+			if (root.TryGetProperty("items", out JsonElement itemsEl))
+			{
+				foreach (JsonProperty item in itemsEl.EnumerateObject())
+				{
+					string desc = item.Value.TryGetProperty("description", out JsonElement descEl) ? descEl.GetString() ?? "" : "";
+					bool isRequired = item.Value.TryGetProperty("required", out JsonElement reqEl) && reqEl.GetBoolean();
+					List<string> metadata = [];
+					if (item.Value.TryGetProperty("metadata", out JsonElement metaEl))
+						foreach (JsonElement m in metaEl.EnumerateArray())
+							metadata.Add(m.GetString()!);
+					items.Add(new(item.Name, desc, isRequired, metadata));
+				}
+			}
+
+			CacheFormatDef? cacheFormat = null;
+			if (root.TryGetProperty("cacheFormat", out JsonElement cacheFormatEl))
+			{
+				List<SectionDef> sections = [];
+				if (cacheFormatEl.TryGetProperty("sections", out JsonElement sectionsEl))
+				{
+					foreach (JsonElement section in sectionsEl.EnumerateArray())
+					{
+						sections.Add(new(
+							section.GetProperty("name").GetString()!,
+							section.TryGetProperty("description", out JsonElement secDescEl) ? secDescEl.GetString() ?? "" : "",
+							section.TryGetProperty("itemType", out JsonElement secItemEl) ? secItemEl.GetString() : null));
+					}
+				}
+
+				cacheFormat = new(
+					VersionHeader: GetStringOrEmpty(cacheFormatEl, "versionHeader"),
+					HashHeaderPrefix: GetStringOrEmpty(cacheFormatEl, "hashHeaderPrefix"),
+					SliceSeparator: GetStringOrEmpty(cacheFormatEl, "sliceSeparator"),
+					SectionOpen: GetStringOrEmpty(cacheFormatEl, "sectionOpen"),
+					SectionClose: GetStringOrEmpty(cacheFormatEl, "sectionClose"),
+					CommentChar: GetStringOrEmpty(cacheFormatEl, "commentChar"),
+					ProjectHeaderPrefix: GetStringOrEmpty(cacheFormatEl, "projectHeaderPrefix"),
+					LanguagePrefix: GetStringOrEmpty(cacheFormatEl, "languagePrefix"),
+					PrimaryMarker: GetStringOrEmpty(cacheFormatEl, "primaryMarker"),
+					LastDtbSucceededMarker: GetStringOrEmpty(cacheFormatEl, "lastDtbSucceededMarker"),
+					Sections: sections);
+			}
+
+			PathSentinelsDef? pathSentinels = null;
+			if (root.TryGetProperty("pathSentinels", out JsonElement sentinelsEl))
+			{
+				List<(string Name, string Value)> entries = [];
+				foreach (JsonProperty entry in sentinelsEl.EnumerateObject())
+				{
+					if (entry.Name.StartsWith("$", StringComparison.Ordinal))
+						continue;
+					if (entry.Value.ValueKind != JsonValueKind.String)
+						continue;
+					entries.Add((entry.Name, entry.Value.GetString()!));
+				}
+				pathSentinels = new(entries);
+			}
+
+			return new(required, optional, items,
+				cacheFormat ?? throw new InvalidOperationException("Schema is missing required 'cacheFormat' block."),
+				pathSentinels ?? throw new InvalidOperationException("Schema is missing required 'pathSentinels' block."));
+		}
+		catch
+		{
+			return null;
+		}
+	}
+
+	private static string GenerateProjectProperties(Schema schema, string ns)
+	{
+		StringBuilder sb = new();
+		sb.AppendLine("// <auto-generated/>");
+		sb.AppendLine("// Generated from project-data-schema.json by DataModelSchemaGenerator.");
+		sb.AppendLine();
+		sb.AppendLine($"namespace {ns};");
+		sb.AppendLine();
+		sb.AppendLine("/// <summary>Strongly-typed constants for all Data Model property names.</summary>");
+		sb.AppendLine("internal static class ProjectProperties");
+		sb.AppendLine("{");
+
+		foreach (PropertyDef p in schema.Required)
+		{
+			sb.AppendLine($"\t/// <summary>{EscapeXml(p.Description)}</summary>");
+			sb.AppendLine($"\tpublic const string {p.Name} = \"{p.Name}\";");
+		}
+		sb.AppendLine();
+		foreach (PropertyDef p in schema.Optional)
+		{
+			sb.AppendLine($"\t/// <summary>{EscapeXml(p.Description)}</summary>");
+			sb.AppendLine($"\tpublic const string {p.Name} = \"{p.Name}\";");
+		}
+
+		sb.AppendLine();
+		sb.Append("\tpublic static readonly string[] Required = [");
+		sb.Append(string.Join(", ", schema.Required.Select(p => $"\"{p.Name}\"")));
+		sb.AppendLine("];");
+
+		sb.AppendLine();
+		sb.AppendLine("\t/// <summary>");
+		sb.AppendLine("\t/// All Data Model property names. Every property is exported into the cache file's");
+		sb.AppendLine("\t/// <c>[properties]</c> section by the writer (the generated <c>_ProjectDataProperties</c>");
+		sb.AppendLine("\t/// MSBuild allow-list is the same set). This is also the forward-compatibility");
+		sb.AppendLine("\t/// \"known [properties] key\" set: a key NOT listed here is treated as data authored by a");
+		sb.AppendLine("\t/// newer writer and preserved losslessly rather than dropped.");
+		sb.AppendLine("\t/// </summary>");
+		sb.Append("\tpublic static readonly string[] All = [");
+		sb.Append(string.Join(", ", schema.Required.Concat(schema.Optional).Select(p => $"\"{p.Name}\"")));
+		sb.AppendLine("];");
+
+		sb.AppendLine("}");
+		return sb.ToString();
+	}
+
+	private static string GenerateProjectItems(Schema schema, string ns)
+	{
+		StringBuilder sb = new();
+		sb.AppendLine("// <auto-generated/>");
+		sb.AppendLine("// Generated from project-data-schema.json by DataModelSchemaGenerator.");
+		sb.AppendLine();
+		sb.AppendLine("using System.Collections.Generic;");
+		sb.AppendLine();
+		sb.AppendLine($"namespace {ns};");
+		sb.AppendLine();
+		sb.AppendLine("/// <summary>Strongly-typed constants for Data Model item types and metadata.</summary>");
+		sb.AppendLine("internal static class ProjectItems");
+		sb.AppendLine("{");
+
+		foreach (ItemDef item in schema.Items)
+		{
+			sb.AppendLine($"\t/// <summary>{EscapeXml(item.Description)}</summary>");
+			if (item.Metadata.Count == 0)
+				sb.AppendLine($"\tpublic const string {item.Name} = \"{item.Name}\";");
+			else
+			{
+				sb.AppendLine($"\tpublic static class {item.Name}");
+				sb.AppendLine("\t{");
+				sb.AppendLine($"\t\tpublic const string ItemType = \"{item.Name}\";");
+				foreach (string meta in item.Metadata)
+					sb.AppendLine($"\t\tpublic const string {char.ToUpperInvariant(meta[0]) + meta.Substring(1)} = \"{meta}\";");
+				sb.AppendLine("\t}");
+			}
+			sb.AppendLine();
+		}
+
+		sb.Append("\tpublic static readonly string[] AllItemTypes = [");
+		sb.Append(string.Join(", ", schema.Items.Select(i => $"\"{i.Name}\"")));
+		sb.AppendLine("];");
+
+		sb.AppendLine();
+		sb.AppendLine("\t/// <summary>Item types that must be present (even if empty) in every valid snapshot.</summary>");
+		sb.Append("\tpublic static readonly string[] RequiredItemTypes = [");
+		sb.Append(string.Join(", ", schema.Items.Where(i => i.IsRequired).Select(i => $"\"{i.Name}\"")));
+		sb.AppendLine("];");
+
+		sb.AppendLine();
+		sb.AppendLine("\t/// <summary>");
+		sb.AppendLine("\t/// Every metadata key the writer can emit on any item (the union across all item");
+		sb.AppendLine("\t/// types). Used by forward-compatibility preservation to tell a known <c>@metadata</c>");
+		sb.AppendLine("\t/// line from one written by a newer version that must be carried through losslessly.");
+		sb.AppendLine("\t/// </summary>");
+		sb.Append("\tpublic static readonly string[] AllMetadata = [");
+		sb.Append(string.Join(", ", schema.Items
+			.SelectMany(i => i.Metadata)
+			.Distinct(StringComparer.Ordinal)
+			.Select(m => $"\"{m}\"")));
+		sb.AppendLine("];");
+
+		sb.AppendLine();
+		sb.AppendLine("\t/// <summary>");
+		sb.AppendLine("\t/// Metadata keys the writer can emit, grouped by the item type that carries them (NOT a");
+		sb.AppendLine("\t/// flattened union). Forward-compatibility preservation uses this to decide what is");
+		sb.AppendLine("\t/// \"known\" <em>per item type</em>, so a newer version that reuses an existing metadata");
+		sb.AppendLine("\t/// name on a different item type is still treated as unknown and carried through losslessly.");
+		sb.AppendLine("\t/// </summary>");
+		sb.AppendLine("\tpublic static readonly Dictionary<string, string[]> MetadataByItemType = new(System.StringComparer.Ordinal)");
+		sb.AppendLine("\t{");
+		foreach (ItemDef item in schema.Items.Where(i => i.Metadata.Count > 0))
+		{
+			string metas = string.Join(", ", item.Metadata.Select(m => $"\"{m}\""));
+			sb.AppendLine($"\t\t[\"{item.Name}\"] = [{metas}],");
+		}
+
+		sb.AppendLine("\t};");
+
+		sb.AppendLine("}");
+		return sb.ToString();
+	}
+
+	private static string GenerateTypedProperties(Schema schema, string ns)
+	{
+		StringBuilder sb = new();
+		sb.AppendLine("// <auto-generated/>");
+		sb.AppendLine("#nullable enable");
+		sb.AppendLine("// Generated from project-data-schema.json by DataModelSchemaGenerator.");
+		sb.AppendLine();
+		sb.AppendLine("using System;");
+		sb.AppendLine();
+		sb.AppendLine($"namespace {ns};");
+		sb.AppendLine();
+		sb.AppendLine("/// <summary>Strongly-typed accessor over <see cref=\"KeyValueCollection\"/>.</summary>");
+		sb.AppendLine("internal readonly ref struct TypedProperties");
+		sb.AppendLine("{");
+		sb.AppendLine("\tprivate readonly KeyValueCollection inner;");
+		sb.AppendLine("\tpublic TypedProperties(KeyValueCollection inner) => this.inner = inner;");
+		sb.AppendLine();
+
+		foreach (PropertyDef p in schema.Required)
+		{
+			sb.AppendLine($"\t/// <summary>{EscapeXml(p.Description)}</summary>");
+			sb.AppendLine($"\tpublic string {p.Name} => this.inner[ProjectProperties.{p.Name}] ?? throw new InvalidOperationException(\"Required Data Model property '\" + ProjectProperties.{p.Name} + \"' is missing. The .lscache file may be incomplete or the property merge failed.\");");
+		}
+		sb.AppendLine();
+		foreach (PropertyDef p in schema.Optional)
+		{
+			sb.AppendLine($"\t/// <summary>{EscapeXml(p.Description)}</summary>");
+			sb.AppendLine($"\tpublic string? {p.Name} => this.inner[ProjectProperties.{p.Name}];");
+		}
+
+		sb.AppendLine("}");
+		sb.AppendLine();
+		sb.AppendLine("internal static class TypedPropertiesExtensions");
+		sb.AppendLine("{");
+		sb.AppendLine("\tpublic static TypedProperties Typed(this ProjectDataSnapshot snapshot) => new(snapshot.Properties);");
+		sb.AppendLine("}");
+		return sb.ToString();
+	}
+
+	private static string EscapeXml(string text) => text.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;");
+
+	private static string GetStringOrEmpty(JsonElement el, string name)
+		=> el.TryGetProperty(name, out JsonElement v) && v.ValueKind == JsonValueKind.String ? v.GetString() ?? "" : "";
+
+	private static string EscapeForCSharpString(string value)
+		=> value.Replace("\\", "\\\\").Replace("\"", "\\\"");
+
+	private static string PascalCase(string name)
+	{
+		if (string.IsNullOrEmpty(name))
+			return name;
+		return char.ToUpperInvariant(name[0]) + name.Substring(1);
+	}
+
+	private static string GenerateCacheFormat(Schema schema, string ns)
+	{
+		CacheFormatDef cacheFormat = schema.CacheFormat;
+		StringBuilder sb = new();
+		sb.AppendLine("// <auto-generated/>");
+		sb.AppendLine("// Generated from project-data-schema.json by DataModelSchemaGenerator.");
+		sb.AppendLine();
+		sb.AppendLine("using System.Collections.Generic;");
+		sb.AppendLine();
+		sb.AppendLine($"namespace {ns};");
+		sb.AppendLine();
+		sb.AppendLine("/// <summary>");
+		sb.AppendLine("/// Wire-format tokens for the on-disk <c>.lscache</c> file. Shared by the writer");
+		sb.AppendLine("/// (<c>Microsoft.NET.ProjectData.Tasks</c>) and the reader");
+		sb.AppendLine("/// (<c>Microsoft.NET.ProjectData</c>) so renames cannot silently drop a section.");
+		sb.AppendLine("/// </summary>");
+		sb.AppendLine("internal static class CacheFormat");
+		sb.AppendLine("{");
+		sb.AppendLine($"\tpublic const string VersionHeader = \"{EscapeForCSharpString(cacheFormat.VersionHeader)}\";");
+		sb.AppendLine($"\tpublic const string HashHeaderPrefix = \"{EscapeForCSharpString(cacheFormat.HashHeaderPrefix)}\";");
+		sb.AppendLine($"\tpublic const string SliceSeparator = \"{EscapeForCSharpString(cacheFormat.SliceSeparator)}\";");
+		sb.AppendLine($"\tpublic const string SectionOpen = \"{EscapeForCSharpString(cacheFormat.SectionOpen)}\";");
+		sb.AppendLine($"\tpublic const string SectionClose = \"{EscapeForCSharpString(cacheFormat.SectionClose)}\";");
+		if (cacheFormat.CommentChar.Length == 1)
+			sb.AppendLine($"\tpublic const char CommentChar = '{EscapeForCSharpString(cacheFormat.CommentChar)}';");
+		sb.AppendLine($"\tpublic const string ProjectHeaderPrefix = \"{EscapeForCSharpString(cacheFormat.ProjectHeaderPrefix)}\";");
+		sb.AppendLine($"\tpublic const string LanguagePrefix = \"{EscapeForCSharpString(cacheFormat.LanguagePrefix)}\";");
+		sb.AppendLine($"\tpublic const string PrimaryMarker = \"{EscapeForCSharpString(cacheFormat.PrimaryMarker)}\";");
+		sb.AppendLine($"\tpublic const string LastDtbSucceededMarker = \"{EscapeForCSharpString(cacheFormat.LastDtbSucceededMarker)}\";");
+		sb.AppendLine();
+		sb.AppendLine("\t/// <summary>Section names emitted as <c>[name]</c> by the writer and matched without brackets by the reader.</summary>");
+		sb.AppendLine("\tpublic static class Sections");
+		sb.AppendLine("\t{");
+		foreach (SectionDef section in cacheFormat.Sections)
+		{
+			if (!string.IsNullOrEmpty(section.Description))
+				sb.AppendLine($"\t\t/// <summary>{EscapeXml(section.Description)}</summary>");
+			sb.AppendLine($"\t\tpublic const string {PascalCase(section.Name)} = \"{EscapeForCSharpString(section.Name)}\";");
+		}
+		sb.AppendLine();
+		sb.Append("\t\tpublic static readonly string[] All = [");
+		sb.Append(string.Join(", ", cacheFormat.Sections.Select(s => $"\"{EscapeForCSharpString(s.Name)}\"")));
+		sb.AppendLine("];");
+		sb.AppendLine();
+		sb.AppendLine("\t\t/// <summary>");
+		sb.AppendLine("\t\t/// Item <c>@metadata</c> keys the writer can emit, keyed by the WIRE section that carries");
+		sb.AppendLine("\t\t/// them (resolved through the section's <c>itemType</c> link in the schema). Used by");
+		sb.AppendLine("\t\t/// forward-compatibility preservation to judge \"known\" metadata <em>per section</em>, so a");
+		sb.AppendLine("\t\t/// newer writer that reuses an existing metadata name on a different item type is still");
+		sb.AppendLine("\t\t/// preserved rather than mistaken for regenerable data. Only sections whose item type");
+		sb.AppendLine("\t\t/// emits metadata appear here; a section absent from the map emits no metadata.");
+		sb.AppendLine("\t\t/// </summary>");
+		sb.AppendLine("\t\tpublic static readonly Dictionary<string, string[]> MetadataBySection = new(System.StringComparer.Ordinal)");
+		sb.AppendLine("\t\t{");
+		foreach (SectionDef section in cacheFormat.Sections)
+		{
+			if (section.ItemType is null)
+				continue;
+			ItemDef? item = schema.Items.FirstOrDefault(i => i.Name == section.ItemType);
+			if (item is null || item.Metadata.Count == 0)
+				continue;
+			string metas = string.Join(", ", item.Metadata.Select(m => $"\"{EscapeForCSharpString(m)}\""));
+			sb.AppendLine($"\t\t\t[\"{EscapeForCSharpString(section.Name)}\"] = [{metas}],");
+		}
+		sb.AppendLine("\t\t};");
+		sb.AppendLine("\t}");
+		sb.AppendLine();
+		sb.AppendLine("\t/// <summary>Returns <paramref name=\"name\"/> wrapped in section delimiters, e.g. <c>[sourceFiles]</c>.</summary>");
+		sb.AppendLine("\tpublic static string SectionHeader(string name) => SectionOpen + name + SectionClose;");
+		sb.AppendLine("}");
+		return sb.ToString();
+	}
+
+	private static string GeneratePathSentinels(PathSentinelsDef pathSentinels, string ns)
+	{
+		StringBuilder sb = new();
+		sb.AppendLine("// <auto-generated/>");
+		sb.AppendLine("// Generated from project-data-schema.json by DataModelSchemaGenerator.");
+		sb.AppendLine();
+		sb.AppendLine($"namespace {ns};");
+		sb.AppendLine();
+		sb.AppendLine("/// <summary>");
+		sb.AppendLine("/// Sentinel prefixes embedded in encoded paths in the <c>.lscache</c> file.");
+		sb.AppendLine("/// The writer rewrites version-specific or location-specific paths to these sentinels");
+		sb.AppendLine("/// so the cache is portable across machines and SDK upgrades; the reader resolves them");
+		sb.AppendLine("/// via <c>CachePathResolver</c>.");
+		sb.AppendLine("/// </summary>");
+		sb.AppendLine("internal static class PathSentinels");
+		sb.AppendLine("{");
+		foreach ((string name, string value) in pathSentinels.Entries)
+		{
+			sb.AppendLine($"\tpublic const string {PascalCase(name)} = \"{EscapeForCSharpString(value)}\";");
+		}
+		sb.AppendLine("}");
+		return sb.ToString();
+	}
+
+	private sealed record PropertyDef(string Name, string Description);
+	private sealed record ItemDef(string Name, string Description, bool IsRequired, List<string> Metadata);
+	private sealed record SectionDef(string Name, string Description, string? ItemType);
+	private sealed record CacheFormatDef(
+		string VersionHeader,
+		string HashHeaderPrefix,
+		string SliceSeparator,
+		string SectionOpen,
+		string SectionClose,
+		string CommentChar,
+		string ProjectHeaderPrefix,
+		string LanguagePrefix,
+		string PrimaryMarker,
+		string LastDtbSucceededMarker,
+		List<SectionDef> Sections);
+	private sealed record PathSentinelsDef(List<(string Name, string Value)> Entries);
+	private sealed record Schema(
+		List<PropertyDef> Required,
+		List<PropertyDef> Optional,
+		List<ItemDef> Items,
+		CacheFormatDef CacheFormat,
+		PathSentinelsDef PathSentinels);
+}

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Generators/DataModelSchemaGenerator.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Generators/DataModelSchemaGenerator.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
 using System.Text;

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Generators/GeneratorSourceText.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Generators/GeneratorSourceText.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Text;
 using Microsoft.CodeAnalysis.Text;

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Generators/GeneratorSourceText.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Generators/GeneratorSourceText.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System.Text;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.NET.ProjectData.Generators;
+
+internal static class GeneratorSourceText
+{
+	public static SourceText From(string source)
+		=> SourceText.From(source, Encoding.UTF8, SourceHashAlgorithm.Sha256);
+}

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Generators/Microsoft.NET.ProjectData.Generators.csproj
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Generators/Microsoft.NET.ProjectData.Generators.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>Microsoft.NET.ProjectData.Generators</RootNamespace>
+    <IsPackable>false</IsPackable>
+
+    <!-- Declare Platforms so EnableDynamicPlatformResolution (set globally in
+         server/Directory.Build.props) doesn't emit MSB3982 when this project is
+         referenced as an analyzer from a project that targets a specific platform
+         (e.g. Microsoft.NET.ProjectData.Tasks). The SetPlatform="" on the
+         ProjectReference is insufficient on its own. -->
+    <Platforms>AnyCPU</Platforms>
+
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <EnableAotAnalyzer>false</EnableAotAnalyzer>
+    <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <NoWarn>$(NoWarn);RS2008;RS1041</NoWarn>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Source generators must use Microsoft.CodeAnalysis versions compatible with the build host's Roslyn;
+     so these are pinned for now. This can be removed once we update the SDK version to be newer than the
+     centrally managed versions. -->
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" VersionOverride="4.14.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" VersionOverride="5.8.0-1.26319.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" PrivateAssets="all" VersionOverride="5.8.0-1.26319.2" />
+  </ItemGroup>
+
+</Project>

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Generators/Microsoft.NET.ProjectData.Generators.csproj
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Generators/Microsoft.NET.ProjectData.Generators.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <RootNamespace>Microsoft.NET.ProjectData.Generators</RootNamespace>
     <IsPackable>false</IsPackable>
+    <TargetFramework>netstandard2.0</TargetFramework>
 
     <!-- Declare Platforms so EnableDynamicPlatformResolution (set globally in
          server/Directory.Build.props) doesn't emit MSB3982 when this project is
@@ -20,12 +21,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Source generators must use Microsoft.CodeAnalysis versions compatible with the build host's Roslyn;
-     so these are pinned for now. This can be removed once we update the SDK version to be newer than the
-     centrally managed versions. -->
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" VersionOverride="4.14.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" VersionOverride="5.8.0-1.26319.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" PrivateAssets="all" VersionOverride="5.8.0-1.26319.2" />
+    <Compile Include="..\..\..\Dependencies\Contracts\IsExternalInit.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" PrivateAssets="all" />
+    <PackageReference Include="System.Text.Json" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Generators/project-data-schema.json
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Generators/project-data-schema.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$comment": "Canonical Data Model schema. Used by both the C# source generator and TypeScript codegen to produce typed accessors, compile-time validated queries, and cache validation.",
+
+  "$comment-properties": "Every property listed here is persisted into the [properties] section of the .lscache file by the writer (it appears in the generated _ProjectDataProperties allow-list) and is part of the typed Data Model contract. The MSBuild value written is \"value\" when present, otherwise $(<name>). This set is also the forward-compat \"known [properties] key\" set (ForwardCompat.KnownPropertyKeys / ProjectProperties.All): a key not in it is treated as data authored by a newer writer and preserved losslessly. 'required' properties are always written and throw if missing on read; 'optional' properties are omitted when empty and read as null.",
+
+  "properties": {
+    "required": [
+      { "name": "AssemblyName", "description": "Assembly output name." },
+      { "name": "OutputType", "description": "Project output type: Library, Exe, WinExe." },
+      { "name": "TargetFramework", "description": "Active target framework moniker (e.g., net10.0)." },
+      { "name": "TargetFrameworkIdentifier", "description": "Framework identifier (e.g., .NETCoreApp)." },
+      { "name": "ProjectAssetsFile", "description": "Path to project.assets.json." },
+      { "name": "TargetPath", "description": "Full path to the primary build output assembly." }
+    ],
+    "optional": [
+      { "name": "RootNamespace", "description": "Root namespace for the project." },
+      { "name": "TargetFrameworkVersion", "description": "Framework version (e.g., v10.0)." },
+      { "name": "TargetRefPath", "description": "Path to the ref assembly (if produced)." },
+      { "name": "MaxSupportedLangVersion", "description": "Maximum C# language version supported by the SDK." },
+      { "name": "RunAnalyzers", "description": "Whether analyzers run during build." },
+      { "name": "RunAnalyzersDuringLiveAnalysis", "description": "Whether analyzers run during live analysis." },
+      { "name": "CompilerGeneratedFilesOutputPath", "description": "Directory for source-generated files." },
+      { "name": "BaseIntermediateOutputPath", "description": "Root intermediate-output directory (default obj/). Persisted so the redirected location is known when releasing VS Code's recursive watcher handles before a folder rename on Windows." },
+      { "name": "BaseOutputPath", "description": "Root build-output directory (default bin/). Persisted so the redirected location is known when releasing VS Code's recursive watcher handles before a folder rename on Windows." },
+      { "name": "SolutionPath", "description": "Path to the solution file (injected at runtime, not from cache)." },
+      { "name": "TemporaryDependencyNodeTargetIdentifier", "description": "Roslyn/CPS dependency-node TFM identifier. Duplicates TargetFramework's value but Roslyn keys on this exact (intentionally awkward) name to identify a dependency node's target framework, so it must be persisted under this name for cache-load workspace hydration. Not otherwise read as a typed property.", "value": "$(TargetFramework)" }
+    ]
+  },
+
+  "items": {
+    "Compile": {
+      "required": true,
+      "description": "Source files included in compilation.",
+      "metadata": ["Link"]
+    },
+    "MetadataReference": {
+      "required": true,
+      "description": "Assembly references.",
+      "metadata": ["aliases", "embedInteropTypes"]
+    },
+    "AnalyzerReference": {
+      "required": true,
+      "description": "Roslyn analyzer assemblies.",
+      "metadata": []
+    },
+    "AnalyzerConfigFile": {
+      "required": false,
+      "description": "EditorConfig and global analyzer config files.",
+      "metadata": []
+    },
+    "AdditionalFile": {
+      "required": false,
+      "description": "Additional files passed to analyzers.",
+      "metadata": []
+    },
+    "ProjectReference": {
+      "required": true,
+      "description": "Project-to-project references.",
+      "metadata": []
+    },
+    "CommandLineArgument": {
+      "required": true,
+      "description": "Compiler command-line arguments.",
+      "metadata": []
+    },
+    "EmbeddedResource": {
+      "required": false,
+      "description": "Embedded resource files (.resx, etc.).",
+      "metadata": ["Generator", "LastGenOutput", "CustomToolNamespace"]
+    }
+  },
+
+  "cacheFormat": {
+    "$comment": "Wire-format tokens for the on-disk .lscache file. Shared by the writer (Microsoft.NET.ProjectData.Tasks) and the reader (Microsoft.NET.ProjectData) so renames cannot silently drop a section. VERSIONING: 'versionHeader' is 'version=<major>[.<minor>]' (an absent minor means '.0'). The reader accepts any file whose MAJOR matches and ignores the minor, so a newer minor's additive data (new sections / [properties] keys / @metadata) is silently ignored; a different major is a clean cache miss. The writer preserves any such unknown data when it rewrites a file authored by a newer minor (see ForwardCompat) so mixed-version teams don't churn the file. Bump the MINOR for purely additive data an old reader can ignore AND an old writer can round-trip losslessly; bump the MAJOR for anything else (grammar/encoding changes, repurposing or removing meaning, optional->required, or data the old writer cannot carry forward losslessly). It is about the KIND of change, never the amount. 'hashHeaderPrefix' is LEGACY: the writer no longer emits a 'hash=' header (no-op writes are detected by a direct byte compare), but the reader still skips a leading 'hash=' line so pre-migration files keep reading. Do not reintroduce a persisted hash.",
+    "versionHeader": "version=2",
+    "hashHeaderPrefix": "hash=",
+    "sliceSeparator": "---",
+    "sectionOpen": "[",
+    "sectionClose": "]",
+    "commentChar": "#",
+    "projectHeaderPrefix": "project=",
+    "languagePrefix": "language=",
+    "primaryMarker": "primary",
+    "lastDtbSucceededMarker": "lastDtbSucceeded",
+    "sections": [
+      { "name": "project", "description": "Project identity, language, and slice markers." },
+      { "name": "sliceDimensions", "description": "Per-slice dimensions (e.g., TargetFramework=net10.0)." },
+      { "name": "properties", "description": "MSBuild properties evaluated for the project/slice." },
+      { "name": "commandLineArguments", "description": "Compiler command-line arguments in evaluation order." },
+      { "name": "sourceFiles", "description": "Source files in the @(Compile) item set.", "itemType": "Compile" },
+      { "name": "metadataReferences", "description": "Assembly references (@(MetadataReference)) with optional aliases/embedInteropTypes.", "itemType": "MetadataReference" },
+      { "name": "analyzerReferences", "description": "Roslyn analyzer assemblies (@(AnalyzerReference))." },
+      { "name": "analyzerConfigFiles", "description": "EditorConfig / global analyzer config files." },
+      { "name": "additionalFiles", "description": "Files passed to analyzers via @(AdditionalFile)." },
+      { "name": "projectReferences", "description": "Resolved project-to-project references." },
+      { "name": "embeddedResources", "description": "Embedded resource files (.resx, etc.) with optional Generator/LastGenOutput/CustomToolNamespace metadata.", "itemType": "EmbeddedResource" },
+      { "name": "capabilities", "description": "Project capabilities flags." },
+      { "name": "frameworkPacks", "description": "Ref-pack names (e.g. Microsoft.NETCore.App.Ref); reader probes the SDK install first, then the NuGet cache, so the same cache works whether the writing machine resolved the pack from <DOTNET>/packs/ or from <NUGET>/." },
+      { "name": "sdkAnalyzerPacks", "description": "SDK-shipped analyzer NuGet package IDs; reader enumerates analyzers/dotnet/<lang>/ on disk." },
+      { "name": "sdkAnalyzerConfigPolicy", "description": "Policy entries for SDK-shipped analyzer config files; reader resolves them under the bound SDK." }
+    ]
+  },
+
+  "pathSentinels": {
+    "$comment": "Sentinel prefixes embedded in encoded paths. The writer rewrites version-specific or location-specific paths to these sentinels so the cache is portable across machines and SDK upgrades; the reader resolves them via CachePathResolver.",
+    "netSdk": "<NETSDK>",
+    "path": "<PATH>",
+    "netFxRef": "<NETFXREF>",
+    "nuget": "<NUGET>",
+    "nugetPp": "<NUGETPP>",
+    "dotnet": "<DOTNET>"
+  }
+}

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Tests/CacheFileReaderTests.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Tests/CacheFileReaderTests.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -422,7 +424,8 @@ public class CacheFileReaderTests
 		ImmutableArray<CachedSliceData> slices = await ParseAsync(content);
 		Assert.Equal(2, slices[0].MetadataReferences.Length);
 
-		Assert.Equal(["global", "interop"], slices[0].MetadataReferences[0].Aliases);
+		// Roslyn is on xunit v2, so we must call ToArray() to get the correct overload that compares the values and not the actual array identity
+		Assert.Equal(["global", "interop"], slices[0].MetadataReferences[0].Aliases.ToArray());
 		Assert.True(slices[0].MetadataReferences[0].EmbedInteropTypes);
 
 		Assert.True(slices[0].MetadataReferences[1].Aliases.IsEmpty);
@@ -437,7 +440,8 @@ public class CacheFileReaderTests
 	public void DeriveFolderNames_From_Relative_Path()
 	{
 		ImmutableArray<string> folders = CacheFileReader.DeriveFolderNamesFromPortablePath("src/Models/User.cs");
-		Assert.Equal(["src", "Models"], folders);
+		// Roslyn is on xunit v2, so we must call ToArray() to get the correct overload that compares the values and not the actual array identity
+		Assert.Equal(["src", "Models"], folders.ToArray());
 	}
 
 	[Fact]

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Tests/CacheFileReaderTests.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Tests/CacheFileReaderTests.cs
@@ -1,0 +1,1812 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Text;
+
+namespace Microsoft.NET.ProjectData.Tests;
+
+[CollectionDefinition(DotnetRootEnvCollection.Name, DisableParallelization = true)]
+public sealed class DotnetRootEnvCollection
+{
+	public const string Name = "DotnetRootEnv";
+}
+
+[Collection(DotnetRootEnvCollection.Name)]
+public class CacheFileReaderTests
+{
+	private static readonly CachePathResolver Resolver = new();
+	private static readonly string TestProjectDirectory = Path.Combine(Path.GetTempPath(), "projectdata-cache-tests", "TestProject");
+	private static readonly string TestProjectFilePath = Path.Combine(TestProjectDirectory, "TestProject.csproj");
+
+	#region Header and Structure
+
+	[Fact]
+	public async Task Empty_File_Returns_Empty()
+	{
+		ImmutableArray<CachedSliceData> slices = await ParseAsync("");
+		Assert.True(slices.IsEmpty);
+	}
+
+	[Fact]
+	public async Task Invalid_Version_Returns_Empty()
+	{
+		ImmutableArray<CachedSliceData> slices = await ParseAsync("version=99\n");
+		Assert.True(slices.IsEmpty);
+	}
+
+	[Fact]
+	public async Task Minimal_Valid_File_Parses_One_Slice()
+	{
+		string content = """
+			version=2
+
+			[project]
+			language=C#
+			""";
+
+		ImmutableArray<CachedSliceData> slices = await ParseAsync(content);
+		Assert.Single(slices);
+		Assert.Equal("C#", slices[0].LanguageName);
+	}
+
+	[Fact]
+	public async Task Hash_Header_Is_Ignored_When_Parsing()
+	{
+		string content = $"hash={new string('a', 64)}\nversion=2\n\n[project]\nlanguage=C#\n";
+
+		ImmutableArray<CachedSliceData> slices = await ParseAsync(content);
+		Assert.Single(slices);
+		Assert.Equal("C#", slices[0].LanguageName);
+	}
+
+	[Fact]
+	public async Task Comments_And_Blank_Lines_Are_Skipped()
+	{
+		string content = """
+			version=2
+
+			# This is a comment
+
+			# Another comment
+
+			[project]
+			language=C#
+			""";
+
+		ImmutableArray<CachedSliceData> slices = await ParseAsync(content);
+		Assert.Single(slices);
+	}
+
+	[Fact]
+	public async Task Multiple_Slices_Separated_By_Dashes()
+	{
+		string content = """
+			version=2
+
+			[project]
+			language=C#
+			primary
+			lastDtbSucceeded
+
+			[sliceDimensions]
+			TargetFramework=net10.0
+
+			---
+
+			[project]
+			language=C#
+
+			[sliceDimensions]
+			TargetFramework=net8.0
+			""";
+
+		ImmutableArray<CachedSliceData> slices = await ParseAsync(content);
+		Assert.Equal(2, slices.Length);
+
+		Assert.True(slices[0].IsPrimary);
+		Assert.True(slices[0].LastDesignTimeBuildSucceeded);
+		Assert.Equal("net10.0", slices[0].SliceDimensions["TargetFramework"]);
+
+		Assert.False(slices[1].IsPrimary);
+		Assert.False(slices[1].LastDesignTimeBuildSucceeded);
+		Assert.Equal("net8.0", slices[1].SliceDimensions["TargetFramework"]);
+	}
+
+	#endregion
+
+	#region Properties
+
+	[Fact]
+	public async Task Properties_Are_Parsed()
+	{
+		string content = """
+			version=2
+
+			[project]
+			language=C#
+
+			[properties]
+			AssemblyName=MyProject
+			RootNamespace=MyProject.Root
+			""";
+
+		ImmutableArray<CachedSliceData> slices = await ParseAsync(content);
+		Assert.Single(slices);
+		Assert.Equal("MyProject", slices[0].Properties["AssemblyName"]);
+		Assert.Equal("MyProject.Root", slices[0].Properties["RootNamespace"]);
+	}
+
+	[Fact]
+	public async Task Property_Value_May_Contain_Equals_Sign()
+	{
+		string content = """
+			version=2
+
+			[project]
+			language=C#
+
+			[properties]
+			Weird=val=ue=with=equals
+			""";
+
+		ImmutableArray<CachedSliceData> slices = await ParseAsync(content);
+		Assert.Equal("val=ue=with=equals", slices[0].Properties["Weird"]);
+	}
+
+	#endregion
+
+	#region Command Line Arguments
+
+	[Fact]
+	public async Task CommandLineArguments_Are_Parsed()
+	{
+		string content = """
+			version=2
+
+			[project]
+			language=C#
+
+			[commandLineArguments]
+			/langversion:preview
+			/nullable:enable
+			""";
+
+		ImmutableArray<CachedSliceData> slices = await ParseAsync(content);
+		Assert.Equal(2, slices[0].CommandLineArguments.Length);
+		Assert.Equal("/langversion:preview", slices[0].CommandLineArguments[0]);
+		Assert.Equal("/nullable:enable", slices[0].CommandLineArguments[1]);
+	}
+
+	[Fact]
+	public async Task ReadFromAsync_With_Shared_StringPool_Deduplicates_Shared_Strings_Across_Reads_And_Ignores_Legacy_DynamicFiles_Section()
+	{
+		const string content = """
+			version=2
+
+			[project]
+			language=C#
+
+			[sliceDimensions]
+			TargetFramework=net10.0
+
+			[properties]
+			AssemblyName=SharedAssembly
+
+			[commandLineArguments]
+			/langversion:preview
+
+			[sourceFiles]
+			C:\shared\Program.cs
+
+			[metadataReferences]
+			C:\shared\System.Runtime.dll
+			@aliases=global,shared
+
+			[analyzerReferences]
+			C:\shared\MyAnalyzer.dll
+
+			[additionalFiles]
+			C:\shared\.editorconfig
+
+			[dynamicFiles]
+			C:\shared\Generated.g.cs
+			@folderNames=Generated,Shared
+
+			[capabilities]
+			CSharp
+			""";
+
+		StringPool stringPool = new();
+
+		async Task<CachedSliceData> ParseSingleSliceAsync(string projectFilePath)
+		{
+			using StringReader reader = new(StripLeadingTabs(content));
+			ImmutableArray<CachedSliceData> slices = await CacheFileReader.ReadFromAsync(
+				reader,
+				Resolver,
+				Path.GetDirectoryName(projectFilePath)!,
+				projectFilePath,
+				stringPool: stringPool);
+			return Assert.Single(slices);
+		}
+
+		CachedSliceData first = await ParseSingleSliceAsync(@"C:\dev\Shared\ProjectA.csproj");
+		CachedSliceData second = await ParseSingleSliceAsync(@"C:\dev\Shared\ProjectB.csproj");
+
+		Assert.Same(first.SliceDimensions.Keys.Single(), second.SliceDimensions.Keys.Single());
+		Assert.Same(first.SliceDimensions["TargetFramework"], second.SliceDimensions["TargetFramework"]);
+
+		string firstPropertyKey = first.Properties.Keys.Single();
+		string secondPropertyKey = second.Properties.Keys.Single();
+		Assert.Same(firstPropertyKey, secondPropertyKey);
+		Assert.Same(first.Properties[firstPropertyKey], second.Properties[secondPropertyKey]);
+
+		Assert.Same(first.CommandLineArguments[0], second.CommandLineArguments[0]);
+		Assert.Same(first.SourceFiles[0].FilePath, second.SourceFiles[0].FilePath);
+		Assert.Same(first.MetadataReferences[0].FilePath, second.MetadataReferences[0].FilePath);
+		Assert.Same(first.MetadataReferences[0].Aliases[0], second.MetadataReferences[0].Aliases[0]);
+		Assert.Same(first.AnalyzerReferences[0], second.AnalyzerReferences[0]);
+		Assert.Same(first.AdditionalFiles[0], second.AdditionalFiles[0]);
+		Assert.Same(first.Capabilities[0], second.Capabilities[0]);
+	}
+
+	#endregion
+
+	#region Indentation Compression
+
+	[Fact]
+	public void ExpandCompressedPaths_Flat_Paths()
+	{
+		List<string> lines = ["Program.cs", "Helper.cs"];
+		List<(string Path, Dictionary<string, string>? Metadata)> result = CacheFileReader.ExpandCompressedPaths(lines);
+
+		Assert.Equal(2, result.Count);
+		Assert.Equal("Program.cs", result[0].Path);
+		Assert.Equal("Helper.cs", result[1].Path);
+	}
+
+	[Fact]
+	public void ExpandCompressedPaths_Single_Level_Prefix()
+	{
+		List<string> lines =
+		[
+			"src/Models/",
+			" Product.cs",
+			" User.cs",
+		];
+
+		List<(string Path, Dictionary<string, string>? Metadata)> result = CacheFileReader.ExpandCompressedPaths(lines);
+
+		Assert.Equal(2, result.Count);
+		Assert.Equal("src/Models/Product.cs", result[0].Path);
+		Assert.Equal("src/Models/User.cs", result[1].Path);
+	}
+
+	[Fact]
+	public void ExpandCompressedPaths_Nested_Prefixes()
+	{
+		List<string> lines =
+		[
+			"<DOTNET>/packs/Microsoft.NETCore.App.Ref/10.0.3/ref/net10.0/",
+			" System.Collections.dll",
+			" System.Runtime.dll",
+		];
+
+		List<(string Path, Dictionary<string, string>? Metadata)> result = CacheFileReader.ExpandCompressedPaths(lines);
+
+		Assert.Equal(2, result.Count);
+		Assert.Equal("<DOTNET>/packs/Microsoft.NETCore.App.Ref/10.0.3/ref/net10.0/System.Collections.dll", result[0].Path);
+		Assert.Equal("<DOTNET>/packs/Microsoft.NETCore.App.Ref/10.0.3/ref/net10.0/System.Runtime.dll", result[1].Path);
+	}
+
+	[Fact]
+	public void ExpandCompressedPaths_Mixed_Compressed_And_Uncompressed()
+	{
+		List<string> lines =
+		[
+			"Program.cs",
+			"src/A/B/",
+			" File1.cs",
+			" File2.cs",
+			"src/A/C/File3.cs",
+		];
+
+		List<(string Path, Dictionary<string, string>? Metadata)> result = CacheFileReader.ExpandCompressedPaths(lines);
+
+		Assert.Equal(4, result.Count);
+		Assert.Equal("Program.cs", result[0].Path);
+		Assert.Equal("src/A/B/File1.cs", result[1].Path);
+		Assert.Equal("src/A/B/File2.cs", result[2].Path);
+		Assert.Equal("src/A/C/File3.cs", result[3].Path);
+	}
+
+	[Fact]
+	public void ExpandCompressedPaths_With_Metadata()
+	{
+		List<string> lines =
+		[
+			"lib/Interop.dll",
+			" @aliases=global,interop",
+			" @embedInteropTypes",
+		];
+
+		List<(string Path, Dictionary<string, string>? Metadata)> result = CacheFileReader.ExpandCompressedPaths(lines);
+
+		Assert.Single(result);
+		Assert.Equal("lib/Interop.dll", result[0].Path);
+		Assert.NotNull(result[0].Metadata);
+		Assert.Equal("global,interop", result[0].Metadata!["aliases"]);
+		Assert.Equal("", result[0].Metadata!["embedInteropTypes"]);
+	}
+
+	[Fact]
+	public void ExpandCompressedPaths_Metadata_Under_Compressed_Path()
+	{
+		List<string> lines =
+		[
+			"<NUGET>/package/1.0/lib/",
+			" File.cs",
+			"  @folderNames=External",
+		];
+
+		List<(string Path, Dictionary<string, string>? Metadata)> result = CacheFileReader.ExpandCompressedPaths(lines);
+
+		Assert.Single(result);
+		Assert.Equal("<NUGET>/package/1.0/lib/File.cs", result[0].Path);
+		Assert.NotNull(result[0].Metadata);
+		Assert.Equal("External", result[0].Metadata!["folderNames"]);
+	}
+
+	#endregion
+
+	#region Source Files with Link
+
+	[Fact]
+	public async Task SourceFiles_Link_Parsed_From_Metadata()
+	{
+		string content = """
+			version=2
+
+			[project]
+			language=C#
+
+			[sourceFiles]
+			../Shared/User.cs
+			 @link=Models/User.cs
+			""";
+
+		ImmutableArray<CachedSliceData> slices = await ParseAsync(content);
+		Assert.Single(slices[0].SourceFiles);
+		Assert.Equal("Models/User.cs", slices[0].SourceFiles[0].Link);
+	}
+
+	[Fact]
+	public async Task SourceFiles_Link_Null_When_Metadata_Missing()
+	{
+		string content = """
+			version=2
+
+			[project]
+			language=C#
+
+			[sourceFiles]
+			Program.cs
+			""";
+
+		ImmutableArray<CachedSliceData> slices = await ParseAsync(content);
+		Assert.Single(slices[0].SourceFiles);
+		Assert.Null(slices[0].SourceFiles[0].Link);
+	}
+
+	#endregion
+
+	#region Metadata References
+
+	[Fact]
+	public async Task MetadataReferences_Parsed_With_Aliases_And_EmbedInteropTypes()
+	{
+		string content = """
+			version=2
+
+			[project]
+			language=C#
+
+			[metadataReferences]
+			lib/Interop.dll
+			 @aliases=global,interop
+			 @embedInteropTypes
+			lib/Other.dll
+			""";
+
+		ImmutableArray<CachedSliceData> slices = await ParseAsync(content);
+		Assert.Equal(2, slices[0].MetadataReferences.Length);
+
+		Assert.Equal(["global", "interop"], slices[0].MetadataReferences[0].Aliases);
+		Assert.True(slices[0].MetadataReferences[0].EmbedInteropTypes);
+
+		Assert.True(slices[0].MetadataReferences[1].Aliases.IsEmpty);
+		Assert.False(slices[0].MetadataReferences[1].EmbedInteropTypes);
+	}
+
+	#endregion
+
+	#region DeriveFolderNames
+
+	[Fact]
+	public void DeriveFolderNames_From_Relative_Path()
+	{
+		ImmutableArray<string> folders = CacheFileReader.DeriveFolderNamesFromPortablePath("src/Models/User.cs");
+		Assert.Equal(["src", "Models"], folders);
+	}
+
+	[Fact]
+	public void DeriveFolderNames_Empty_For_Root_File()
+	{
+		ImmutableArray<string> folders = CacheFileReader.DeriveFolderNamesFromPortablePath("Program.cs");
+		Assert.True(folders.IsEmpty);
+	}
+
+	[Fact]
+	public void DeriveFolderNames_Empty_For_Sentinel_Path()
+	{
+		ImmutableArray<string> folders = CacheFileReader.DeriveFolderNamesFromPortablePath("<NUGET>/package/1.0/lib/File.cs");
+		Assert.True(folders.IsEmpty);
+	}
+
+	[Fact]
+	public void DeriveFolderNames_Empty_For_Parent_Relative_Path()
+	{
+		ImmutableArray<string> folders = CacheFileReader.DeriveFolderNamesFromPortablePath("../Other/File.cs");
+		Assert.True(folders.IsEmpty);
+	}
+
+	#endregion
+
+	#region Complete File Parsing
+
+	[Fact]
+	public async Task Complete_Cache_File_Example()
+	{
+		// This matches the complete example from the cache file specification.
+		string content = """
+			version=2
+
+			# This file caches language service data.
+
+			[project]
+			language=C#
+			primary
+			lastDtbSucceeded
+
+			[sliceDimensions]
+			TargetFramework=net10.0
+
+			[properties]
+			AssemblyName=MyProject
+			RootNamespace=MyProject
+
+			[commandLineArguments]
+			/langversion:preview
+			/nullable:enable
+
+			[sourceFiles]
+			Program.cs
+			src/Models/
+			 Product.cs
+			 User.cs
+
+			[analyzerConfigFiles]
+			.editorconfig
+
+			[additionalFiles]
+			data/config.json
+
+			---
+
+			[project]
+			language=C#
+
+			[sliceDimensions]
+			TargetFramework=net8.0
+
+			[sourceFiles]
+			Program.cs
+			src/Models/
+			 Product.cs
+			 User.cs
+			""";
+
+		ImmutableArray<CachedSliceData> slices = await ParseAsync(content);
+
+		Assert.Equal(2, slices.Length);
+
+		// First slice
+		CachedSliceData first = slices[0];
+		Assert.True(first.IsPrimary);
+		Assert.True(first.LastDesignTimeBuildSucceeded);
+		Assert.Equal("C#", first.LanguageName);
+		Assert.Equal("net10.0", first.SliceDimensions["TargetFramework"]);
+		Assert.Equal("MyProject", first.Properties["AssemblyName"]);
+		Assert.Equal(2, first.CommandLineArguments.Length);
+		Assert.Equal(3, first.SourceFiles.Length);
+		Assert.Single(first.AnalyzerConfigFiles);
+		Assert.Single(first.AdditionalFiles);
+
+		// Source files had indentation compression expanded
+		Assert.Contains(first.SourceFiles, f => f.FilePath.EndsWith("Program.cs"));
+		Assert.Contains(first.SourceFiles, f => f.FilePath.EndsWith("Product.cs"));
+		Assert.Contains(first.SourceFiles, f => f.FilePath.EndsWith("User.cs"));
+
+		// Second slice
+		CachedSliceData second = slices[1];
+		Assert.False(second.IsPrimary);
+		Assert.Equal("net8.0", second.SliceDimensions["TargetFramework"]);
+		Assert.Equal(3, second.SourceFiles.Length);
+	}
+
+	#endregion
+
+	#region Forward Compatibility (version tolerance + unknown data)
+
+	// A newer MINOR version (same major) must be accepted: forward-compatible additions
+	// are ignored, not rejected. Only the MAJOR (the token before the first '.') is parsed and
+	// gated; everything after the first '.' is deliberately opaque/informational, so an exotic
+	// future minor format (extra components, suffixes, non-numeric text) must NOT cause a miss.
+	// Note this differs from "version=2x" (no dot), where the whole suffix is the major and must
+	// be numeric — that case is a miss (see Rejects_Different_Major_Or_Malformed_Version).
+	[Theory]
+	[InlineData("version=2")]
+	[InlineData("version=2.0")]
+	[InlineData("version=2.1")]
+	[InlineData("version=2.99")]
+	[InlineData("version=2.0.5")]
+	[InlineData("version=2.not-a-number")]
+	[InlineData("version=2.3-preview")]
+	public async Task Accepts_Same_Major_Version(string versionLine)
+	{
+		string content = $"{versionLine}\n\n[project]\nlanguage=C#\n";
+		ImmutableArray<CachedSliceData> slices = await ParseAsync(content);
+		Assert.Single(slices);
+		Assert.Equal("C#", slices[0].LanguageName);
+	}
+
+	// A different MAJOR version, or a malformed/missing version header, is a clean cache miss.
+	[Theory]
+	[InlineData("version=3")]
+	[InlineData("version=3.0")]
+	[InlineData("version=1")]
+	[InlineData("version=1.9")]
+	[InlineData("version=")]
+	[InlineData("version=abc")]
+	[InlineData("version=2x")]
+	[InlineData("version=.2")]
+	[InlineData("ver=2")]
+	[InlineData("")]
+	public async Task Rejects_Different_Major_Or_Malformed_Version(string versionLine)
+	{
+		string content = $"{versionLine}\n\n[project]\nlanguage=C#\n";
+		ImmutableArray<CachedSliceData> slices = await ParseAsync(content);
+		Assert.True(slices.IsEmpty);
+	}
+
+	// Reading a same-major / different-minor cache (a mixed-version team) is a normal, recoverable
+	// situation: it is read successfully and surfaced at INFORMATION level, not as a warning. An
+	// exact version match must stay silent so steady-state reads never spam the log.
+	[Fact]
+	public async Task Reading_A_Different_Minor_Version_Logs_Information_Not_Warning()
+	{
+		CapturingTraceListener listener = new();
+		Trace.Listeners.Add(listener);
+		try
+		{
+			ImmutableArray<CachedSliceData> slices = await ParseAsync("version=2.7\n\n[project]\nlanguage=C#\n");
+			Assert.Single(slices);
+			Assert.Contains("different minor version", listener.Information);
+			Assert.Contains("version=2.7", listener.Information);
+			Assert.Empty(listener.Warnings);
+
+			listener.Clear();
+			await ParseAsync("version=2\n\n[project]\nlanguage=C#\n");
+			Assert.DoesNotContain("different minor version", listener.Information);
+		}
+		finally
+		{
+			Trace.Listeners.Remove(listener);
+		}
+	}
+
+	// A normal, successful read (matching version, slices present) must not emit any warnings: opening
+	// the file and reporting the slice count are routine events surfaced at INFORMATION level. Warnings
+	// stay reserved for genuine anomalies (version rejection, project-path mismatch, empty-despite-valid).
+	[Fact]
+	public async Task Reading_A_Valid_Cache_Logs_No_Warnings()
+	{
+		CapturingTraceListener listener = new();
+		Trace.Listeners.Add(listener);
+		try
+		{
+			ImmutableArray<CachedSliceData> slices = await ParseAsync("version=2\n\n[project]\nlanguage=C#\n");
+			Assert.Single(slices);
+			Assert.Empty(listener.Warnings);
+			Assert.Contains("Read 1 slice(s)", listener.Information);
+		}
+		finally
+		{
+			Trace.Listeners.Remove(listener);
+		}
+	}
+
+	// Unknown sections, unknown [project] markers/keys, and unknown @metadata produce no
+	// state in the model — the reader behaves exactly as if they weren't there. This is the
+	// "reader is lossy for unknown data" contract that lets a newer writer add data an older
+	// reader simply ignores.
+	[Fact]
+	public async Task Unknown_Sections_Markers_And_Metadata_Are_Invisible()
+	{
+		string known = """
+			version=2
+
+			[project]
+			language=C#
+			primary
+			lastDtbSucceeded
+
+			[sliceDimensions]
+			TargetFramework=net10.0
+
+			[properties]
+			AssemblyName=MyProject
+			RootNamespace=MyProject
+
+			[commandLineArguments]
+			/nullable:enable
+
+			[sourceFiles]
+			Program.cs
+			src/Models/
+			 Product.cs
+			 User.cs
+
+			[analyzerConfigFiles]
+			.editorconfig
+
+			[additionalFiles]
+			data/config.json
+			""";
+
+		// The same project as authored by a hypothetical newer minor version that sprinkles
+		// forward-compatible additions the current reader does not understand.
+		string withUnknown = """
+			version=2.7
+
+			[project]
+			language=C#
+			primary
+			lastDtbSucceeded
+			futureProjectMarker
+			futureProjectKey=abc
+
+			[sliceDimensions]
+			TargetFramework=net10.0
+
+			[properties]
+			AssemblyName=MyProject
+			RootNamespace=MyProject
+
+			[futureSection]
+			some unknown payload
+			 indented unknown child
+
+			[commandLineArguments]
+			/nullable:enable
+
+			[sourceFiles]
+			Program.cs
+			src/Models/
+			 Product.cs
+			 @futureMeta=ignored
+			 User.cs
+
+			[analyzerConfigFiles]
+			.editorconfig
+
+			[anotherFutureSection]
+			more unknown payload
+
+			[additionalFiles]
+			data/config.json
+			""";
+
+		ImmutableArray<CachedSliceData> knownSlices = await ParseAsync(known);
+		ImmutableArray<CachedSliceData> unknownSlices = await ParseAsync(withUnknown);
+
+		Assert.Equal(DumpSlices(knownSlices), DumpSlices(unknownSlices));
+	}
+
+	// An unknown key in [properties] is a plausible MINOR addition. The reader must not choke
+	// on it, and it must not corrupt any other field. (It is harmlessly retained in the open
+	// Properties dictionary; no consumer looks it up.)
+	[Fact]
+	public async Task Unknown_Property_Key_Does_Not_Corrupt_Other_Fields()
+	{
+		string content = """
+			version=2.4
+
+			[project]
+			language=C#
+
+			[properties]
+			AssemblyName=MyProject
+			FutureProperty=should-not-break-anything
+			RootNamespace=MyProject
+
+			[sourceFiles]
+			Program.cs
+			""";
+
+		ImmutableArray<CachedSliceData> slices = await ParseAsync(content);
+
+		Assert.Single(slices);
+		CachedSliceData slice = slices[0];
+		Assert.Equal("MyProject", slice.Properties["AssemblyName"]);
+		Assert.Equal("MyProject", slice.Properties["RootNamespace"]);
+		Assert.Single(slice.SourceFiles);
+		Assert.EndsWith("Program.cs", slice.SourceFiles[0].FilePath);
+	}
+
+	// Guard: an unknown section appearing anywhere must never throw and never drop known data
+	// that follows it. This locks in the reader's "no fatal default" behavior so a future edit
+	// can't accidentally make unknown sections a hard failure.
+	[Fact]
+	public async Task Unknown_Section_Between_Known_Sections_Does_Not_Drop_Following_Data()
+	{
+		string content = """
+			version=2.1
+
+			[project]
+			language=C#
+
+			[futureSectionBeforeKnown]
+			junk
+			 more junk
+
+			[properties]
+			AssemblyName=MyProject
+
+			[sourceFiles]
+			Program.cs
+			""";
+
+		ImmutableArray<CachedSliceData> slices = await ParseAsync(content);
+
+		Assert.Single(slices);
+		Assert.Equal("MyProject", slices[0].Properties["AssemblyName"]);
+		Assert.Single(slices[0].SourceFiles);
+	}
+
+	private static string DumpSlices(ImmutableArray<CachedSliceData> slices)
+		=> string.Join("\n====\n", slices.Select(DumpSlice));
+
+	private static string DumpSlice(CachedSliceData s)
+	{
+		System.Text.StringBuilder sb = new();
+		sb.AppendLine($"language={s.LanguageName}");
+		sb.AppendLine($"projectFilePath={s.ProjectFilePath}");
+		sb.AppendLine($"isPrimary={s.IsPrimary}");
+		sb.AppendLine($"lastDtb={s.LastDesignTimeBuildSucceeded}");
+		sb.AppendLine("sliceDimensions:");
+		foreach (KeyValuePair<string, string> kvp in s.SliceDimensions.OrderBy(k => k.Key, StringComparer.Ordinal))
+			sb.AppendLine($"  {kvp.Key}={kvp.Value}");
+		sb.AppendLine("properties:");
+		foreach (KeyValuePair<string, string> kvp in s.Properties.OrderBy(k => k.Key, StringComparer.Ordinal))
+			sb.AppendLine($"  {kvp.Key}={kvp.Value}");
+		sb.AppendLine("commandLineArguments:");
+		foreach (string a in s.CommandLineArguments) sb.AppendLine($"  {a}");
+		sb.AppendLine("sourceFiles:");
+		foreach (CachedSourceFile f in s.SourceFiles) sb.AppendLine($"  {f.FilePath} link={f.Link}");
+		sb.AppendLine("metadataReferences:");
+		foreach (CachedMetadataReference m in s.MetadataReferences) sb.AppendLine($"  {m.FilePath} aliases=[{string.Join(",", m.Aliases)}] embed={m.EmbedInteropTypes}");
+		sb.AppendLine("analyzerReferences:");
+		foreach (string a in s.AnalyzerReferences) sb.AppendLine($"  {a}");
+		sb.AppendLine("analyzerConfigFiles:");
+		foreach (string a in s.AnalyzerConfigFiles) sb.AppendLine($"  {a}");
+		sb.AppendLine("additionalFiles:");
+		foreach (string a in s.AdditionalFiles) sb.AppendLine($"  {a}");
+		sb.AppendLine("embeddedResources:");
+		foreach (CachedEmbeddedResource e in s.EmbeddedResources) sb.AppendLine($"  {e.FilePath} gen={e.Generator} last={e.LastGenOutput} ns={e.CustomToolNamespace}");
+		sb.AppendLine("projectReferences:");
+		foreach (string p in s.ProjectReferences) sb.AppendLine($"  {p}");
+		sb.AppendLine("capabilities:");
+		foreach (string c in s.Capabilities) sb.AppendLine($"  {c}");
+		return sb.ToString();
+	}
+
+	#endregion
+
+	#region User-Folder Mode
+
+	[Fact]
+	public async Task UserFolder_Valid_Project_Header_Accepted()
+	{
+		string projectDirectory = Path.Combine(Path.GetTempPath(), "projectdata-cache-tests", "dev");
+		string projectFilePath = Path.Combine(projectDirectory, "MyProject.csproj");
+		string content = $"version=2\nproject={projectFilePath.Replace('\\', '/')}\n\n[project]\nlanguage=C#\n";
+
+		using StringReader reader = new(content);
+		ImmutableArray<CachedSliceData> slices = await CacheFileReader.ReadFromAsync(
+			reader, Resolver, projectDirectory, projectFilePath, expectedProjectFilePath: projectFilePath);
+
+		Assert.Single(slices);
+	}
+
+	[Fact]
+	public async Task UserFolder_Mismatched_Project_Header_Returns_Empty()
+	{
+		string content = "version=2\nproject=C:\\dev\\OtherProject.csproj\n\n[project]\nlanguage=C#\n";
+
+		using StringReader reader = new(content);
+		ImmutableArray<CachedSliceData> slices = await CacheFileReader.ReadFromAsync(
+			reader, Resolver, @"C:\dev", @"C:\dev\MyProject.csproj", expectedProjectFilePath: @"C:\dev\MyProject.csproj");
+
+		Assert.True(slices.IsEmpty);
+	}
+
+	[Fact]
+	public async Task UserFolder_Missing_Project_Header_Returns_Empty()
+	{
+		string content = "version=2\n\n[project]\nlanguage=C#\n";
+
+		using StringReader reader = new(content);
+		ImmutableArray<CachedSliceData> slices = await CacheFileReader.ReadFromAsync(
+			reader, Resolver, @"C:\dev", @"C:\dev\MyProject.csproj", expectedProjectFilePath: @"C:\dev\MyProject.csproj");
+
+		Assert.True(slices.IsEmpty);
+	}
+
+	[Fact]
+	public async Task Project_Field_Inside_Project_Block_Overrides_Project_Path()
+	{
+		string projectDirectory = Path.Combine(Path.GetTempPath(), "projectdata-cache-tests", "dev");
+		string fallbackProjectFilePath = Path.Combine(projectDirectory, "Fallback.csproj");
+		string expectedProjectFilePath = Path.Combine(projectDirectory, "Subdir", "MyProject.csproj");
+		string content = "version=2\n\n[project]\nproject=Subdir/MyProject.csproj\nlanguage=C#\n";
+
+		using StringReader reader = new(content);
+		ImmutableArray<CachedSliceData> slices = await CacheFileReader.ReadFromAsync(
+			reader, Resolver, projectDirectory, fallbackProjectFilePath, expectedProjectFilePath: expectedProjectFilePath);
+
+		Assert.Single(slices);
+		Assert.Equal(expectedProjectFilePath, slices[0].ProjectFilePath);
+	}
+
+	#endregion
+
+	#region Cache File Path Computation
+
+	[Fact]
+	public void ProjectFolder_CacheFilePath()
+	{
+		string path = CacheFileReader.GetProjectFolderCacheFilePath(@"C:\dev\Foo\Foo.csproj");
+		Assert.Equal(@"C:\dev\Foo\Foo.csproj.lscache", path);
+	}
+
+	[Fact]
+	public void UserFolder_CacheFilePath_Is_Deterministic()
+	{
+		string path1 = CacheFileReader.GetUserFolderCacheFilePath(@"C:\dev\Foo\Foo.csproj");
+		string path2 = CacheFileReader.GetUserFolderCacheFilePath(@"C:\dev\Foo\Foo.csproj");
+		Assert.Equal(path1, path2);
+	}
+
+	[Fact]
+	public void UserFolder_CacheFilePath_Differs_For_Different_Projects()
+	{
+		string path1 = CacheFileReader.GetUserFolderCacheFilePath(@"C:\dev\Foo\Foo.csproj");
+		string path2 = CacheFileReader.GetUserFolderCacheFilePath(@"C:\dev\Bar\Bar.csproj");
+		Assert.NotEqual(path1, path2);
+	}
+
+	#endregion
+
+	#region Version 2 / Framework Packs
+
+	[Fact]
+	public async Task Version2_Header_Accepted()
+	{
+		string content = """
+			version=2
+
+			[project]
+			language=C#
+			""";
+
+		ImmutableArray<CachedSliceData> slices = await ParseAsync(content);
+		Assert.Single(slices);
+		Assert.Equal("C#", slices[0].LanguageName);
+	}
+
+	[Fact]
+	public async Task FrameworkPacks_Section_Is_Tolerated_Even_With_No_Pack_OnDisk()
+	{
+		// When the named pack isn't installed on the test machine, expansion is a no-op.
+		string content = """
+			version=2
+
+			[project]
+			language=C#
+
+			[sliceDimensions]
+			TargetFramework=net10.0
+
+			[frameworkPacks]
+			NoSuch.Pack.That.Does.Not.Exist
+			""";
+
+		ImmutableArray<CachedSliceData> slices = await ParseAsync(content);
+		Assert.Single(slices);
+		Assert.Empty(slices[0].MetadataReferences);
+		Assert.Empty(slices[0].AnalyzerReferences);
+	}
+
+	[Fact]
+	public async Task FrameworkPacks_Expand_Into_MetadataAndAnalyzer_References()
+	{
+		using TempPack pack = TempPack.Create("Test.Fake.Ref", "10.0.7", managed: ["System.Sample.dll"], analyzers: ["Sample.Analyzer.dll"]);
+
+		string content = $$"""
+			version=2
+
+			[project]
+			language=C#
+
+			[sliceDimensions]
+			TargetFramework=net10.0
+
+			[frameworkPacks]
+			Test.Fake.Ref
+			""";
+
+		ImmutableArray<CachedSliceData> slices = await ParseWithDotNetRoot(content, pack.DotNetRoot);
+
+		Assert.Single(slices);
+		Assert.Single(slices[0].MetadataReferences);
+		Assert.EndsWith("System.Sample.dll", slices[0].MetadataReferences[0].FilePath);
+		Assert.Single(slices[0].AnalyzerReferences);
+		Assert.EndsWith("Sample.Analyzer.dll", slices[0].AnalyzerReferences[0]);
+	}
+
+	[Fact]
+	public async Task FrameworkPacks_Expand_FromBoundSdkPathDotNetRoot()
+	{
+		using TempPack pack = TempPack.Create("Test.Fake.Ref", "10.0.7", managed: ["System.Sample.dll"], analyzers: [], targetFramework: "net10.0");
+		string sdkPath = Path.Combine(pack.DotNetRoot, "sdk", "10.0.100");
+		Directory.CreateDirectory(sdkPath);
+
+		string content = """
+			version=2
+
+			[project]
+			language=C#
+
+			[sliceDimensions]
+			TargetFramework=net10.0
+
+			[frameworkPacks]
+			Test.Fake.Ref
+			""";
+
+		content = StripLeadingTabs(content);
+		CachePathResolver resolver = new("10.0.100", sdkPath);
+		using StringReader reader = new(content);
+		ImmutableArray<CachedSliceData> slices = await CacheFileReader.ReadFromAsync(reader, resolver, @"C:\dev\TestProject", @"C:\dev\TestProject\TestProject.csproj");
+
+		Assert.Single(slices);
+		Assert.Single(slices[0].MetadataReferences);
+		Assert.EndsWith("System.Sample.dll", slices[0].MetadataReferences[0].FilePath);
+	}
+
+	[Fact]
+	public async Task FrameworkPacks_NuGetWinsConflict_PackEntriesWithSameBasenameAreSkipped()
+	{
+		using TempPack pack = TempPack.Create("Test.Fake.Ref", "10.0.7", managed: ["System.Text.Json.dll", "System.Sample.dll"], analyzers: []);
+
+		string content = $$"""
+			version=2
+
+			[project]
+			language=C#
+
+			[sliceDimensions]
+			TargetFramework=net10.0
+
+			[frameworkPacks]
+			Test.Fake.Ref
+
+			[metadataReferences]
+			<NUGET>/system.text.json/9.0.0/lib/net10.0/System.Text.Json.dll
+			""";
+
+		ImmutableArray<CachedSliceData> slices = await ParseWithDotNetRoot(content, pack.DotNetRoot);
+
+		Assert.Single(slices);
+		// Expect: explicit NuGet entry + System.Sample.dll from pack (NOT the pack's System.Text.Json.dll).
+		Assert.Equal(2, slices[0].MetadataReferences.Length);
+		Assert.Single(slices[0].MetadataReferences, r => r.FilePath.Contains("system.text.json", StringComparison.OrdinalIgnoreCase));
+		Assert.Single(slices[0].MetadataReferences, r => r.FilePath.EndsWith("System.Sample.dll"));
+		Assert.DoesNotContain(slices[0].MetadataReferences, r => r.FilePath.Contains(Path.Combine("Test.Fake.Ref", "10.0.7"), StringComparison.OrdinalIgnoreCase) && r.FilePath.EndsWith("System.Text.Json.dll"));
+	}
+
+	[Fact]
+	public async Task FrameworkPacks_PicksHighestInstalledMatchingTfmMajor()
+	{
+		using TempPack pack = TempPack.Create("Test.Fake.Ref", "10.0.3", managed: ["Old.dll"], analyzers: []);
+		// Add a higher version under the same root.
+		string higherVerDir = Path.Combine(pack.DotNetRoot, "packs", "Test.Fake.Ref", "10.0.7");
+		Directory.CreateDirectory(Path.Combine(higherVerDir, "ref", "net10.0"));
+		Directory.CreateDirectory(Path.Combine(higherVerDir, "data"));
+		File.WriteAllText(
+			Path.Combine(higherVerDir, "data", "FrameworkList.xml"),
+			"<FileList><File Type=\"Managed\" Path=\"ref/net10.0/New.dll\"/></FileList>");
+		File.WriteAllText(Path.Combine(higherVerDir, "ref", "net10.0", "New.dll"), string.Empty);
+
+		string content = """
+			version=2
+
+			[project]
+			language=C#
+
+			[sliceDimensions]
+			TargetFramework=net10.0
+
+			[frameworkPacks]
+			Test.Fake.Ref
+			""";
+
+		ImmutableArray<CachedSliceData> slices = await ParseWithDotNetRoot(content, pack.DotNetRoot);
+
+		Assert.Single(slices);
+		Assert.Single(slices[0].MetadataReferences);
+		Assert.EndsWith("New.dll", slices[0].MetadataReferences[0].FilePath);
+	}
+
+	[Fact]
+	public async Task FrameworkPacks_Expand_PrereleasePackVersion_ForPreviewTfm()
+	{
+		using TempPack pack = TempPack.Create(
+			"Test.Fake.Ref",
+			"11.0.0-preview.3.26207.106",
+			managed: ["Preview.dll"],
+			analyzers: [],
+			targetFramework: "net11.0");
+
+		string content = """
+			version=2
+
+			[project]
+			language=C#
+
+			[sliceDimensions]
+			TargetFramework=net11.0
+
+			[frameworkPacks]
+			Test.Fake.Ref
+			""";
+
+		ImmutableArray<CachedSliceData> slices = await ParseWithDotNetRoot(content, pack.DotNetRoot);
+
+		Assert.Single(slices);
+		Assert.Single(slices[0].MetadataReferences);
+		Assert.EndsWith("Preview.dll", slices[0].MetadataReferences[0].FilePath);
+	}
+
+	[Fact]
+	public async Task FrameworkPacks_FallsBackToNuGet_ExactSdkKnownPackageVersion()
+	{
+		using TempNuGetPack pack = TempNuGetPack.Create(
+			packName: "Microsoft.NETCore.App.Ref",
+			sdkKnownVersion: "8.0.26",
+			installedVersions: [("8.0.26", "Exact.dll"), ("8.0.25", "Fallback.dll")],
+			targetFramework: "net8.0");
+
+		string content = """
+			version=2
+
+			[project]
+			language=C#
+
+			[sliceDimensions]
+			TargetFramework=net8.0
+
+			[frameworkPacks]
+			Microsoft.NETCore.App.Ref
+			""";
+
+		ImmutableArray<CachedSliceData> slices = await ParseWithNuGetRoot(content, pack.NuGetRoot, pack.SdkPath);
+
+		Assert.Single(slices);
+		Assert.Single(slices[0].MetadataReferences);
+		Assert.EndsWith("Exact.dll", slices[0].MetadataReferences[0].FilePath);
+	}
+
+	[Fact]
+	public async Task FrameworkPacks_FallsBackToNuGet_HighestInstalledMatchingTfmMajor()
+	{
+		using TempNuGetPack pack = TempNuGetPack.Create(
+			packName: "Microsoft.NETCore.App.Ref",
+			sdkKnownVersion: "8.0.26",
+			installedVersions: [("8.0.24", "Old.dll"), ("8.0.25", "Fallback.dll"), ("9.0.1", "WrongMajor.dll")],
+			targetFramework: "net8.0");
+
+		string content = """
+			version=2
+
+			[project]
+			language=C#
+
+			[sliceDimensions]
+			TargetFramework=net8.0
+
+			[frameworkPacks]
+			Microsoft.NETCore.App.Ref
+			""";
+
+		ImmutableArray<CachedSliceData> slices = await ParseWithNuGetRoot(content, pack.NuGetRoot, pack.SdkPath);
+
+		Assert.Single(slices);
+		Assert.Single(slices[0].MetadataReferences);
+		Assert.EndsWith("Fallback.dll", slices[0].MetadataReferences[0].FilePath);
+	}
+
+	[Fact]
+	public async Task FrameworkPacks_MissingPackage_IsTolerated()
+	{
+		using TempNuGetPack pack = TempNuGetPack.Create(
+			packName: "Microsoft.NETCore.App.Ref",
+			sdkKnownVersion: "8.0.26",
+			installedVersions: [],
+			targetFramework: "net8.0");
+
+		string content = """
+			version=2
+
+			[project]
+			language=C#
+
+			[sliceDimensions]
+			TargetFramework=net8.0
+
+			[frameworkPacks]
+			Microsoft.NETCore.App.Ref
+			""";
+
+		ImmutableArray<CachedSliceData> slices = await ParseWithNuGetRoot(content, pack.NuGetRoot, pack.SdkPath);
+
+		Assert.Single(slices);
+		Assert.Empty(slices[0].MetadataReferences);
+		Assert.Empty(slices[0].AnalyzerReferences);
+	}
+
+	/// <summary>
+	/// Regression for a test-isolation leak: <see cref="ParseWithDotNetRoot"/> used to
+	/// set <c>DOTNET_ROOT</c> and then construct <see cref="CachePathResolver"/> via its
+	/// ambient-env constructor, which also unconditionally probes
+	/// <c>C:\Program Files\dotnet</c>, <c>~/.dotnet</c>, etc. On developer machines that
+	/// have <c>Microsoft.NETCore.App.Ref 8.0.x</c> installed under
+	/// <c>Program Files\dotnet\packs\</c>, a <c>[frameworkPacks] Microsoft.NETCore.App.Ref</c>
+	/// entry on <c>net8.0</c> resolved to the real system pack (163 DLLs) instead of finding
+	/// nothing under the synthetic test root. CI didn't catch it because runners don't have
+	/// that pack installed. This test asserts the helper produces a resolver whose dotnet
+	/// roots are exactly what the test supplied.
+	/// </summary>
+	[Fact]
+	public async Task FrameworkPacks_DoesNotResolveFromAmbientDotNetInstall()
+	{
+		// Synthetic root contains an unrelated pack name, so any `Microsoft.NETCore.App.Ref`
+		// match could only come from the host's real `dotnet` install — which the test
+		// helper must isolate against.
+		using TempPack pack = TempPack.Create("Test.Unrelated.Ref", "10.0.7", managed: ["X.dll"], analyzers: []);
+
+		string content = """
+			version=2
+
+			[project]
+			language=C#
+
+			[sliceDimensions]
+			TargetFramework=net8.0
+
+			[frameworkPacks]
+			Microsoft.NETCore.App.Ref
+			""";
+
+		ImmutableArray<CachedSliceData> slices = await ParseWithDotNetRoot(content, pack.DotNetRoot);
+
+		Assert.Single(slices);
+		Assert.Empty(slices[0].MetadataReferences);
+		Assert.Empty(slices[0].AnalyzerReferences);
+	}
+
+	[Fact]
+	public async Task NetFxRefMetadataReferences_ExpandFromNuGetPackage()
+	{
+		using TempNetFrameworkReferenceAssemblies pack = TempNetFrameworkReferenceAssemblies.Create(
+			version: "v4.7.2",
+			assemblies: ["mscorlib.dll", "System.dll", Path.Combine("Facades", "System.Runtime.dll")]);
+
+		string content = """
+			version=2
+
+			[project]
+			language=C#
+
+			[sliceDimensions]
+			TargetFramework=net472
+
+			[metadataReferences]
+			<NETFXREF>/v4.7.2/mscorlib.dll
+			<NETFXREF>/v4.7.2/Facades/System.Runtime.dll
+			""";
+
+		ImmutableArray<CachedSliceData> slices = await ParseWithNuGetRoot(content, pack.NuGetRoot, pack.SdkPath);
+
+		Assert.Single(slices);
+		Assert.Equal(2, slices[0].MetadataReferences.Length);
+		Assert.Contains(slices[0].MetadataReferences, reference => reference.FilePath.EndsWith(Path.Combine("v4.7.2", "mscorlib.dll"), StringComparison.OrdinalIgnoreCase));
+		Assert.Contains(slices[0].MetadataReferences, reference => reference.FilePath.EndsWith(Path.Combine("Facades", "System.Runtime.dll"), StringComparison.OrdinalIgnoreCase));
+	}
+
+	[Fact]
+	public async Task NetFxRefMetadataReferences_MissingPackage_IsTolerated()
+	{
+		const string missingVersion = "v9.9.9";
+		using TempNetFrameworkReferenceAssemblies pack = TempNetFrameworkReferenceAssemblies.Create(version: missingVersion, assemblies: []);
+
+		string content = """
+			version=2
+
+			[project]
+			language=C#
+
+			[sliceDimensions]
+			TargetFramework=net472
+
+			[metadataReferences]
+			<NETFXREF>/v9.9.9/mscorlib.dll
+			""";
+
+		ImmutableArray<CachedSliceData> slices = await ParseWithNuGetRoot(content, pack.NuGetRoot, pack.SdkPath);
+
+		Assert.Single(slices);
+		Assert.Empty(slices[0].MetadataReferences);
+	}
+
+	[Fact]
+	public async Task SdkAnalyzerPacks_Expand_ExactSdkKnownPackageVersion()
+	{
+		using TempSdkAnalyzerPack pack = TempSdkAnalyzerPack.Create(
+			packageId: "Microsoft.NET.ILLink.Tasks",
+			sdkKnownVersion: "10.0.7",
+			installedVersions: [("10.0.7", "Exact.dll"), ("10.0.8", "Wrong.dll")],
+			targetFramework: "net10.0");
+
+		string content = """
+			version=2
+
+			[project]
+			language=C#
+
+			[sliceDimensions]
+			TargetFramework=net10.0
+
+			[sdkAnalyzerPacks]
+			Microsoft.NET.ILLink.Tasks
+			""";
+
+		ImmutableArray<CachedSliceData> slices = await ParseWithNuGetRoot(content, pack.NuGetRoot, pack.SdkPath);
+
+		Assert.Single(slices);
+		Assert.Single(slices[0].AnalyzerReferences);
+		Assert.EndsWith("Exact.dll", slices[0].AnalyzerReferences[0]);
+	}
+
+	[Fact]
+	public async Task SdkAnalyzerPacks_FallsBackToHighestInstalledMatchingTfmMajor()
+	{
+		using TempSdkAnalyzerPack pack = TempSdkAnalyzerPack.Create(
+			packageId: "Microsoft.NET.ILLink.Tasks",
+			sdkKnownVersion: "10.0.9",
+			installedVersions: [("10.0.5", "Old.dll"), ("10.0.8", "Fallback.dll"), ("9.0.9", "WrongMajor.dll")],
+			targetFramework: "net10.0");
+
+		string content = """
+			version=2
+
+			[project]
+			language=C#
+
+			[sliceDimensions]
+			TargetFramework=net10.0
+
+			[sdkAnalyzerPacks]
+			Microsoft.NET.ILLink.Tasks
+			""";
+
+		ImmutableArray<CachedSliceData> slices = await ParseWithNuGetRoot(content, pack.NuGetRoot, pack.SdkPath);
+
+		Assert.Single(slices);
+		Assert.Single(slices[0].AnalyzerReferences);
+		Assert.EndsWith("Fallback.dll", slices[0].AnalyzerReferences[0]);
+	}
+
+	[Fact]
+	public async Task SdkAnalyzerPacks_MissingPackage_IsTolerated()
+	{
+		using TempSdkAnalyzerPack pack = TempSdkAnalyzerPack.Create(
+			packageId: "Microsoft.NET.ILLink.Tasks",
+			sdkKnownVersion: "10.0.7",
+			installedVersions: [],
+			targetFramework: "net10.0");
+
+		string content = """
+			version=2
+
+			[project]
+			language=C#
+
+			[sliceDimensions]
+			TargetFramework=net10.0
+
+			[sdkAnalyzerPacks]
+			Microsoft.NET.ILLink.Tasks
+			""";
+
+		ImmutableArray<CachedSliceData> slices = await ParseWithNuGetRoot(content, pack.NuGetRoot, pack.SdkPath);
+
+		Assert.Single(slices);
+		Assert.Empty(slices[0].AnalyzerReferences);
+	}
+
+	[Fact]
+	public async Task SdkAnalyzerConfigPolicy_DefaultAnalysisLevel_ResolvesFromTargetFramework()
+	{
+		const string content = """
+			version=2
+
+			[project]
+			language=C#
+
+			[sliceDimensions]
+			TargetFramework=net10.0
+
+			[sdkAnalyzerConfigPolicy]
+			Microsoft.NET.Sdk/analyzers
+			Microsoft.NET.Sdk/codestyle/cs
+			""";
+
+		using TempSdkAnalyzerConfigFiles sdk10 = TempSdkAnalyzerConfigFiles.Create(latestAnalysisLevel: "10.0");
+		ImmutableArray<CachedSliceData> sdk10Slices = await ParseWithNuGetRoot(content, sdk10.NuGetRoot, sdk10.SdkPath);
+
+		Assert.Single(sdk10Slices);
+		Assert.Single(sdk10Slices[0].AnalyzerConfigFiles);
+		Assert.Contains(sdk10Slices[0].AnalyzerConfigFiles, path => path.EndsWith(Path.Combine("config", "analysislevel_10_default.globalconfig"), StringComparison.OrdinalIgnoreCase));
+		Assert.DoesNotContain(sdk10Slices[0].AnalyzerConfigFiles, path => path.EndsWith(Path.Combine("config", "analysislevelstyle_default.globalconfig"), StringComparison.OrdinalIgnoreCase));
+
+		using TempSdkAnalyzerConfigFiles sdk11 = TempSdkAnalyzerConfigFiles.Create(latestAnalysisLevel: "11.0");
+		ImmutableArray<CachedSliceData> sdk11Slices = await ParseWithNuGetRoot(content, sdk11.NuGetRoot, sdk11.SdkPath);
+
+		Assert.Single(sdk11Slices);
+		Assert.Single(sdk11Slices[0].AnalyzerConfigFiles);
+		Assert.Contains(sdk11Slices[0].AnalyzerConfigFiles, path => path.EndsWith(Path.Combine("config", "analysislevel_10_default.globalconfig"), StringComparison.OrdinalIgnoreCase));
+		Assert.DoesNotContain(sdk11Slices[0].AnalyzerConfigFiles, path => path.EndsWith(Path.Combine("config", "analysislevelstyle_default.globalconfig"), StringComparison.OrdinalIgnoreCase));
+	}
+
+	[Fact]
+	public async Task SdkAnalyzerConfigPolicy_ExplicitLatest_ResolvesUsingSelectedSdkLatest()
+	{
+		const string content = """
+			version=2
+
+			[project]
+			language=C#
+
+			[sliceDimensions]
+			TargetFramework=net10.0
+
+			[sdkAnalyzerConfigPolicy]
+			Microsoft.NET.Sdk/analyzers|AnalysisLevel=latest
+			Microsoft.NET.Sdk/codestyle/cs|AnalysisLevel=latest
+			""";
+
+		using TempSdkAnalyzerConfigFiles sdk11 = TempSdkAnalyzerConfigFiles.Create(latestAnalysisLevel: "11.0");
+		ImmutableArray<CachedSliceData> sdk11Slices = await ParseWithNuGetRoot(content, sdk11.NuGetRoot, sdk11.SdkPath);
+
+		Assert.Single(sdk11Slices);
+		Assert.Equal(2, sdk11Slices[0].AnalyzerConfigFiles.Length);
+		Assert.Contains(sdk11Slices[0].AnalyzerConfigFiles, path => path.EndsWith(Path.Combine("config", "analysislevel_11_default.globalconfig"), StringComparison.OrdinalIgnoreCase));
+		Assert.Contains(sdk11Slices[0].AnalyzerConfigFiles, path => path.EndsWith(Path.Combine("config", "analysislevelstyle_default.globalconfig"), StringComparison.OrdinalIgnoreCase));
+	}
+
+	[Fact]
+	public async Task SdkAnalyzerConfigPolicy_NoSdkBinding_IsTolerated()
+	{
+		string content = """
+			version=2
+
+			[project]
+			language=C#
+
+			[sdkAnalyzerConfigPolicy]
+			Microsoft.NET.Sdk/analyzers|AnalysisLevel=latest
+			Microsoft.NET.Sdk/codestyle/cs|AnalysisLevel=latest
+			""";
+
+		ImmutableArray<CachedSliceData> slices = await ParseWithoutSdkBinding(content);
+
+		Assert.Single(slices);
+		Assert.Empty(slices[0].AnalyzerConfigFiles);
+	}
+
+	private static async Task<ImmutableArray<CachedSliceData>> ParseWithDotNetRoot(string content, string dotnetRoot)
+	{
+		content = StripLeadingTabs(content);
+		CachePathResolver resolver = new(
+			sdkVersion: null,
+			sdkPath: null,
+			dotnetRoots: [dotnetRoot],
+			nugetFolders: [],
+			netFxRefRoot: null);
+		using StringReader reader = new(content);
+		return await CacheFileReader.ReadFromAsync(reader, resolver, @"C:\dev\TestProject", @"C:\dev\TestProject\TestProject.csproj");
+	}
+
+	private static async Task<ImmutableArray<CachedSliceData>> ParseWithoutSdkBinding(string content)
+	{
+		content = StripLeadingTabs(content);
+		CachePathResolver resolver = new(
+			sdkVersion: null,
+			sdkPath: null,
+			dotnetRoots: [],
+			nugetFolders: [],
+			netFxRefRoot: null);
+		using StringReader reader = new(content);
+		return await CacheFileReader.ReadFromAsync(reader, resolver, @"C:\dev\TestProject", @"C:\dev\TestProject\TestProject.csproj");
+	}
+
+	private static async Task<ImmutableArray<CachedSliceData>> ParseWithNuGetRoot(string content, string nugetRoot, string sdkPath)
+	{
+		content = StripLeadingTabs(content);
+		CachePathResolver resolver = new(
+			sdkVersion: "10.0.100",
+			sdkPath: sdkPath,
+			dotnetRoots: [],
+			nugetFolders: [nugetRoot],
+			netFxRefRoot: null);
+		using StringReader reader = new(content);
+		return await CacheFileReader.ReadFromAsync(reader, resolver, @"C:\dev\TestProject", @"C:\dev\TestProject\TestProject.csproj");
+	}
+
+	/// <summary>
+	/// Creates a synthetic on-disk SDK ref pack layout with a FrameworkList.xml and empty
+	/// reference / analyzer files, rooted under a temp dotnet folder. Returns the path of
+	/// that synthetic dotnet root for use as DOTNET_ROOT.
+	/// </summary>
+	private sealed class TempPack : IDisposable
+	{
+		public string DotNetRoot { get; }
+		private readonly string root;
+
+		private TempPack(string dotnetRoot, string root)
+		{
+			this.DotNetRoot = dotnetRoot;
+			this.root = root;
+		}
+
+		public static TempPack Create(string packName, string packVersion, IEnumerable<string> managed, IEnumerable<string> analyzers, string targetFramework = "net10.0")
+		{
+			string root = Path.Combine(Path.GetTempPath(), "lscache-pack-" + Guid.NewGuid().ToString("N"));
+			string dotnetRoot = Path.Combine(root, "dotnet");
+			string packDir = Path.Combine(dotnetRoot, "packs", packName, packVersion);
+			string dataDir = Path.Combine(packDir, "data");
+			string refDir = Path.Combine(packDir, "ref", targetFramework);
+			string analyzerDir = Path.Combine(packDir, "analyzers", "dotnet", "cs");
+			Directory.CreateDirectory(dataDir);
+			Directory.CreateDirectory(refDir);
+			Directory.CreateDirectory(analyzerDir);
+
+			System.Text.StringBuilder sb = new();
+			sb.Append("<FileList>");
+			foreach (string m in managed)
+			{
+				sb.Append($"<File Type=\"Managed\" Path=\"ref/{targetFramework}/{m}\" AssemblyName=\"{Path.GetFileNameWithoutExtension(m)}\" />");
+				File.WriteAllText(Path.Combine(refDir, m), string.Empty);
+			}
+			foreach (string a in analyzers)
+			{
+				sb.Append($"<File Type=\"Analyzer\" Language=\"cs\" Path=\"analyzers/dotnet/cs/{a}\" />");
+				File.WriteAllText(Path.Combine(analyzerDir, a), string.Empty);
+			}
+			sb.Append("</FileList>");
+			File.WriteAllText(Path.Combine(dataDir, "FrameworkList.xml"), sb.ToString());
+
+			return new TempPack(dotnetRoot, root);
+		}
+
+		public void Dispose()
+		{
+			try { Directory.Delete(this.root, recursive: true); } catch { }
+		}
+	}
+
+	private sealed class TempNuGetPack : IDisposable
+	{
+		public string NuGetRoot { get; }
+		public string SdkPath { get; }
+		private readonly string root;
+
+		private TempNuGetPack(string root, string nugetRoot, string sdkPath)
+		{
+			this.root = root;
+			this.NuGetRoot = nugetRoot;
+			this.SdkPath = sdkPath;
+		}
+
+		public static TempNuGetPack Create(
+			string packName,
+			string sdkKnownVersion,
+			IEnumerable<(string Version, string ManagedAssembly)> installedVersions,
+			string targetFramework)
+		{
+			string root = Path.Combine(Path.GetTempPath(), "lscache-nuget-pack-" + Guid.NewGuid().ToString("N"));
+			string nugetRoot = Path.Combine(root, "nuget");
+			string sdkPath = Path.Combine(root, "dotnet", "sdk", "10.0.100");
+			Directory.CreateDirectory(sdkPath);
+			File.WriteAllText(
+				Path.Combine(sdkPath, "Microsoft.NETCoreSdk.BundledVersions.props"),
+				$"""
+				<Project>
+				  <ItemGroup>
+				    <KnownFrameworkReference Include="Microsoft.NETCore.App" TargetFramework="{targetFramework}" TargetingPackName="{packName}" TargetingPackVersion="{sdkKnownVersion}" />
+				  </ItemGroup>
+				</Project>
+				""");
+
+			foreach ((string version, string managedAssembly) in installedVersions)
+			{
+				string packDir = Path.Combine(nugetRoot, packName.ToLowerInvariant(), version);
+				string dataDir = Path.Combine(packDir, "data");
+				string refDir = Path.Combine(packDir, "ref", targetFramework);
+				Directory.CreateDirectory(dataDir);
+				Directory.CreateDirectory(refDir);
+				File.WriteAllText(
+					Path.Combine(dataDir, "FrameworkList.xml"),
+					$"<FileList><File Type=\"Managed\" Path=\"ref/{targetFramework}/{managedAssembly}\" /></FileList>");
+				File.WriteAllText(Path.Combine(refDir, managedAssembly), string.Empty);
+			}
+
+			return new TempNuGetPack(root, nugetRoot, sdkPath);
+		}
+
+		public void Dispose()
+		{
+			try { Directory.Delete(this.root, recursive: true); } catch { }
+		}
+	}
+
+	private sealed class TempNetFrameworkReferenceAssemblies : IDisposable
+	{
+		public string NuGetRoot { get; }
+		public string SdkPath { get; }
+		private readonly string root;
+
+		private TempNetFrameworkReferenceAssemblies(string root, string nugetRoot, string sdkPath)
+		{
+			this.root = root;
+			this.NuGetRoot = nugetRoot;
+			this.SdkPath = sdkPath;
+		}
+
+		public static TempNetFrameworkReferenceAssemblies Create(string version, IEnumerable<string> assemblies)
+		{
+			string root = Path.Combine(Path.GetTempPath(), "lscache-netfx-refs-" + Guid.NewGuid().ToString("N"));
+			string nugetRoot = Path.Combine(root, "nuget");
+			string sdkPath = Path.Combine(root, "dotnet", "sdk", "10.0.100");
+			Directory.CreateDirectory(sdkPath);
+
+			string packageId = "microsoft.netframework.referenceassemblies.net" + version.Replace("v", string.Empty, StringComparison.OrdinalIgnoreCase).Replace(".", string.Empty, StringComparison.Ordinal);
+			string refDir = Path.Combine(nugetRoot, packageId, "1.0.3", "build", ".NETFramework", version);
+			foreach (string assembly in assemblies)
+			{
+				string path = Path.Combine(refDir, assembly);
+				Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+				File.WriteAllText(path, string.Empty);
+			}
+
+			return new TempNetFrameworkReferenceAssemblies(root, nugetRoot, sdkPath);
+		}
+
+		public void Dispose()
+		{
+			try { Directory.Delete(this.root, recursive: true); } catch { }
+		}
+	}
+
+	private sealed class TempSdkAnalyzerPack : IDisposable
+	{
+		public string NuGetRoot { get; }
+		public string SdkPath { get; }
+		private readonly string root;
+
+		private TempSdkAnalyzerPack(string root, string nugetRoot, string sdkPath)
+		{
+			this.root = root;
+			this.NuGetRoot = nugetRoot;
+			this.SdkPath = sdkPath;
+		}
+
+		public static TempSdkAnalyzerPack Create(
+			string packageId,
+			string sdkKnownVersion,
+			IEnumerable<(string Version, string AnalyzerAssembly)> installedVersions,
+			string targetFramework)
+		{
+			string root = Path.Combine(Path.GetTempPath(), "lscache-sdk-analyzer-pack-" + Guid.NewGuid().ToString("N"));
+			string nugetRoot = Path.Combine(root, "nuget");
+			string sdkPath = Path.Combine(root, "dotnet", "sdk", "10.0.100");
+			Directory.CreateDirectory(sdkPath);
+			File.WriteAllText(
+				Path.Combine(sdkPath, "Microsoft.NETCoreSdk.BundledVersions.props"),
+				$"""
+				<Project>
+				  <ItemGroup>
+				    <KnownILLinkPack Include="{packageId}" TargetFramework="{targetFramework}" ILLinkPackVersion="{sdkKnownVersion}" />
+				  </ItemGroup>
+				</Project>
+				""");
+
+			foreach ((string version, string analyzerAssembly) in installedVersions)
+			{
+				string analyzerDir = Path.Combine(nugetRoot, packageId.ToLowerInvariant(), version, "analyzers", "dotnet", "cs");
+				Directory.CreateDirectory(analyzerDir);
+				File.WriteAllText(Path.Combine(analyzerDir, analyzerAssembly), string.Empty);
+			}
+
+			return new TempSdkAnalyzerPack(root, nugetRoot, sdkPath);
+		}
+
+		public void Dispose()
+		{
+			try { Directory.Delete(this.root, recursive: true); } catch { }
+		}
+	}
+
+	private sealed class TempSdkAnalyzerConfigFiles : IDisposable
+	{
+		public string NuGetRoot { get; }
+		public string SdkPath { get; }
+		private readonly string root;
+
+		private TempSdkAnalyzerConfigFiles(string root, string nugetRoot, string sdkPath)
+		{
+			this.root = root;
+			this.NuGetRoot = nugetRoot;
+			this.SdkPath = sdkPath;
+		}
+
+		public static TempSdkAnalyzerConfigFiles Create(string latestAnalysisLevel = "10.0")
+		{
+			string root = Path.Combine(Path.GetTempPath(), "lscache-sdk-analyzer-config-" + Guid.NewGuid().ToString("N"));
+			string nugetRoot = Path.Combine(root, "nuget");
+			string sdkPath = Path.Combine(root, "dotnet", "sdk", "10.0.100");
+			string targetsDir = Path.Combine(sdkPath, "Sdks", "Microsoft.NET.Sdk", "targets");
+			string analyzerConfigDir = Path.Combine(sdkPath, "Sdks", "Microsoft.NET.Sdk", "analyzers", "build", "config");
+			string codeStyleConfigDir = Path.Combine(sdkPath, "Sdks", "Microsoft.NET.Sdk", "codestyle", "cs", "build", "config");
+			Directory.CreateDirectory(targetsDir);
+			Directory.CreateDirectory(analyzerConfigDir);
+			Directory.CreateDirectory(codeStyleConfigDir);
+			File.WriteAllText(Path.Combine(targetsDir, "Microsoft.NET.Sdk.Analyzers.targets"), $"""
+				<Project>
+				  <PropertyGroup>
+				    <_NoneAnalysisLevel>4.0</_NoneAnalysisLevel>
+				    <_LatestAnalysisLevel>{latestAnalysisLevel}</_LatestAnalysisLevel>
+				    <_PreviewAnalysisLevel>12.0</_PreviewAnalysisLevel>
+				  </PropertyGroup>
+				</Project>
+				""");
+			File.WriteAllText(Path.Combine(analyzerConfigDir, "analysislevel_10_default.globalconfig"), string.Empty);
+			File.WriteAllText(Path.Combine(analyzerConfigDir, "analysislevel_11_default.globalconfig"), string.Empty);
+			File.WriteAllText(Path.Combine(codeStyleConfigDir, "analysislevelstyle_default.globalconfig"), string.Empty);
+
+			return new TempSdkAnalyzerConfigFiles(root, nugetRoot, sdkPath);
+		}
+
+		public void Dispose()
+		{
+			try { Directory.Delete(this.root, recursive: true); } catch { }
+		}
+	}
+
+	#endregion
+
+	/// <summary>
+	/// Helper to parse a cache file from a string using the test project directory.
+	/// </summary>
+	private static async Task<ImmutableArray<CachedSliceData>> ParseAsync(string content)
+	{
+		// Normalize indentation — test strings use tab indentation which we strip.
+		content = StripLeadingTabs(content);
+
+		using StringReader reader = new(content);
+		return await CacheFileReader.ReadFromAsync(reader, Resolver, TestProjectDirectory, TestProjectFilePath);
+	}
+
+	private static string StripLeadingTabs(string content)
+	{
+		string[] lines = content.Split('\n');
+		// Find the minimum tab indentation (ignoring empty lines).
+		int minTabs = int.MaxValue;
+		foreach (string line in lines)
+		{
+			if (line.Trim().Length == 0)
+				continue;
+			int tabs = 0;
+			foreach (char c in line)
+			{
+				if (c == '\t')
+					tabs++;
+				else
+					break;
+			}
+			minTabs = Math.Min(minTabs, tabs);
+		}
+
+		if (minTabs == int.MaxValue || minTabs == 0)
+			return content;
+
+		return string.Join('\n', lines.Select(l => l.Length > minTabs ? l[minTabs..] : l));
+	}
+
+	// Captures Trace output by severity so a test can assert that a given message was emitted at
+	// Information level (and NOT as a Warning). Only used while explicitly added to Trace.Listeners
+	// inside a test; this collection disables parallelization, so no other test logs concurrently.
+	private sealed class CapturingTraceListener : TraceListener
+	{
+		private readonly StringBuilder information = new();
+		private readonly StringBuilder warnings = new();
+
+		public string Information => this.information.ToString();
+
+		public string Warnings => this.warnings.ToString();
+
+		public override bool IsThreadSafe => false;
+
+		public void Clear()
+		{
+			this.information.Clear();
+			this.warnings.Clear();
+		}
+
+		public override void TraceEvent(TraceEventCache? eventCache, string source, TraceEventType eventType, int id, string? message)
+		{
+			StringBuilder? sink = eventType switch
+			{
+				TraceEventType.Information => this.information,
+				TraceEventType.Warning => this.warnings,
+				_ => null,
+			};
+			sink?.Append(message).Append('\n');
+		}
+
+		public override void TraceEvent(TraceEventCache? eventCache, string source, TraceEventType eventType, int id, string? format, params object?[]? args)
+			=> this.TraceEvent(eventCache, source, eventType, id, args is null ? format : string.Format(format ?? string.Empty, args));
+
+		// Unused for event-based tracing, but TraceListener requires them.
+		public override void Write(string? message)
+		{
+		}
+
+		public override void WriteLine(string? message)
+		{
+		}
+	}
+}

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Tests/CachePathResolverNetSdkTests.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Tests/CachePathResolverNetSdkTests.cs
@@ -1,0 +1,157 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+namespace Microsoft.NET.ProjectData.Tests;
+
+/// <summary>
+/// Tests for the <c>&lt;NETSDK&gt;</c> sentinel introduced for SDK-shipped content
+/// (analyzers, global configs). The cache file is environment-agnostic — it stores
+/// paths under <c>&lt;DOTNET&gt;/sdk/&lt;ver&gt;/...</c> as <c>&lt;NETSDK&gt;/...</c>
+/// without a version, and the resolver requires a caller-supplied SDK binding.
+/// </summary>
+[Collection(DotnetRootEnvCollection.Name)]
+public sealed class CachePathResolverNetSdkTests
+{
+	[Fact]
+	public void Resolve_WithoutBinding_IsNotBound()
+	{
+		var resolver = new CachePathResolver();
+		Assert.False(resolver.IsNetSdkBound);
+	}
+
+	[Fact]
+	public void Resolve_WithoutBinding_ThrowsWhenToAbsoluteCalledOnNetSdk()
+	{
+		// When unbound, callers must check IsNetSdkBound and not call ToAbsolute
+		// on <NETSDK> paths. This verifies the contract is enforced.
+		var resolver = new CachePathResolver();
+		Assert.False(resolver.IsNetSdkBound);
+		Assert.Throws<InvalidOperationException>(
+			() => resolver.ToAbsolute("<NETSDK>/Sdks/Microsoft.NET.Sdk/analyzers/Foo.dll", projectDirectory: "/p"));
+	}
+
+	[Fact]
+	public void Resolve_WithSdkPath_UsesPathDirectly_EvenIfNotOnDisk()
+	{
+		string sdkPath = OperatingSystem.IsWindows()
+			? @"C:\does\not\exist\dotnet\sdk\10.0.202"
+			: "/does/not/exist/dotnet/sdk/10.0.202";
+		var resolver = new CachePathResolver("10.0.202", sdkPath);
+		string result = resolver.ToAbsolute("<NETSDK>/Sdks/Microsoft.NET.Sdk/analyzers/Foo.dll", projectDirectory: "/p");
+		Assert.Equal(JoinPlat(sdkPath, "Sdks", "Microsoft.NET.Sdk", "analyzers", "Foo.dll"), result);
+	}
+
+	[Fact]
+	public void Resolve_WithSdkVersion_LocatesUnderInstalledRoot()
+	{
+		// Build a synthetic dotnet root and point DOTNET_ROOT at it.
+		string root = Path.Combine(Path.GetTempPath(), "lscache-netsdk-" + Guid.NewGuid().ToString("N"));
+		string sdkDir = Path.Combine(root, "dotnet", "sdk", "10.0.202", "Sdks", "Microsoft.NET.Sdk", "analyzers");
+		Directory.CreateDirectory(sdkDir);
+		File.WriteAllText(Path.Combine(sdkDir, "Foo.dll"), string.Empty);
+
+		string previous = Environment.GetEnvironmentVariable("DOTNET_ROOT") ?? string.Empty;
+		try
+		{
+			Environment.SetEnvironmentVariable("DOTNET_ROOT", Path.Combine(root, "dotnet"));
+			var resolver = new CachePathResolver("10.0.202");
+			string result = resolver.ToAbsolute("<NETSDK>/Sdks/Microsoft.NET.Sdk/analyzers/Foo.dll", projectDirectory: "/p");
+			Assert.Equal(
+				JoinPlat(root, "dotnet", "sdk", "10.0.202", "Sdks", "Microsoft.NET.Sdk", "analyzers", "Foo.dll"),
+				result);
+		}
+		finally
+		{
+			Environment.SetEnvironmentVariable("DOTNET_ROOT", previous);
+			try { Directory.Delete(root, recursive: true); } catch { }
+		}
+	}
+
+	[Fact]
+	public void Resolve_WithSdkVersion_NotInstalled_ReturnsBestEffortPath()
+	{
+		// No matching SDK on disk: the resolver constructs a path under the first known
+		// dotnet root anyway, mirroring the existing <DOTNET> "file not found" behavior.
+		// Caller deals with missing-on-disk via DTB regeneration.
+		string root = Path.Combine(Path.GetTempPath(), "lscache-netsdk-" + Guid.NewGuid().ToString("N"));
+		Directory.CreateDirectory(Path.Combine(root, "dotnet"));
+		string previous = Environment.GetEnvironmentVariable("DOTNET_ROOT") ?? string.Empty;
+		try
+		{
+			Environment.SetEnvironmentVariable("DOTNET_ROOT", Path.Combine(root, "dotnet"));
+			var resolver = new CachePathResolver("99.99.999");
+			string result = resolver.ToAbsolute("<NETSDK>/global.config", projectDirectory: "/p");
+			Assert.Contains("99.99.999", result);
+			Assert.EndsWith("global.config", result);
+		}
+		finally
+		{
+			Environment.SetEnvironmentVariable("DOTNET_ROOT", previous);
+			try { Directory.Delete(root, recursive: true); } catch { }
+		}
+	}
+
+	[Fact]
+	public void MakeAbsolute_EmbeddedNetSdk_Resolves()
+	{
+		string sdkPath = OperatingSystem.IsWindows()
+			? @"C:\dotnet\sdk\10.0.202"
+			: "/dotnet/sdk/10.0.202";
+		var resolver = new CachePathResolver("10.0.202", sdkPath);
+		string text = "/keyfile:<NETSDK>/keys/strong.snk";
+		string result = resolver.MakeAbsolute(text, projectDirectory: "/p");
+		Assert.Equal("/keyfile:" + JoinPlat(sdkPath, "keys", "strong.snk"), result);
+	}
+
+	[Fact]
+	public void Ctor_NullOrEmptyVersion_Throws()
+	{
+		Assert.Throws<ArgumentException>(() => new CachePathResolver(sdkVersion: ""));
+		Assert.Throws<ArgumentNullException>(() => new CachePathResolver(sdkVersion: null!));
+	}
+
+	/// <summary>
+	/// Regression for the test-isolation seam. The public constructors discover dotnet
+	/// roots from <c>DOTNET_ROOT</c> + ambient probes (<c>C:\Program Files\dotnet</c>, etc.).
+	/// The internal seam constructor must use the caller-supplied roots verbatim and
+	/// never consult the environment, even when <c>DOTNET_ROOT</c> points at a directory
+	/// that contains the pack being looked up.
+	/// </summary>
+	[Fact]
+	public void Ctor_ExplicitRoots_IgnoresAmbientDotNetRootEnvironment()
+	{
+		// Build a synthetic dotnet root that DOES contain Microsoft.NETCore.App.Ref/8.0.26.
+		// If the seam leaked to the ambient env, FindRefPackDirectory would return this path.
+		string ambientRoot = Path.Combine(Path.GetTempPath(), "lscache-ambient-leak-" + Guid.NewGuid().ToString("N"));
+		string ambientDotnet = Path.Combine(ambientRoot, "dotnet");
+		string ambientPack = Path.Combine(ambientDotnet, "packs", "Microsoft.NETCore.App.Ref", "8.0.26", "ref", "net8.0");
+		Directory.CreateDirectory(ambientPack);
+		File.WriteAllText(Path.Combine(ambientPack, "Ambient.dll"), string.Empty);
+
+		// Unrelated explicit root. Even though it exists, it doesn't contain the pack.
+		string explicitRoot = Path.Combine(Path.GetTempPath(), "lscache-explicit-" + Guid.NewGuid().ToString("N"));
+		Directory.CreateDirectory(explicitRoot);
+
+		string previous = Environment.GetEnvironmentVariable("DOTNET_ROOT") ?? string.Empty;
+		try
+		{
+			Environment.SetEnvironmentVariable("DOTNET_ROOT", ambientDotnet);
+
+			CachePathResolver resolver = new(
+				sdkVersion: null,
+				sdkPath: null,
+				dotnetRoots: [explicitRoot],
+				nugetFolders: [],
+				netFxRefRoot: null);
+
+			Assert.Null(resolver.FindRefPackDirectory("Microsoft.NETCore.App.Ref", "net8.0"));
+		}
+		finally
+		{
+			Environment.SetEnvironmentVariable("DOTNET_ROOT", previous);
+			try { Directory.Delete(ambientRoot, recursive: true); } catch { }
+			try { Directory.Delete(explicitRoot, recursive: true); } catch { }
+		}
+	}
+
+	private static string JoinPlat(params string[] parts) => Path.Combine(parts);
+}

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Tests/CachePathResolverNetSdkTests.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Tests/CachePathResolverNetSdkTests.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.NET.ProjectData.Tests;
 

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Tests/CachePathResolverNuGetPpTests.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Tests/CachePathResolverNuGetPpTests.cs
@@ -1,0 +1,244 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+namespace Microsoft.NET.ProjectData.Tests;
+
+/// <summary>
+/// Tests for the <c>&lt;NUGETPP&gt;</c> sentinel used for NuGet preprocessed content assets.
+/// The writer emits <c>&lt;NUGETPP&gt;/{PackageId}/{Version}/...</c> and the reader resolves
+/// it by scanning <c>obj/**/NuGet/*/</c> for the matching package-relative path.
+/// </summary>
+public sealed class CachePathResolverNuGetPpTests : IDisposable
+{
+	private readonly string tempRoot;
+	private readonly string projectDir;
+
+	public CachePathResolverNuGetPpTests()
+	{
+		this.tempRoot = Path.Combine(Path.GetTempPath(), "lscache-nugetpp-" + Guid.NewGuid().ToString("N"));
+		this.projectDir = Path.Combine(this.tempRoot, "proj");
+		Directory.CreateDirectory(this.projectDir);
+	}
+
+	public void Dispose()
+	{
+		try { Directory.Delete(this.tempRoot, recursive: true); } catch { }
+	}
+
+	[Fact]
+	public void ToAbsolute_NuGetPpSentinel_ResolvesWhenFileExists()
+	{
+		// Simulate: obj/Debug/net8.0/NuGet/7E7D116BF0B1C551/Nullable/1.3.0/Nullable/NullableAttributes.cs
+		string hashDir = Path.Combine(this.projectDir, "obj", "Debug", "net8.0", "NuGet", "7E7D116BF0B1C551", "Nullable", "1.3.0", "Nullable");
+		Directory.CreateDirectory(hashDir);
+		string expectedFile = Path.Combine(hashDir, "NullableAttributes.cs");
+		File.WriteAllText(expectedFile, string.Empty);
+
+		var resolver = new CachePathResolver();
+		string result = resolver.ToAbsolute("<NUGETPP>/Nullable/1.3.0/Nullable/NullableAttributes.cs", this.projectDir);
+
+		Assert.Equal(expectedFile, result);
+	}
+
+	[Fact]
+	public void ToAbsolute_NuGetPpSentinel_ResolvesWithDifferentHash()
+	{
+		// Different hash value — reader should still find the file
+		string hashDir = Path.Combine(this.projectDir, "obj", "Release", "net6.0", "NuGet", "ABCDEF0123456789", "Pkg", "2.0.0");
+		Directory.CreateDirectory(hashDir);
+		string expectedFile = Path.Combine(hashDir, "File.cs");
+		File.WriteAllText(expectedFile, string.Empty);
+
+		var resolver = new CachePathResolver();
+		string result = resolver.ToAbsolute("<NUGETPP>/Pkg/2.0.0/File.cs", this.projectDir);
+
+		Assert.Equal(expectedFile, result);
+	}
+
+	[Fact]
+	public void ToAbsolute_NuGetPpSentinel_FallsBackWhenNoObjExists()
+	{
+		// No obj/ directory — should return a best-effort path without throwing
+		var resolver = new CachePathResolver();
+		string result = resolver.ToAbsolute("<NUGETPP>/Nullable/1.3.0/Nullable/NullableAttributes.cs", this.projectDir);
+
+		Assert.Contains("NuGet", result);
+		Assert.EndsWith("NullableAttributes.cs", result);
+		Assert.StartsWith(Path.Combine(this.projectDir, "obj"), result);
+	}
+
+	[Fact]
+	public void ToAbsolute_NuGetPpSentinel_FallsBackWhenFileNotFound()
+	{
+		// obj/ exists but no matching file under any hash
+		string nugetDir = Path.Combine(this.projectDir, "obj", "Debug", "net8.0", "NuGet", "AAAAAAAAAAAAAAAA", "OtherPkg", "1.0.0");
+		Directory.CreateDirectory(nugetDir);
+
+		var resolver = new CachePathResolver();
+		string result = resolver.ToAbsolute("<NUGETPP>/Nullable/1.3.0/Nullable/NullableAttributes.cs", this.projectDir);
+
+		// Falls back to best-effort path
+		Assert.EndsWith("NullableAttributes.cs", result);
+	}
+
+	[Fact]
+	public void MakeAbsolute_NuGetPpSentinel_ResolvesInlineOccurrence()
+	{
+		// Simulate the file on disk
+		string hashDir = Path.Combine(this.projectDir, "obj", "Debug", "net8.0", "NuGet", "1234567890ABCDEF", "Nullable", "1.3.0", "Nullable");
+		Directory.CreateDirectory(hashDir);
+		string expectedFile = Path.Combine(hashDir, "NullableAttributes.cs");
+		File.WriteAllText(expectedFile, string.Empty);
+
+		var resolver = new CachePathResolver();
+		string result = resolver.MakeAbsolute("/some/prefix<NUGETPP>/Nullable/1.3.0/Nullable/NullableAttributes.cs", this.projectDir);
+
+		Assert.StartsWith("/some/prefix", result);
+		Assert.EndsWith("NullableAttributes.cs", result);
+		Assert.Contains("NuGet", result);
+	}
+
+	[Fact]
+	public void ToAbsolute_NuGetPpSentinel_MultipleHashDirs_FindsCorrectOne()
+	{
+		// Two hash dirs exist, only one has the target file
+		string wrongHash = Path.Combine(this.projectDir, "obj", "Debug", "net8.0", "NuGet", "0000000000000000", "Nullable", "1.3.0", "Nullable");
+		string rightHash = Path.Combine(this.projectDir, "obj", "Debug", "net8.0", "NuGet", "FFFFFFFFFFFFFFFF", "Nullable", "1.3.0", "Nullable");
+		Directory.CreateDirectory(wrongHash);
+		Directory.CreateDirectory(rightHash);
+		string expectedFile = Path.Combine(rightHash, "NullableAttributes.cs");
+		File.WriteAllText(expectedFile, string.Empty);
+
+		var resolver = new CachePathResolver();
+		string result = resolver.ToAbsolute("<NUGETPP>/Nullable/1.3.0/Nullable/NullableAttributes.cs", this.projectDir);
+
+		Assert.Equal(expectedFile, result);
+	}
+
+	[Fact]
+	public void ToAbsolute_NuGetPpSentinel_PrefersDebugOverOtherConfigurations()
+	{
+		// Both obj/Debug/.../NuGet and obj/Release/.../NuGet contain the file under
+		// different hashes. The resolver must prefer Debug even when Release is
+		// chronologically newer, because the committed lscaches are generated in
+		// Debug (the refresh-lscache skill always builds Debug, and Aspire / Roslyn
+		// / CPS all treat Debug as the universal local-dev configuration). Without
+		// this preference, a stale Release build on the developer's machine could
+		// be picked first purely by OS enumeration order, returning content that
+		// doesn't match what the writer recorded.
+		string releaseHashDir = Path.Combine(this.projectDir, "obj", "Release", "net8.0", "NuGet", "AAAAAAAAAAAAAAAA");
+		string debugHashDir = Path.Combine(this.projectDir, "obj", "Debug", "net8.0", "NuGet", "BBBBBBBBBBBBBBBB");
+		string releasePackageDir = Path.Combine(releaseHashDir, "Nullable", "1.3.0", "Nullable");
+		string debugPackageDir = Path.Combine(debugHashDir, "Nullable", "1.3.0", "Nullable");
+		Directory.CreateDirectory(releasePackageDir);
+		Directory.CreateDirectory(debugPackageDir);
+		string releaseFile = Path.Combine(releasePackageDir, "NullableAttributes.cs");
+		string debugFile = Path.Combine(debugPackageDir, "NullableAttributes.cs");
+		File.WriteAllText(releaseFile, "// from release");
+		File.WriteAllText(debugFile, "// from debug");
+
+		// Make Release deliberately newer so the test fails if we accidentally fall
+		// back to "newest wins across all configurations" instead of preferring Debug.
+		DateTime baseTime = DateTime.UtcNow.AddHours(-1);
+		Directory.SetLastWriteTimeUtc(debugHashDir, baseTime);
+		Directory.SetLastWriteTimeUtc(releaseHashDir, baseTime.AddMinutes(30));
+
+		var resolver = new CachePathResolver();
+		string result = resolver.ToAbsolute("<NUGETPP>/Nullable/1.3.0/Nullable/NullableAttributes.cs", this.projectDir);
+
+		Assert.Equal(debugFile, result);
+	}
+
+	[Fact]
+	public void ToAbsolute_NuGetPpSentinel_RootedSuffix_ReturnsFallbackInsideObjNuGet()
+	{
+		// Defense in depth: lscache content is writer-generated, but if a malformed
+		// or stray cache ever supplied a rooted suffix, naive Path.Combine would
+		// discard the obj prefix and return an absolute path outside the project.
+		// The resolver should reject and return a non-existent placeholder under
+		// `obj/NuGet` so File.Exists fails cleanly downstream.
+		var resolver = new CachePathResolver();
+		string result = resolver.ToAbsolute("<NUGETPP>//etc/passwd", this.projectDir);
+
+		Assert.StartsWith(Path.Combine(this.projectDir, "obj"), result);
+		Assert.DoesNotContain("etc", result, StringComparison.OrdinalIgnoreCase);
+		Assert.False(File.Exists(result));
+	}
+
+	[Fact]
+	public void ToAbsolute_NuGetPpSentinel_BackslashRootedSuffix_ReturnsFallbackInsideObjNuGet()
+	{
+		var resolver = new CachePathResolver();
+		string result = resolver.ToAbsolute("<NUGETPP>/\\Windows\\System32\\evil.dll", this.projectDir);
+
+		Assert.StartsWith(Path.Combine(this.projectDir, "obj"), result);
+		Assert.DoesNotContain("System32", result, StringComparison.OrdinalIgnoreCase);
+	}
+
+	[Fact]
+	public void ToAbsolute_NuGetPpSentinel_TraversalSegment_ReturnsFallbackInsideObjNuGet()
+	{
+		// `..` segments could escape the hash directory if combined naively.
+		var resolver = new CachePathResolver();
+		string result = resolver.ToAbsolute("<NUGETPP>/Pkg/1.0.0/../../../../../etc/shadow", this.projectDir);
+
+		Assert.StartsWith(Path.Combine(this.projectDir, "obj"), result);
+		Assert.DoesNotContain("shadow", result, StringComparison.OrdinalIgnoreCase);
+		Assert.DoesNotContain("..", result);
+	}
+
+	[Fact]
+	public void ToAbsolute_NuGetPpSentinel_DriveLetterRootedSuffix_ReturnsFallbackInsideObjNuGet()
+	{
+		// Windows-only: `Path.IsPathRooted("C:/...")` is true only on Windows.
+		// On Linux/macOS, `C:` is just a weirdly-named relative path segment
+		// — the resolver treats it as a normal package id and the suffix is
+		// safe by definition. This test asserts the resolver's drive-letter
+		// rejection on the platforms where that rejection is meaningful.
+		if (!System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
+		{
+			return;
+		}
+
+		var resolver = new CachePathResolver();
+		string result = resolver.ToAbsolute("<NUGETPP>/C:/Windows/win.ini", this.projectDir);
+
+		Assert.StartsWith(Path.Combine(this.projectDir, "obj"), result);
+		Assert.DoesNotContain("win.ini", result, StringComparison.OrdinalIgnoreCase);
+	}
+
+	[Fact]
+	public void ToAbsolute_NuGetPpSentinel_MultipleHashDirsBothContainFile_PrefersNewest()
+	{
+		// Both hash dirs contain the same file. The resolver should return the
+		// file from the most recently written hash dir so the reader sees the
+		// output of the latest restore, not a stale leftover. Without explicit
+		// ordering, enumeration order is OS-defined (alphabetical on NTFS,
+		// inode/insertion order elsewhere) and would non-deterministically
+		// pick one or the other.
+		string olderHashDir = Path.Combine(this.projectDir, "obj", "Debug", "net8.0", "NuGet", "0000000000000000");
+		string newerHashDir = Path.Combine(this.projectDir, "obj", "Debug", "net8.0", "NuGet", "FFFFFFFFFFFFFFFF");
+		string olderPackageDir = Path.Combine(olderHashDir, "Nullable", "1.3.0", "Nullable");
+		string newerPackageDir = Path.Combine(newerHashDir, "Nullable", "1.3.0", "Nullable");
+		Directory.CreateDirectory(olderPackageDir);
+		Directory.CreateDirectory(newerPackageDir);
+		string olderFile = Path.Combine(olderPackageDir, "NullableAttributes.cs");
+		string newerFile = Path.Combine(newerPackageDir, "NullableAttributes.cs");
+		File.WriteAllText(olderFile, "// stale");
+		File.WriteAllText(newerFile, "// fresh");
+
+		// Force a stable mtime ordering. We set the hash-dir mtimes directly
+		// because the resolver compares hash-dir level, not file level, and
+		// `Directory.CreateDirectory` mtimes can land within the same FS tick
+		// in fast tests. Note: the "wrong" alphabetical winner would be the
+		// '0000...' hash, so the test would silently regress to NTFS-order
+		// passing if we didn't deliberately make 'FFFF...' newer.
+		DateTime baseTime = DateTime.UtcNow.AddHours(-1);
+		Directory.SetLastWriteTimeUtc(olderHashDir, baseTime);
+		Directory.SetLastWriteTimeUtc(newerHashDir, baseTime.AddMinutes(30));
+
+		var resolver = new CachePathResolver();
+		string result = resolver.ToAbsolute("<NUGETPP>/Nullable/1.3.0/Nullable/NullableAttributes.cs", this.projectDir);
+
+		Assert.Equal(newerFile, result);
+	}
+}

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Tests/CachePathResolverNuGetPpTests.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Tests/CachePathResolverNuGetPpTests.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.NET.ProjectData.Tests;
 

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Tests/Microsoft.NET.ProjectData.Tests.csproj
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Tests/Microsoft.NET.ProjectData.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Microsoft.NET.ProjectData.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.NET.ProjectData\Microsoft.NET.ProjectData.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+</Project>

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Tests/Microsoft.NET.ProjectData.Tests.csproj
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Tests/Microsoft.NET.ProjectData.Tests.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <!-- Roslyn expects all unit test projects end with "UnitTests" -->
+    <AssemblyName>Microsoft.NET.ProjectData.UnitTests</AssemblyName>
     <RootNamespace>Microsoft.NET.ProjectData.Tests</RootNamespace>
     <IsPackable>false</IsPackable>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
@@ -12,13 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Microsoft.NET.ProjectData\Microsoft.NET.ProjectData.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit.v3" />
-    <PackageReference Include="xunit.runner.visualstudio" />
+    <ProjectReference Include="..\..\..\Compilers\Test\Core\Microsoft.CodeAnalysis.Test.Utilities.csproj" />
+    <ProjectReference Include="..\Microsoft.NET.ProjectData\Microsoft.NET.ProjectData.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Tests/ProjectDataSnapshotFactoryTests.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Tests/ProjectDataSnapshotFactoryTests.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
 

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Tests/ProjectDataSnapshotFactoryTests.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Tests/ProjectDataSnapshotFactoryTests.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System.Collections.Immutable;
+
+namespace Microsoft.NET.ProjectData.Tests;
+
+public class ProjectDataSnapshotFactoryTests
+{
+	[Fact]
+	public void CreateSnapshots_Merges_Shared_Slice_Into_TargetFramework_Slices()
+	{
+		CachedSliceData sharedSlice = CreateSlice(
+			properties: new() { ["AssemblyName"] = "App" },
+			sourceFiles: [new CachedSourceFile { FilePath = @"C:\repo\App\Program.cs" }]);
+		CachedSliceData tfmSlice = CreateSlice(
+			sliceDimensions: new() { ["TargetFramework"] = "net10.0" },
+			properties: new() { ["TargetFramework"] = "net10.0" },
+			metadataReferences: [new CachedMetadataReference { FilePath = @"C:\packs\System.Runtime.dll", Aliases = [] }]);
+
+		ImmutableArray<ProjectDataSnapshot> snapshots = ProjectDataSnapshotFactory.CreateSnapshots([sharedSlice, tfmSlice]);
+
+		ProjectDataSnapshot snapshot = Assert.Single(snapshots);
+		Assert.Equal("App", snapshot.Properties["AssemblyName"]);
+		Assert.Equal("net10.0", snapshot.Properties["TargetFramework"]);
+		Assert.True(snapshot.ItemsByType.TryGetValue("Compile", out ImmutableArray<ProjectDataItem> compileItems));
+		Assert.Equal(@"C:\repo\App\Program.cs", Assert.Single(compileItems).ItemSpec);
+		Assert.True(snapshot.ItemsByType.TryGetValue("MetadataReference", out ImmutableArray<ProjectDataItem> referenceItems));
+		Assert.Equal(@"C:\packs\System.Runtime.dll", Assert.Single(referenceItems).ItemSpec);
+	}
+
+	[Fact]
+	public void CreateSnapshot_Uses_Runtime_SolutionPath_Instead_Of_Cached_Value()
+	{
+		CachedSliceData slice = CreateSlice(properties: new()
+		{
+			["SolutionPath"] = @"C:\stale\Stale.sln",
+		});
+
+		ProjectDataSnapshot snapshot = ProjectDataSnapshotFactory.CreateSnapshot(slice, @"C:\current\Current.sln");
+
+		Assert.Equal(@"C:\current\Current.sln", snapshot.Properties["SolutionPath"]);
+	}
+
+	[Fact]
+	public void CreateSnapshot_Omits_SolutionPath_When_Runtime_SolutionPath_Is_Empty()
+	{
+		CachedSliceData slice = CreateSlice(properties: new()
+		{
+			["SolutionPath"] = @"C:\stale\Stale.sln",
+		});
+
+		ProjectDataSnapshot snapshot = ProjectDataSnapshotFactory.CreateSnapshot(slice, solutionPath: null);
+
+		Assert.False(snapshot.Properties.TryGetValue("SolutionPath", out _));
+	}
+
+	private static CachedSliceData CreateSlice(
+		Dictionary<string, string>? sliceDimensions = null,
+		Dictionary<string, string>? properties = null,
+		ImmutableArray<CachedSourceFile> sourceFiles = default,
+		ImmutableArray<CachedMetadataReference> metadataReferences = default)
+		=> new()
+		{
+			LanguageName = "C#",
+			ProjectFilePath = @"C:\repo\App\App.csproj",
+			SliceDimensions = (sliceDimensions ?? []).ToImmutableDictionary(),
+			CommandLineArguments = [],
+			SourceFiles = sourceFiles.IsDefault ? [] : sourceFiles,
+			MetadataReferences = metadataReferences.IsDefault ? [] : metadataReferences,
+			AnalyzerReferences = [],
+			AnalyzerConfigFiles = [],
+			AdditionalFiles = [],
+			EmbeddedResources = [],
+			ProjectReferences = [],
+			Capabilities = [],
+			Properties = (properties ?? []).ToImmutableDictionary(),
+		};
+}

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Tests/UnsupportedProjectDataMarkerTests.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Tests/UnsupportedProjectDataMarkerTests.cs
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+namespace Microsoft.NET.ProjectData.Tests;
+
+[Collection(DotnetRootEnvCollection.Name)]
+public sealed class UnsupportedProjectDataMarkerTests : IDisposable
+{
+	private readonly string workDir;
+	private readonly string previousCacheRoot;
+
+	public UnsupportedProjectDataMarkerTests()
+	{
+		this.workDir = Path.Combine(Path.GetTempPath(), "unsupported-projectdata-marker-" + Guid.NewGuid().ToString("N"));
+		Directory.CreateDirectory(this.workDir);
+		this.previousCacheRoot = Environment.GetEnvironmentVariable("DOTNET_PROJECTDATA_CACHE_DIR") ?? string.Empty;
+		Environment.SetEnvironmentVariable("DOTNET_PROJECTDATA_CACHE_DIR", Path.Combine(this.workDir, "cache"));
+	}
+
+	public void Dispose()
+	{
+		Environment.SetEnvironmentVariable("DOTNET_PROJECTDATA_CACHE_DIR", string.IsNullOrEmpty(this.previousCacheRoot) ? null : this.previousCacheRoot);
+		try
+		{
+			Directory.Delete(this.workDir, recursive: true);
+		}
+		catch
+		{
+		}
+	}
+
+	[Fact]
+	public void Write_CreatesValidMarkerBesideUserCachePath()
+	{
+		string projectFile = this.WriteProject("App.csproj");
+
+		string markerPath = UnsupportedProjectDataMarker.Write(projectFile, "CannotWriteProjectData");
+
+		Assert.EndsWith(".unsupported", markerPath);
+		Assert.StartsWith(Path.Combine(this.workDir, "cache"), markerPath);
+		Assert.True(UnsupportedProjectDataMarker.TryReadValid(projectFile, out UnsupportedProjectDataMarkerData marker));
+		Assert.Equal("CannotWriteProjectData", marker.Reason);
+		Assert.Equal(markerPath, marker.MarkerFilePath);
+	}
+
+	[Fact]
+	public void TryReadValid_ReturnsFalseWhenProjectChanges()
+	{
+		string projectFile = this.WriteProject("App.csproj");
+		UnsupportedProjectDataMarker.Write(projectFile, "CannotWriteProjectData");
+
+		File.AppendAllText(projectFile, Environment.NewLine);
+
+		Assert.False(UnsupportedProjectDataMarker.TryReadValid(projectFile, out _));
+	}
+
+	[Fact]
+	public void TryReadValid_ReturnsFalseWhenAncestorInputChanges()
+	{
+		string projectFile = this.WriteProject("src/App/App.csproj");
+		string directoryBuildProps = Path.Combine(this.workDir, "Directory.Build.props");
+		File.WriteAllText(directoryBuildProps, "<Project />");
+		UnsupportedProjectDataMarker.Write(projectFile, "CannotWriteProjectData");
+
+		File.WriteAllText(directoryBuildProps, "<Project><PropertyGroup><LangVersion>preview</LangVersion></PropertyGroup></Project>");
+
+		Assert.False(UnsupportedProjectDataMarker.TryReadValid(projectFile, out _));
+	}
+
+	[Fact]
+	public void Delete_RemovesMarker()
+	{
+		string projectFile = this.WriteProject("App.csproj");
+		string markerPath = UnsupportedProjectDataMarker.Write(projectFile, "CannotWriteProjectData");
+
+		UnsupportedProjectDataMarker.Delete(projectFile);
+
+		Assert.False(File.Exists(markerPath));
+	}
+
+	private string WriteProject(string relativePath)
+	{
+		string projectFile = Path.Combine(this.workDir, relativePath);
+		Directory.CreateDirectory(Path.GetDirectoryName(projectFile)!);
+		File.WriteAllText(
+			projectFile,
+			"""
+			<Project Sdk="Microsoft.NET.Sdk">
+			  <PropertyGroup>
+			    <TargetFramework>net8.0</TargetFramework>
+			  </PropertyGroup>
+			</Project>
+			""");
+		return projectFile;
+	}
+}

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Tests/UnsupportedProjectDataMarkerTests.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Tests/UnsupportedProjectDataMarkerTests.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.NET.ProjectData.Tests;
 

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Tests/UserFolderCachePathTests.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Tests/UserFolderCachePathTests.cs
@@ -1,0 +1,177 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System.Runtime.InteropServices;
+
+namespace Microsoft.NET.ProjectData.Tests;
+
+/// <summary>
+/// Tests for <see cref="UserFolderCachePath"/>. The same source file is linked
+/// into the MSBuild Tasks assembly via <c>&lt;Compile Include=...&gt;</c>; this fixture
+/// guards against accidental drift.
+/// </summary>
+[Collection(DotnetRootEnvCollection.Name)]
+public sealed class UserFolderCachePathTests
+{
+	[Fact]
+	public void Compute_IsDeterministic()
+	{
+		const string project = "/repo/src/MyApp/MyApp.csproj";
+		Assert.Equal(UserFolderCachePath.Compute(project), UserFolderCachePath.Compute(project));
+	}
+
+	[Fact]
+	public void Compute_ProducesDifferentPathsForDifferentInputs()
+	{
+		string a = UserFolderCachePath.Compute("/repo/src/Foo/Foo.csproj");
+		string b = UserFolderCachePath.Compute("/repo/src/Bar/Bar.csproj");
+		Assert.NotEqual(a, b);
+	}
+
+	[Fact]
+	public void Compute_LayoutIsTwoSegmentsAfterBase()
+	{
+		// override base to a known temp root so the layout shape can be asserted
+		// without depending on the user's dotnet home.
+		string root = Path.Combine(Path.GetTempPath(), "userfolder-cache-test-" + Guid.NewGuid().ToString("N"));
+		string? previous = Environment.GetEnvironmentVariable("DOTNET_PROJECTDATA_CACHE_DIR");
+		Environment.SetEnvironmentVariable("DOTNET_PROJECTDATA_CACHE_DIR", root);
+		try
+		{
+			string actual = UserFolderCachePath.Compute("/repo/src/Sample/Sample.csproj");
+			Assert.StartsWith(root, actual, StringComparison.Ordinal);
+			string relative = actual.Substring(root.Length).TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+			string[] parts = relative.Split(new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar }, StringSplitOptions.RemoveEmptyEntries);
+			Assert.Equal(2, parts.Length);
+			Assert.Equal(2, parts[0].Length);
+			Assert.Equal(38, parts[1].Length); // SHA-1 is 40 hex chars; first 2 form the bucket, remaining 38 form the leaf
+		}
+		finally
+		{
+			Environment.SetEnvironmentVariable("DOTNET_PROJECTDATA_CACHE_DIR", previous);
+		}
+	}
+
+	[Fact]
+	public void GetCacheBaseDirectory_UsesProjectDataOverride()
+	{
+		string root = Path.Combine(Path.GetTempPath(), "projectdata-cache-override-" + Guid.NewGuid().ToString("N"));
+		string xdgCacheHome = Path.Combine(Path.GetTempPath(), "projectdata-xdg-cache-" + Guid.NewGuid().ToString("N"));
+		string? previousCacheRoot = Environment.GetEnvironmentVariable("DOTNET_PROJECTDATA_CACHE_DIR");
+		string? previousXdgCacheHome = Environment.GetEnvironmentVariable("XDG_CACHE_HOME");
+		Environment.SetEnvironmentVariable("DOTNET_PROJECTDATA_CACHE_DIR", root);
+		Environment.SetEnvironmentVariable("XDG_CACHE_HOME", xdgCacheHome);
+		try
+		{
+			Assert.Equal(root, UserFolderCachePath.GetCacheBaseDirectory());
+		}
+		finally
+		{
+			Environment.SetEnvironmentVariable("DOTNET_PROJECTDATA_CACHE_DIR", previousCacheRoot);
+			Environment.SetEnvironmentVariable("XDG_CACHE_HOME", previousXdgCacheHome);
+		}
+	}
+
+	[Fact]
+	public void GetCacheBaseDirectory_DefaultsUnderWindowsLocalAppData()
+	{
+		if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+		{
+			return;
+		}
+
+		string? previousCacheRoot = Environment.GetEnvironmentVariable("DOTNET_PROJECTDATA_CACHE_DIR");
+		Environment.SetEnvironmentVariable("DOTNET_PROJECTDATA_CACHE_DIR", null);
+		try
+		{
+			string localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+			Assert.Equal(Path.Combine(localAppData, "Microsoft", "dotnet-projectdata"), UserFolderCachePath.GetCacheBaseDirectory());
+		}
+		finally
+		{
+			Environment.SetEnvironmentVariable("DOTNET_PROJECTDATA_CACHE_DIR", previousCacheRoot);
+		}
+	}
+
+	[Fact]
+	public void GetCacheBaseDirectory_DefaultsUnderXdgCacheHomeOnLinux()
+	{
+		if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+		{
+			return;
+		}
+
+		string xdgCacheHome = Path.Combine(Path.GetTempPath(), "projectdata-xdg-cache-" + Guid.NewGuid().ToString("N"));
+		string? previousCacheRoot = Environment.GetEnvironmentVariable("DOTNET_PROJECTDATA_CACHE_DIR");
+		string? previousXdgCacheHome = Environment.GetEnvironmentVariable("XDG_CACHE_HOME");
+		Environment.SetEnvironmentVariable("DOTNET_PROJECTDATA_CACHE_DIR", null);
+		Environment.SetEnvironmentVariable("XDG_CACHE_HOME", xdgCacheHome);
+		try
+		{
+			Assert.Equal(Path.Combine(xdgCacheHome, "dotnet-projectdata"), UserFolderCachePath.GetCacheBaseDirectory());
+		}
+		finally
+		{
+			Environment.SetEnvironmentVariable("DOTNET_PROJECTDATA_CACHE_DIR", previousCacheRoot);
+			Environment.SetEnvironmentVariable("XDG_CACHE_HOME", previousXdgCacheHome);
+		}
+	}
+
+	[Fact]
+	public void GetCacheBaseDirectory_DefaultsUnderPlatformCacheDirectory()
+	{
+		string? previousCacheRoot = Environment.GetEnvironmentVariable("DOTNET_PROJECTDATA_CACHE_DIR");
+		string? previousXdgCacheHome = Environment.GetEnvironmentVariable("XDG_CACHE_HOME");
+		Environment.SetEnvironmentVariable("DOTNET_PROJECTDATA_CACHE_DIR", null);
+		Environment.SetEnvironmentVariable("XDG_CACHE_HOME", null);
+		try
+		{
+			string expected;
+			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+			{
+				string localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+				expected = Path.Combine(localAppData, "Microsoft", "dotnet-projectdata");
+			}
+			else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+			{
+				string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+				expected = Path.Combine(home, "Library", "Caches", "dotnet-projectdata");
+			}
+			else
+			{
+				string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+				expected = Path.Combine(home, ".cache", "dotnet-projectdata");
+			}
+
+			Assert.Equal(expected, UserFolderCachePath.GetCacheBaseDirectory());
+		}
+		finally
+		{
+			Environment.SetEnvironmentVariable("DOTNET_PROJECTDATA_CACHE_DIR", previousCacheRoot);
+			Environment.SetEnvironmentVariable("XDG_CACHE_HOME", previousXdgCacheHome);
+		}
+	}
+
+	[Fact]
+	public void Compute_CaseSensitivityMatchesPlatform()
+	{
+		string lower = UserFolderCachePath.Compute("/repo/src/sample/sample.csproj");
+		string upper = UserFolderCachePath.Compute("/REPO/SRC/SAMPLE/SAMPLE.CSPROJ");
+
+		if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+		{
+			// Linux paths are case-sensitive, so the cache layout follows.
+			Assert.NotEqual(lower, upper);
+		}
+		else
+		{
+			// Windows / macOS: case-insensitive filesystems → identical hashes.
+			Assert.Equal(lower, upper);
+		}
+	}
+
+	[Fact]
+	public void Compute_ThrowsOnEmpty()
+	{
+		Assert.Throws<ArgumentException>(() => UserFolderCachePath.Compute(string.Empty));
+	}
+}

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Tests/UserFolderCachePathTests.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Tests/UserFolderCachePathTests.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Runtime.InteropServices;
 

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/CacheFileReader.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/CacheFileReader.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
 
@@ -96,7 +98,7 @@ public static class CacheFileReader
 		StringPool? stringPool = null,
 		CancellationToken cancellationToken = default)
 	{
-		ImmutableArray<CachedSliceData> slices = await ReadProjectCacheAsync(projectFilePath, cacheInProject, resolver, stringPool, cancellationToken);
+		ImmutableArray<CachedSliceData> slices = await ReadProjectCacheAsync(projectFilePath, cacheInProject, resolver, stringPool, cancellationToken).ConfigureAwait(false);
 		return ProjectDataSnapshotFactory.CreateSnapshots(slices, solutionPath);
 	}
 
@@ -121,7 +123,7 @@ public static class CacheFileReader
 
 			if (File.Exists(projectFolderPath))
 			{
-				return await ReadCacheFileAsync(projectFolderPath, projectFilePath, expectedProjectFilePath: null, resolver, stringPool, cancellationToken);
+				return await ReadCacheFileAsync(projectFolderPath, projectFilePath, expectedProjectFilePath: null, resolver, stringPool, cancellationToken).ConfigureAwait(false);
 			}
 
 			if (!cacheInProject)
@@ -130,7 +132,7 @@ public static class CacheFileReader
 
 				if (File.Exists(userFolderPath))
 				{
-					return await ReadCacheFileAsync(userFolderPath, projectFilePath, expectedProjectFilePath: projectFilePath, resolver, stringPool, cancellationToken);
+					return await ReadCacheFileAsync(userFolderPath, projectFilePath, expectedProjectFilePath: projectFilePath, resolver, stringPool, cancellationToken).ConfigureAwait(false);
 				}
 			}
 
@@ -174,7 +176,9 @@ public static class CacheFileReader
 		string? expectedProjectFilePath,
 		CachePathResolver resolver,
 		StringPool? stringPool,
+#pragma warning disable IDE0060 // Remove unused parameter
 		CancellationToken cancellationToken)
+#pragma warning restore IDE0060 // Remove unused parameter
 	{
 		// DIAG: record the on-disk file size at the moment we open it so we can detect
 		// "DTB succeeded but cache is empty/partially-written when reader opens it".
@@ -187,18 +191,20 @@ public static class CacheFileReader
 			projectFilePath,
 			expectedProjectFilePath ?? "<null>");
 
-		await using FileStream stream = new(cacheFilePath, new FileStreamOptions
+		FileStream stream = new(cacheFilePath, new FileStreamOptions
 		{
 			Mode = FileMode.Open,
 			Access = FileAccess.Read,
 			Share = FileShare.Read,
 			Options = FileOptions.Asynchronous,
 		});
+		await using var _ = stream.ConfigureAwait(false);
+
 		using StreamReader reader = new(stream);
 
 		string projectDirectory = Path.GetDirectoryName(projectFilePath)!;
 
-		return await ReadFromAsync(reader, resolver, projectDirectory, projectFilePath, expectedProjectFilePath, stringPool);
+		return await ReadFromAsync(reader, resolver, projectDirectory, projectFilePath, expectedProjectFilePath, stringPool).ConfigureAwait(false);
 	}
 
 	private static int ParseMajorVersionOrThrow(string versionHeader)
@@ -245,14 +251,14 @@ public static class CacheFileReader
 		ArgumentNullException.ThrowIfNull(projectDirectory);
 		ArgumentNullException.ThrowIfNull(projectFilePath);
 
-		string? firstLineRaw = await reader.ReadLineAsync();
+		string? firstLineRaw = await reader.ReadLineAsync().ConfigureAwait(false);
 		string? firstLine = firstLineRaw;
 
 		bool hadHashHeader = false;
 		if (firstLine is not null && firstLine.StartsWith(CacheFormat.HashHeaderPrefix, StringComparison.Ordinal))
 		{
 			hadHashHeader = true;
-			firstLine = await reader.ReadLineAsync();
+			firstLine = await reader.ReadLineAsync().ConfigureAwait(false);
 		}
 
 		if (!TryParseMajorVersion(firstLine, out int fileMajorVersion) || fileMajorVersion != CurrentMajorVersion)
@@ -293,7 +299,7 @@ public static class CacheFileReader
 		string? declaredProjectFilePath = null;
 
 		string? line;
-		while ((line = await reader.ReadLineAsync()) is not null)
+		while ((line = await reader.ReadLineAsync().ConfigureAwait(false)) is not null)
 		{
 			if (line.Length == 0 || line[0] == CacheFormat.CommentChar)
 			{

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/CacheFileReader.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/CacheFileReader.cs
@@ -1,0 +1,1029 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System.Collections.Immutable;
+
+namespace Microsoft.NET.ProjectData;
+
+/// <summary>
+/// Reads <c>.lscache</c> files and produces <see cref="CachedSliceData"/> for each project configuration slice.
+/// </summary>
+public static class CacheFileReader
+{
+	private const string CacheFileExtension = ".lscache";
+
+	private const string VersionLinePrefix = "version=";
+
+	/// <summary>
+	/// The wire-format version header is <c>version=&lt;major&gt;[.&lt;minor&gt;]</c>. The reader
+	/// accepts any file whose MAJOR version matches the major it was built for, regardless of
+	/// the minor: a newer minor only adds forward-compatible data (new sections, keys, or
+	/// <c>@metadata</c>) that the parsing loop below ignores. A different major is rejected as
+	/// a clean cache miss because the reader cannot safely interpret a format whose major it
+	/// doesn't understand. Absence of a minor component (e.g. <c>version=2</c>) is treated as
+	/// <c>.0</c>.
+	/// </summary>
+	internal static readonly int CurrentMajorVersion = ParseMajorVersionOrThrow(CacheFormat.VersionHeader);
+
+	/// <summary>
+	/// Gets the cache file path for a given project file path in project-folder mode.
+	/// </summary>
+	public static string GetProjectFolderCacheFilePath(string projectFilePath) => projectFilePath + CacheFileExtension;
+
+	/// <summary>
+	/// Gets the cache file path for a given project file path in user-folder mode.
+	///
+	/// <para>The path-computation algorithm lives in the shared
+	/// <see cref="UserFolderCachePath"/> file (linked from the MSBuild task project) so the
+	/// writer and reader cannot drift.</para>
+	/// </summary>
+	public static string GetUserFolderCacheFilePath(string projectFilePath) => UserFolderCachePath.Compute(projectFilePath);
+
+	public static string GetCacheBaseDirectory() => UserFolderCachePath.GetCacheBaseDirectory();
+
+	/// <summary>
+	/// Reads cache data for a single project from its <c>.lscache</c> file.
+	/// Checks the project folder first, then falls back to the user folder.
+	/// </summary>
+	/// <param name="projectFilePath">The absolute path of the project file.</param>
+	/// <param name="cacheInProject">When <see langword="true"/>, the cache file is stored beside the project file.</param>
+	/// <param name="cancellationToken">A cancellation token.</param>
+	/// <returns>The cached slices for the project, or an empty array if no cache exists or the file is invalid.</returns>
+	/// <remarks>
+	/// This overload constructs a <see cref="CachePathResolver"/> with no SDK
+	/// binding. Cache files containing <c>&lt;NETSDK&gt;</c> entries cannot be
+	/// resolved with this overload — use <see cref="ReadProjectCacheAsync(string, bool, CachePathResolver, CancellationToken)"/>
+	/// and pass an SDK-bound resolver instead.
+	/// </remarks>
+	public static Task<ImmutableArray<CachedSliceData>> ReadProjectCacheAsync(
+		string projectFilePath,
+		bool cacheInProject,
+		CancellationToken cancellationToken)
+		=> ReadProjectCacheAsync(projectFilePath, cacheInProject, stringPool: null, cancellationToken);
+
+	public static Task<ImmutableArray<CachedSliceData>> ReadProjectCacheAsync(
+		string projectFilePath,
+		bool cacheInProject,
+		StringPool? stringPool = null,
+		CancellationToken cancellationToken = default)
+		=> ReadProjectCacheAsync(projectFilePath, cacheInProject, new CachePathResolver(), stringPool, cancellationToken);
+
+	public static Task<ImmutableArray<CachedSliceData>> ReadProjectCacheAsync(
+		string projectFilePath,
+		bool cacheInProject,
+		CachePathResolver resolver,
+		CancellationToken cancellationToken)
+		=> ReadProjectCacheAsync(projectFilePath, cacheInProject, resolver, stringPool: null, cancellationToken);
+
+	/// <summary>
+	/// Reads cache data for a single project and converts it to canonical immutable snapshots.
+	/// </summary>
+	public static Task<ImmutableArray<ProjectDataSnapshot>> ReadProjectDataSnapshotsAsync(
+		string projectFilePath,
+		bool cacheInProject,
+		string? solutionPath = null,
+		StringPool? stringPool = null,
+		CancellationToken cancellationToken = default)
+		=> ReadProjectDataSnapshotsAsync(projectFilePath, cacheInProject, new CachePathResolver(), solutionPath, stringPool, cancellationToken);
+
+	/// <summary>
+	/// Reads cache data for a single project with a caller-supplied resolver and converts it to canonical immutable snapshots.
+	/// </summary>
+	public static async Task<ImmutableArray<ProjectDataSnapshot>> ReadProjectDataSnapshotsAsync(
+		string projectFilePath,
+		bool cacheInProject,
+		CachePathResolver resolver,
+		string? solutionPath = null,
+		StringPool? stringPool = null,
+		CancellationToken cancellationToken = default)
+	{
+		ImmutableArray<CachedSliceData> slices = await ReadProjectCacheAsync(projectFilePath, cacheInProject, resolver, stringPool, cancellationToken);
+		return ProjectDataSnapshotFactory.CreateSnapshots(slices, solutionPath);
+	}
+
+	/// <summary>
+	/// Reads cache data for a single project from its <c>.lscache</c> file using
+	/// a caller-supplied resolver. Use the SDK-bound overloads of
+	/// <see cref="CachePathResolver"/> when reading caches that may contain
+	/// <c>&lt;NETSDK&gt;</c> entries.
+	/// </summary>
+	public static async Task<ImmutableArray<CachedSliceData>> ReadProjectCacheAsync(
+		string projectFilePath,
+		bool cacheInProject,
+		CachePathResolver resolver,
+		StringPool? stringPool = null,
+		CancellationToken cancellationToken = default)
+	{
+		try
+		{
+			// Always check the project folder first — a local cache takes precedence
+			// regardless of the setting (handles migration and source-controlled caches).
+			string projectFolderPath = GetProjectFolderCacheFilePath(projectFilePath);
+
+			if (File.Exists(projectFolderPath))
+			{
+				return await ReadCacheFileAsync(projectFolderPath, projectFilePath, expectedProjectFilePath: null, resolver, stringPool, cancellationToken);
+			}
+
+			if (!cacheInProject)
+			{
+				string userFolderPath = GetUserFolderCacheFilePath(projectFilePath);
+
+				if (File.Exists(userFolderPath))
+				{
+					return await ReadCacheFileAsync(userFolderPath, projectFilePath, expectedProjectFilePath: projectFilePath, resolver, stringPool, cancellationToken);
+				}
+			}
+
+			return [];
+		}
+		catch (OperationCanceledException)
+		{
+			return [];
+		}
+		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or FormatException)
+		{
+			System.Diagnostics.Trace.TraceWarning(
+				"[lscache] Failed to read project cache for {0}: {1}",
+				projectFilePath,
+				ex.Message);
+			return [];
+		}
+	}
+
+	/// <summary>
+	/// Gets the path of the cache file that would be watched for a given project.
+	/// Returns the project-folder path if it exists, otherwise the user-folder path.
+	/// </summary>
+	public static string GetCacheFilePathForWatching(string projectFilePath, bool cacheInProject)
+	{
+		string projectFolderPath = GetProjectFolderCacheFilePath(projectFilePath);
+
+		if (File.Exists(projectFolderPath))
+		{
+			return projectFolderPath;
+		}
+
+		return cacheInProject
+			? projectFolderPath
+			: GetUserFolderCacheFilePath(projectFilePath);
+	}
+
+	private static async Task<ImmutableArray<CachedSliceData>> ReadCacheFileAsync(
+		string cacheFilePath,
+		string projectFilePath,
+		string? expectedProjectFilePath,
+		CachePathResolver resolver,
+		StringPool? stringPool,
+		CancellationToken cancellationToken)
+	{
+		// DIAG: record the on-disk file size at the moment we open it so we can detect
+		// "DTB succeeded but cache is empty/partially-written when reader opens it".
+		long fileLength = -1;
+		try { fileLength = new FileInfo(cacheFilePath).Length; } catch { }
+		System.Diagnostics.Trace.TraceInformation(
+			"[lscache-diag] Opening cache file {0} (size={1} bytes) for project {2} expected='{3}'",
+			cacheFilePath,
+			fileLength,
+			projectFilePath,
+			expectedProjectFilePath ?? "<null>");
+
+		await using FileStream stream = new(cacheFilePath, new FileStreamOptions
+		{
+			Mode = FileMode.Open,
+			Access = FileAccess.Read,
+			Share = FileShare.Read,
+			Options = FileOptions.Asynchronous,
+		});
+		using StreamReader reader = new(stream);
+
+		string projectDirectory = Path.GetDirectoryName(projectFilePath)!;
+
+		return await ReadFromAsync(reader, resolver, projectDirectory, projectFilePath, expectedProjectFilePath, stringPool);
+	}
+
+	private static int ParseMajorVersionOrThrow(string versionHeader)
+		=> TryParseMajorVersion(versionHeader, out int major)
+			? major
+			: throw new InvalidOperationException(
+				$"CacheFormat.VersionHeader '{versionHeader}' is not a valid 'version=<major>[.<minor>]' header.");
+
+	/// <summary>
+	/// Parses the MAJOR component from a <c>version=&lt;major&gt;[.&lt;minor&gt;]</c> header line.
+	/// Returns <see langword="false"/> (and sets <paramref name="major"/> to <c>-1</c>) when the
+	/// line is <see langword="null"/>, lacks the <c>version=</c> prefix, or has a non-numeric or
+	/// non-positive major component.
+	/// </summary>
+	internal static bool TryParseMajorVersion(string? line, out int major)
+	{
+		major = -1;
+		if (line is null || !line.StartsWith(VersionLinePrefix, StringComparison.Ordinal))
+			return false;
+
+		ReadOnlySpan<char> value = line.AsSpan(VersionLinePrefix.Length);
+		int dot = value.IndexOf('.');
+		ReadOnlySpan<char> majorSpan = dot >= 0 ? value[..dot] : value;
+		if (!int.TryParse(majorSpan, out int parsed) || parsed <= 0)
+			return false;
+
+		major = parsed;
+		return true;
+	}
+
+	/// <summary>
+	/// Reads all project slices from the given reader.
+	/// </summary>
+	public static async Task<ImmutableArray<CachedSliceData>> ReadFromAsync(
+		TextReader reader,
+		CachePathResolver resolver,
+		string projectDirectory,
+		string projectFilePath,
+		string? expectedProjectFilePath = null,
+		StringPool? stringPool = null)
+	{
+		ArgumentNullException.ThrowIfNull(reader);
+		ArgumentNullException.ThrowIfNull(resolver);
+		ArgumentNullException.ThrowIfNull(projectDirectory);
+		ArgumentNullException.ThrowIfNull(projectFilePath);
+
+		string? firstLineRaw = await reader.ReadLineAsync();
+		string? firstLine = firstLineRaw;
+
+		bool hadHashHeader = false;
+		if (firstLine is not null && firstLine.StartsWith(CacheFormat.HashHeaderPrefix, StringComparison.Ordinal))
+		{
+			hadHashHeader = true;
+			firstLine = await reader.ReadLineAsync();
+		}
+
+		if (!TryParseMajorVersion(firstLine, out int fileMajorVersion) || fileMajorVersion != CurrentMajorVersion)
+		{
+			// A cache written by a different MAJOR version (or an unrecognized header) is a
+			// clean cache miss. A newer MINOR (same major) is accepted: unknown sections,
+			// keys, and metadata are ignored by the parsing loop below. Log enough context to
+			// diagnose silent reader rejections in CI.
+			System.Diagnostics.Trace.TraceWarning(
+				"[lscache-diag] Unsupported cache version for {0}: first-raw='{1}' (len={2}) hadHashHeader={3} version-line='{4}' parsedMajor={5} expectedMajor={6}",
+				projectFilePath,
+				firstLineRaw ?? "<null>",
+				firstLineRaw?.Length ?? -1,
+				hadHashHeader,
+				firstLine ?? "<null>",
+				fileMajorVersion,
+				CurrentMajorVersion);
+			return [];
+		}
+
+		if (firstLine != CacheFormat.VersionHeader)
+		{
+			// Same MAJOR, different version-header text: a teammate on a different MINOR wrote this
+			// file. It is safe to read — any sections, keys, or @metadata this reader does not
+			// recognize are ignored by the loop below — so this is an informational signal about a
+			// mixed-version team, not a warning. The guard keeps the common same-version read path
+			// allocation-free (no params array / boxing unless the headers actually differ).
+			System.Diagnostics.Trace.TraceInformation(
+				"[lscache] Reading a cache written by a different minor version for {0}: file-version='{1}' reader-version='{2}'. Major matches; unrecognized additive data is ignored.",
+				projectFilePath,
+				firstLine,
+				CacheFormat.VersionHeader);
+		}
+
+		ImmutableArray<CachedSliceData>.Builder slices = ImmutableArray.CreateBuilder<CachedSliceData>();
+		SliceBuilder? currentSlice = null;
+		string? currentSection = null;
+		string? declaredProjectFilePath = null;
+
+		string? line;
+		while ((line = await reader.ReadLineAsync()) is not null)
+		{
+			if (line.Length == 0 || line[0] == CacheFormat.CommentChar)
+			{
+				continue;
+			}
+
+			if (line == CacheFormat.SliceSeparator)
+			{
+				if (currentSlice is not null)
+				{
+					slices.Add(currentSlice.Build(declaredProjectFilePath ?? projectFilePath));
+				}
+				currentSlice = null;
+				currentSection = null;
+				continue;
+			}
+
+			if (currentSection is null && line.StartsWith(CacheFormat.ProjectHeaderPrefix, StringComparison.Ordinal))
+			{
+				RecordDeclaredProjectFilePath(line[CacheFormat.ProjectHeaderPrefix.Length..], resolver, projectDirectory, ref declaredProjectFilePath);
+				continue;
+			}
+
+			if (line[0] == '[' && line[^1] == ']')
+			{
+				currentSection = line[1..^1];
+
+				if (currentSection == CacheFormat.Sections.Project)
+				{
+					currentSlice ??= new SliceBuilder(resolver, projectDirectory, stringPool);
+				}
+
+				continue;
+			}
+
+			currentSlice ??= new SliceBuilder(resolver, projectDirectory, stringPool);
+
+			switch (currentSection)
+			{
+				case CacheFormat.Sections.Project:
+					ParseProjectLine(currentSlice, line, resolver, projectDirectory, ref declaredProjectFilePath);
+					break;
+				case CacheFormat.Sections.SliceDimensions:
+					currentSlice.AddSliceDimensionLine(line);
+					break;
+				case CacheFormat.Sections.Properties:
+					currentSlice.AddPropertyLine(line);
+					break;
+				case CacheFormat.Sections.CommandLineArguments:
+					currentSlice.AddCommandLineArgument(resolver.MakeAbsolute(line, projectDirectory));
+					break;
+				case CacheFormat.Sections.SourceFiles:
+					currentSlice.SourceFileLines.Add(line);
+					break;
+				case CacheFormat.Sections.MetadataReferences:
+					currentSlice.MetadataReferenceLines.Add(line);
+					break;
+				case CacheFormat.Sections.AnalyzerReferences:
+					currentSlice.AnalyzerReferenceLines.Add(line);
+					break;
+				case CacheFormat.Sections.FrameworkPacks:
+					currentSlice.FrameworkPacks.Add(line);
+					break;
+				case CacheFormat.Sections.SdkAnalyzerPacks:
+					currentSlice.SdkAnalyzerPacks.Add(line);
+					break;
+				case CacheFormat.Sections.SdkAnalyzerConfigPolicy:
+					currentSlice.SdkAnalyzerConfigPolicy.Add(line);
+					break;
+				case CacheFormat.Sections.AnalyzerConfigFiles:
+					currentSlice.AnalyzerConfigFileLines.Add(line);
+					break;
+				case CacheFormat.Sections.AdditionalFiles:
+					currentSlice.AdditionalFileLines.Add(line);
+					break;
+				case CacheFormat.Sections.EmbeddedResources:
+					currentSlice.EmbeddedResourceLines.Add(line);
+					break;
+				case CacheFormat.Sections.ProjectReferences:
+					currentSlice.ProjectReferenceLines.Add(line);
+					break;
+				case CacheFormat.Sections.Capabilities:
+					currentSlice.AddCapability(line);
+					break;
+			}
+		}
+
+		if (currentSlice is not null)
+		{
+			slices.Add(currentSlice.Build(declaredProjectFilePath ?? projectFilePath));
+		}
+
+		if (expectedProjectFilePath is not null
+			&& (declaredProjectFilePath is null
+				|| !string.Equals(declaredProjectFilePath, expectedProjectFilePath, StringComparisons.Paths)))
+		{
+			// DIAG: cache file's project= line resolves to a different absolute path than the
+			// caller expected. Should not happen when the cache was written for the same project.
+			System.Diagnostics.Trace.TraceWarning(
+				"[lscache-diag] Declared project path mismatch: declared='{0}' expected='{1}' projectFilePath='{2}' projectDirectory='{3}' slices.Count={4}",
+				declaredProjectFilePath ?? "<null>",
+				expectedProjectFilePath,
+				projectFilePath,
+				projectDirectory,
+				slices.Count);
+			return [];
+		}
+
+		// DIAG: log a successful read so we can correlate path/count in CI logs. A normal read is
+		// an informational event, not a warning.
+		if (slices.Count > 0)
+		{
+			System.Diagnostics.Trace.TraceInformation(
+				"[lscache-diag] Read {0} slice(s) for {1} (declared='{2}', expected='{3}')",
+				slices.Count,
+				projectFilePath,
+				declaredProjectFilePath ?? "<null>",
+				expectedProjectFilePath ?? "<null>");
+		}
+		else
+		{
+			// 0 slices despite a header that passed every check is the "DTB succeeded but the cache
+			// is empty/partially-written" anomaly the diagnostics were added to catch — keep it a warning.
+			System.Diagnostics.Trace.TraceWarning(
+				"[lscache-diag] Read 0 slices for {0} despite passing header check (declared='{1}', expected='{2}')",
+				projectFilePath,
+				declaredProjectFilePath ?? "<null>",
+				expectedProjectFilePath ?? "<null>");
+		}
+
+		return slices.ToImmutable();
+
+		static void ParseProjectLine(
+			SliceBuilder builder,
+			string line,
+			CachePathResolver resolver,
+			string projectDirectory,
+			ref string? declaredProjectFilePath)
+		{
+			if (line.StartsWith(CacheFormat.ProjectHeaderPrefix, StringComparison.Ordinal))
+			{
+				RecordDeclaredProjectFilePath(line[CacheFormat.ProjectHeaderPrefix.Length..], resolver, projectDirectory, ref declaredProjectFilePath);
+			}
+			else if (line.StartsWith(CacheFormat.LanguagePrefix, StringComparison.Ordinal))
+			{
+				builder.LanguageName = line[CacheFormat.LanguagePrefix.Length..];
+			}
+			else if (line == CacheFormat.PrimaryMarker)
+			{
+				builder.IsPrimary = true;
+			}
+			else if (line == CacheFormat.LastDtbSucceededMarker)
+			{
+				builder.LastDesignTimeBuildSucceeded = true;
+			}
+		}
+
+		static void RecordDeclaredProjectFilePath(
+			string value,
+			CachePathResolver resolver,
+			string projectDirectory,
+			ref string? declaredProjectFilePath)
+		{
+			// The first ``project=`` line wins — once set, additional slices in the
+			// same file should agree (and we don't want to re-resolve unnecessarily).
+			if (declaredProjectFilePath is not null) return;
+			declaredProjectFilePath = ResolveDeclaredProjectFilePath(value, resolver, projectDirectory);
+		}
+
+		static string ResolveDeclaredProjectFilePath(string value, CachePathResolver resolver, string projectDirectory)
+		{
+			string nativeValue = value.Replace('/', Path.DirectorySeparatorChar);
+			if (Path.IsPathRooted(nativeValue))
+			{
+				return Path.GetFullPath(nativeValue);
+			}
+
+			return value.StartsWith(PathSentinels.Path, StringComparison.Ordinal)
+				? resolver.MakeAbsolute(value, projectDirectory)
+				: resolver.ToAbsolute(value, projectDirectory);
+		}
+
+	}
+
+	/// <summary>
+	/// Expands indentation-compressed paths back into full paths.
+	/// </summary>
+	internal static List<(string Path, Dictionary<string, string>? Metadata)> ExpandCompressedPaths(List<string> lines)
+	{
+		List<(string Path, Dictionary<string, string>? Metadata)> results = [];
+		Stack<(int Indent, string Prefix)> prefixStack = new();
+
+		foreach (string line in lines)
+		{
+			int indent = CountIndent(line);
+			string content = line[indent..];
+
+			if (content.Length > 0 && content[0] == '@')
+			{
+				if (results.Count > 0)
+				{
+					(string Path, Dictionary<string, string>? Metadata) last = results[^1];
+					last.Metadata ??= [];
+					ParseMetadataLine(content, last.Metadata);
+					results[^1] = last;
+				}
+				continue;
+			}
+
+			while (prefixStack.Count > 0 && prefixStack.Peek().Indent >= indent)
+			{
+				_ = prefixStack.Pop();
+			}
+
+			string prefix = prefixStack.Count > 0 ? prefixStack.Peek().Prefix : "";
+
+			if (content.Length > 0 && content[^1] == '/')
+			{
+				prefixStack.Push((indent, prefix + content));
+			}
+			else
+			{
+				results.Add((prefix + content, null));
+			}
+		}
+
+		return results;
+
+		static void ParseMetadataLine(string content, Dictionary<string, string> metadata)
+		{
+			string keyValue = content[1..]; // strip '@'
+			int eq = keyValue.IndexOf('=');
+			if (eq > 0)
+			{
+				metadata[keyValue[..eq]] = keyValue[(eq + 1)..];
+			}
+			else
+			{
+				metadata[keyValue] = "";
+			}
+		}
+
+		static int CountIndent(string line)
+		{
+			int i = 0;
+			while (i < line.Length && line[i] == ' ')
+			{
+				i++;
+			}
+			return i;
+		}
+	}
+
+	internal static ImmutableArray<string> DeriveFolderNamesFromPortablePath(string portablePath)
+	{
+		if (portablePath.Length == 0 || portablePath[0] == '<' || portablePath.StartsWith("../", StringComparison.Ordinal))
+			return [];
+
+		int lastSlash = portablePath.LastIndexOf('/');
+		if (lastSlash < 0)
+			return [];
+
+		return [.. portablePath[..lastSlash].Split('/')];
+	}
+
+	private sealed class SliceBuilder
+	{
+		private readonly CachePathResolver resolver;
+		private readonly string projectDirectory;
+		private readonly StringPool? stringPool;
+
+		public SliceBuilder(CachePathResolver resolver, string projectDirectory, StringPool? stringPool)
+		{
+			this.resolver = resolver;
+			this.projectDirectory = projectDirectory;
+			this.stringPool = stringPool;
+		}
+
+		public string LanguageName = "";
+		public bool IsPrimary;
+		public bool LastDesignTimeBuildSucceeded;
+		public Dictionary<string, string> SliceDimensions = [];
+		public Dictionary<string, string> Properties = [];
+		public List<string> CommandLineArguments = [];
+		public List<string> SourceFileLines = [];
+		public List<string> MetadataReferenceLines = [];
+		public List<string> AnalyzerReferenceLines = [];
+		public List<string> AnalyzerConfigFileLines = [];
+		public List<string> AdditionalFileLines = [];
+		public List<string> EmbeddedResourceLines = [];
+		public List<string> ProjectReferenceLines = [];
+		public List<string> FrameworkPacks = [];
+		public List<string> SdkAnalyzerPacks = [];
+		public List<string> SdkAnalyzerConfigPolicy = [];
+		public List<string> Capabilities = [];
+
+		public void AddSliceDimensionLine(string line)
+		{
+			int eq = line.IndexOf('=');
+			if (eq > 0)
+			{
+				this.SliceDimensions[this.Pool(line[..eq])] = this.Pool(line[(eq + 1)..]);
+			}
+		}
+
+		public void AddPropertyLine(string line)
+		{
+			int eq = line.IndexOf('=');
+			if (eq > 0)
+			{
+				this.Properties[this.Pool(line[..eq])] = this.Pool(this.resolver.MakeAbsolute(line[(eq + 1)..], this.projectDirectory));
+			}
+		}
+
+		public void AddCommandLineArgument(string value) => this.CommandLineArguments.Add(this.Pool(value));
+
+		public void AddCapability(string value) => this.Capabilities.Add(this.Pool(value));
+
+		public CachedSliceData Build(string projectFilePath)
+		{
+			(ImmutableArray<string> packManagedRefs, ImmutableArray<string> packAnalyzerRefs) = this.ExpandFrameworkPacks();
+			ImmutableArray<string> sdkPackAnalyzerRefs = this.ExpandSdkAnalyzerPacks();
+			ImmutableArray<string> analyzerRefs = packAnalyzerRefs.AddRange(sdkPackAnalyzerRefs);
+
+			return new CachedSliceData
+			{
+				LanguageName = this.LanguageName,
+				ProjectFilePath = projectFilePath,
+				SliceDimensions = this.BuildDictionary(this.SliceDimensions),
+				CommandLineArguments = this.BuildStringArray(this.CommandLineArguments),
+				SourceFiles = this.BuildSourceFiles(),
+				MetadataReferences = this.BuildMetadataReferences(packManagedRefs),
+				AnalyzerReferences = this.BuildAnalyzerReferences(analyzerRefs),
+				AnalyzerConfigFiles = this.BuildAnalyzerConfigFiles(),
+				AdditionalFiles = this.BuildSimplePaths(this.AdditionalFileLines),
+				EmbeddedResources = this.BuildEmbeddedResources(),
+				ProjectReferences = this.BuildSimplePaths(this.ProjectReferenceLines),
+				Capabilities = this.BuildStringArray(this.Capabilities),
+				Properties = this.BuildDictionary(this.Properties),
+				IsPrimary = this.IsPrimary,
+				LastDesignTimeBuildSucceeded = this.LastDesignTimeBuildSucceeded,
+			};
+		}
+
+		private string Pool(string value) => this.stringPool?.GetOrAdd(value) ?? value;
+
+		private ImmutableDictionary<string, string> BuildDictionary(Dictionary<string, string> values)
+		{
+			if (values.Count == 0)
+			{
+				return ImmutableDictionary<string, string>.Empty;
+			}
+
+			ImmutableDictionary<string, string>.Builder builder = ImmutableDictionary.CreateBuilder<string, string>();
+			foreach ((string key, string value) in values)
+			{
+				builder[this.Pool(key)] = this.Pool(value);
+			}
+
+			return builder.ToImmutable();
+		}
+
+		private ImmutableArray<string> BuildStringArray(IEnumerable<string> values)
+		{
+			ImmutableArray<string>.Builder builder = ImmutableArray.CreateBuilder<string>();
+			foreach (string value in values)
+			{
+				builder.Add(this.Pool(value));
+			}
+
+			return builder.ToImmutable();
+		}
+
+		private (ImmutableArray<string> Managed, ImmutableArray<string> Analyzers) ExpandFrameworkPacks()
+		{
+			if (this.FrameworkPacks.Count == 0)
+			{
+				return ([], []);
+			}
+
+			string? targetFramework = this.GetTargetFramework();
+
+			ImmutableArray<string>.Builder managed = ImmutableArray.CreateBuilder<string>();
+			ImmutableArray<string>.Builder analyzers = ImmutableArray.CreateBuilder<string>();
+
+			// Probe both SDK install and NuGet locations. The writer always emits canonical
+			// pack names (e.g. Microsoft.NETCore.App.Ref) here regardless of where they were
+			// resolved at write time, so the reader must accept either source.
+			ExpandPacks(
+				this.FrameworkPacks,
+				packName => this.resolver.FindRefPackDirectory(packName, targetFramework)
+					?? this.resolver.FindNuGetFrameworkPackDirectory(packName, targetFramework),
+				managed,
+				analyzers);
+
+			return (managed.ToImmutable(), analyzers.ToImmutable());
+		}
+
+		private ImmutableArray<string> ExpandSdkAnalyzerPacks()
+		{
+			if (this.SdkAnalyzerPacks.Count == 0)
+			{
+				return [];
+			}
+
+			string? targetFramework = this.GetTargetFramework();
+
+			ImmutableArray<string>.Builder analyzerRefs = ImmutableArray.CreateBuilder<string>();
+			foreach (string packageId in this.SdkAnalyzerPacks)
+			{
+				if (string.IsNullOrWhiteSpace(packageId)) continue;
+				string? packageDir = this.resolver.FindSdkAnalyzerPackDirectory(packageId, targetFramework);
+				if (packageDir is null) continue;
+
+				string analyzerDir = Path.Join(packageDir, "analyzers", "dotnet", "cs");
+				if (!Directory.Exists(analyzerDir)) continue;
+
+				foreach (string analyzerPath in Directory.EnumerateFiles(analyzerDir, "*.dll", SearchOption.AllDirectories).OrderBy(static path => path, StringComparer.OrdinalIgnoreCase))
+				{
+					analyzerRefs.Add(this.Pool(analyzerPath));
+				}
+			}
+
+			return analyzerRefs.ToImmutable();
+		}
+
+		private static void ExpandPacks(
+			List<string> packNames,
+			Func<string, string?> resolvePackDirectory,
+			ImmutableArray<string>.Builder managed,
+			ImmutableArray<string>.Builder analyzers)
+		{
+			foreach (string packName in packNames)
+			{
+				if (string.IsNullOrWhiteSpace(packName)) continue;
+				string? packDir = resolvePackDirectory(packName);
+				if (packDir is null) continue;
+
+				FrameworkListExpander.ExpansionResult result = FrameworkListExpander.Expand(packDir);
+				managed.AddRange(result.ManagedAssemblyPaths);
+				analyzers.AddRange(result.AnalyzerCsPaths);
+			}
+		}
+
+		private ImmutableArray<string> BuildSimplePaths(List<string> lines)
+		{
+			if (lines.Count == 0)
+				return [];
+
+			List<(string Path, Dictionary<string, string>? Metadata)> expanded = ExpandCompressedPaths(lines);
+			if (!this.resolver.IsNetSdkBound)
+			{
+				expanded = this.FilterUnresolvableNetSdkPaths(expanded);
+			}
+
+			ImmutableArray<string>.Builder builder = ImmutableArray.CreateBuilder<string>(expanded.Count);
+			foreach ((string path, Dictionary<string, string>? _) in expanded)
+			{
+				builder.Add(this.Pool(this.resolver.ToAbsolute(path, this.projectDirectory)));
+			}
+
+			return builder.ToImmutable();
+		}
+
+		private ImmutableArray<string> BuildAnalyzerConfigFiles()
+		{
+			ImmutableArray<string> explicitFiles = this.BuildSimplePaths(this.AnalyzerConfigFileLines);
+			if (this.SdkAnalyzerConfigPolicy.Count == 0)
+			{
+				return explicitFiles;
+			}
+
+			if (!this.resolver.IsNetSdkBound)
+			{
+				System.Diagnostics.Trace.TraceWarning(
+					"[lscache] Skipping SDK analyzer config policy entries in {0} — no SDK binding supplied. " +
+					"SDK-shipped analyzer configs will be missing until SDK info is available.",
+					this.projectDirectory);
+				return explicitFiles;
+			}
+
+			string? targetFramework = this.GetTargetFramework();
+			ImmutableArray<string>.Builder builder = ImmutableArray.CreateBuilder<string>(explicitFiles.Length + this.SdkAnalyzerConfigPolicy.Count);
+			builder.AddRange(explicitFiles);
+			foreach (string policy in this.SdkAnalyzerConfigPolicy)
+			{
+				foreach (string path in this.resolver.ResolveSdkAnalyzerConfigPolicy(policy, targetFramework))
+				{
+					builder.Add(this.Pool(path));
+				}
+			}
+
+			return builder.ToImmutable();
+		}
+
+		private string? GetTargetFramework()
+		{
+			if (this.SliceDimensions.TryGetValue(ProjectProperties.TargetFramework, out string? targetFramework))
+				return targetFramework;
+			if (this.Properties.TryGetValue(ProjectProperties.TargetFramework, out targetFramework))
+				return targetFramework;
+			return null;
+		}
+
+		private ImmutableArray<string> BuildAnalyzerReferences(ImmutableArray<string> packAnalyzerRefs)
+		{
+			List<string> analyzerLines = this.AnalyzerReferenceLines;
+			if (!this.resolver.IsNetSdkBound)
+			{
+				analyzerLines = this.FilterUnresolvableNetSdkLines(analyzerLines);
+			}
+
+			ImmutableArray<string> explicitRefs = [];
+			if (analyzerLines.Count > 0)
+			{
+				List<(string Path, Dictionary<string, string>? Metadata)> expanded = ExpandCompressedPaths(analyzerLines);
+				ImmutableArray<string>.Builder explicitBuilder = ImmutableArray.CreateBuilder<string>(expanded.Count);
+				foreach ((string path, Dictionary<string, string>? _) in expanded)
+				{
+					explicitBuilder.Add(this.Pool(this.resolver.ToAbsolute(path, this.projectDirectory)));
+				}
+				explicitRefs = explicitBuilder.ToImmutable();
+			}
+
+			if (packAnalyzerRefs.IsDefaultOrEmpty)
+			{
+				return explicitRefs;
+			}
+
+			// NuGet-wins conflict resolution: skip any framework analyzer whose filename
+			// collides with an explicit entry. The cache file holds no exclusion list.
+			HashSet<string> explicitBasenames = BuildBasenameSet(explicitRefs);
+
+			ImmutableArray<string>.Builder result = ImmutableArray.CreateBuilder<string>(explicitRefs.Length + packAnalyzerRefs.Length);
+			result.AddRange(explicitRefs);
+			foreach (string packRef in packAnalyzerRefs)
+			{
+				string filename = Path.GetFileName(packRef);
+				if (explicitBasenames.Contains(filename)) continue;
+				result.Add(this.Pool(packRef));
+			}
+			return result.ToImmutable();
+		}
+
+		/// <summary>
+		/// Filters out lines whose compressed-path prefix starts with the <c>&lt;NETSDK&gt;</c>
+		/// sentinel, logging a single warning when any are dropped. Used when the resolver
+		/// is unbound (no SDK info supplied by the caller) so we skip rather than fabricate
+		/// a phantom path.
+		/// </summary>
+		private List<string> FilterUnresolvableNetSdkLines(List<string> lines)
+		{
+			List<string> filtered = [];
+			bool warned = false;
+			foreach (string line in lines)
+			{
+				string trimmed = line.TrimStart();
+				if (trimmed.StartsWith(PathSentinels.NetSdk, StringComparison.Ordinal))
+				{
+					if (!warned)
+					{
+						System.Diagnostics.Trace.TraceWarning(
+							"[lscache] Skipping <NETSDK> path(s) in {0} — no SDK binding supplied. " +
+							"SDK-shipped analyzers and configs will be missing until SDK info is available.",
+							this.projectDirectory);
+						warned = true;
+					}
+				}
+				else
+				{
+					filtered.Add(line);
+				}
+			}
+			return filtered;
+		}
+
+		private List<(string Path, Dictionary<string, string>? Metadata)> FilterUnresolvableNetSdkPaths(
+			List<(string Path, Dictionary<string, string>? Metadata)> expanded)
+		{
+			bool warned = false;
+			List<(string Path, Dictionary<string, string>? Metadata)> filtered = [];
+			foreach ((string path, Dictionary<string, string>? metadata) in expanded)
+			{
+				if (path.StartsWith(PathSentinels.NetSdk, StringComparison.Ordinal))
+				{
+					if (!warned)
+					{
+						System.Diagnostics.Trace.TraceWarning(
+							"[lscache] Skipping <NETSDK> path(s) in {0} — no SDK binding supplied. " +
+							"SDK-shipped analyzers and configs will be missing until SDK info is available.",
+							this.projectDirectory);
+						warned = true;
+					}
+				}
+				else
+				{
+					filtered.Add((path, metadata));
+				}
+			}
+			return filtered;
+		}
+
+		private ImmutableArray<CachedSourceFile> BuildSourceFiles()
+		{
+			if (this.SourceFileLines.Count == 0)
+				return [];
+
+			List<(string Path, Dictionary<string, string>? Metadata)> expanded = ExpandCompressedPaths(this.SourceFileLines);
+			ImmutableArray<CachedSourceFile>.Builder builder = ImmutableArray.CreateBuilder<CachedSourceFile>(expanded.Count);
+			foreach ((string path, Dictionary<string, string>? metadata) in expanded)
+			{
+				string? link = metadata is not null && metadata.TryGetValue("link", out string? value) && !string.IsNullOrEmpty(value)
+					? value
+					: null;
+				builder.Add(new CachedSourceFile
+				{
+					FilePath = this.Pool(this.resolver.ToAbsolute(path, this.projectDirectory)),
+					Link = link,
+				});
+			}
+
+			return builder.ToImmutable();
+		}
+
+		private ImmutableArray<CachedMetadataReference> BuildMetadataReferences(ImmutableArray<string> packManagedRefs)
+		{
+			ImmutableArray<CachedMetadataReference> explicitRefs = [];
+			if (this.MetadataReferenceLines.Count > 0)
+			{
+				List<(string Path, Dictionary<string, string>? Metadata)> expanded = ExpandCompressedPaths(this.MetadataReferenceLines);
+				ImmutableArray<CachedMetadataReference>.Builder explicitBuilder = ImmutableArray.CreateBuilder<CachedMetadataReference>(expanded.Count);
+				bool warnedMissingNetFxRefs = false;
+				foreach ((string path, Dictionary<string, string>? metadata) in expanded)
+				{
+					ImmutableArray<string> aliases = [];
+					if (metadata is not null && metadata.TryGetValue(ProjectItems.MetadataReference.Aliases, out string? aliasText) && aliasText.Length > 0)
+					{
+						aliases = this.BuildStringArray(aliasText.Split(','));
+					}
+
+					string? resolvedPath;
+					if (this.resolver.TryResolveNetFrameworkReferenceAssemblyPath(path, out string? netFxPath))
+					{
+						if (netFxPath is null)
+						{
+							if (!warnedMissingNetFxRefs)
+							{
+								System.Diagnostics.Trace.TraceWarning(
+									"[lscache] Skipping <NETFXREF> metadata reference(s) in {0} because no matching .NET Framework reference assemblies were found.",
+									this.projectDirectory);
+								warnedMissingNetFxRefs = true;
+							}
+							continue;
+						}
+
+						resolvedPath = netFxPath;
+					}
+					else
+					{
+						resolvedPath = this.resolver.ToAbsolute(path, this.projectDirectory);
+					}
+
+					explicitBuilder.Add(new CachedMetadataReference
+					{
+						FilePath = this.Pool(resolvedPath),
+						Aliases = aliases,
+						EmbedInteropTypes = metadata is not null && metadata.ContainsKey(ProjectItems.MetadataReference.EmbedInteropTypes),
+					});
+				}
+				explicitRefs = explicitBuilder.ToImmutable();
+			}
+
+			if (packManagedRefs.IsDefaultOrEmpty)
+			{
+				return explicitRefs;
+			}
+
+			// NuGet-wins conflict resolution: skip any framework managed assembly whose
+			// filename collides with an explicit entry. Explicit NuGet/project refs win.
+			HashSet<string> explicitBasenames = new(StringComparer.OrdinalIgnoreCase);
+			foreach (CachedMetadataReference r in explicitRefs)
+			{
+				explicitBasenames.Add(Path.GetFileName(r.FilePath));
+			}
+
+			ImmutableArray<CachedMetadataReference>.Builder result = ImmutableArray.CreateBuilder<CachedMetadataReference>(explicitRefs.Length + packManagedRefs.Length);
+			result.AddRange(explicitRefs);
+			foreach (string packRef in packManagedRefs)
+			{
+				string filename = Path.GetFileName(packRef);
+				if (explicitBasenames.Contains(filename)) continue;
+				result.Add(new CachedMetadataReference
+				{
+					FilePath = this.Pool(packRef),
+					Aliases = [],
+					EmbedInteropTypes = false,
+				});
+			}
+			return result.ToImmutable();
+		}
+
+		private static HashSet<string> BuildBasenameSet(ImmutableArray<string> paths)
+		{
+			HashSet<string> set = new(StringComparer.OrdinalIgnoreCase);
+			foreach (string p in paths)
+			{
+				set.Add(Path.GetFileName(p));
+			}
+			return set;
+		}
+
+		private ImmutableArray<CachedEmbeddedResource> BuildEmbeddedResources()
+		{
+			if (this.EmbeddedResourceLines.Count == 0)
+				return [];
+
+			List<(string Path, Dictionary<string, string>? Metadata)> expanded = ExpandCompressedPaths(this.EmbeddedResourceLines);
+			ImmutableArray<CachedEmbeddedResource>.Builder builder = ImmutableArray.CreateBuilder<CachedEmbeddedResource>(expanded.Count);
+			foreach ((string path, Dictionary<string, string>? metadata) in expanded)
+			{
+				builder.Add(new CachedEmbeddedResource
+				{
+					FilePath = this.Pool(this.resolver.ToAbsolute(path, this.projectDirectory)),
+					Generator = metadata is not null && metadata.TryGetValue(ProjectItems.EmbeddedResource.Generator, out string? gen) ? gen : null,
+					LastGenOutput = metadata is not null && metadata.TryGetValue(ProjectItems.EmbeddedResource.LastGenOutput, out string? lgo) ? lgo : null,
+					CustomToolNamespace = metadata is not null && metadata.TryGetValue(ProjectItems.EmbeddedResource.CustomToolNamespace, out string? ctn) ? ctn : null,
+				});
+			}
+
+			return builder.ToImmutable();
+		}
+	}
+}

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/CachePathResolver.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/CachePathResolver.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Concurrent;
 

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/CachePathResolver.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/CachePathResolver.cs
@@ -1,0 +1,1356 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System.Collections.Concurrent;
+
+namespace Microsoft.NET.ProjectData;
+
+/// <summary>
+/// Converts between absolute file paths and portable cache representations used in <c>.lscache</c> files.
+/// </summary>
+/// <remarks>
+/// <para>Paths are classified into four categories:</para>
+/// <list type="bullet">
+///   <item><b>NuGet cache</b> — stored as <c>&lt;NUGET&gt;/package/version/...</c></item>
+///   <item><b>Dotnet installation</b> — stored as <c>&lt;DOTNET&gt;/packs/...</c></item>
+///   <item><b>.NET Framework reference assemblies</b> — stored as <c>&lt;NETFXREF&gt;/v4.7.2/...</c></item>
+///   <item><b>Project-relative</b> — resolved relative to the project directory</item>
+/// </list>
+/// <para>Adapted from dotnet-project-system's CachePathResolver.cs.</para>
+/// </remarks>
+public sealed class CachePathResolver
+{
+	private readonly string[] nugetFolders;
+	private readonly string[] dotnetRoots;
+	private readonly string? netFxRefRoot;
+	private readonly string? netSdkPath;
+	private static readonly ConcurrentDictionary<string, Lazy<SdkAnalysisLevelDefaults>> SdkAnalysisLevelDefaultsCache = new(StringComparers.Paths);
+
+	/// <summary>
+	/// Constructs a resolver bound only to the ambient environment
+	/// (<c>&lt;DOTNET&gt;</c>, <c>&lt;NUGET&gt;</c>, <c>&lt;NETFXREF&gt;</c>).
+	/// When the cache file contains <c>&lt;NETSDK&gt;</c> entries they cannot
+	/// be resolved — callers should check <see cref="IsNetSdkBound"/> and skip
+	/// or warn accordingly.
+	/// </summary>
+	public CachePathResolver()
+	{
+		this.nugetFolders = ResolveNuGetFoldersFromEnvironment();
+		this.dotnetRoots = ResolveDotNetRootsFromEnvironment();
+		this.netFxRefRoot = ResolveNetFxRefRootFromEnvironment();
+		this.netSdkPath = null;
+	}
+
+	/// <summary>
+	/// Constructs a resolver bound to a specific SDK version. The SDK
+	/// directory is resolved as <c>&lt;dotnetRoot&gt;/sdk/&lt;sdkVersion&gt;/</c>
+	/// against the first dotnet root that contains it. The caller is
+	/// responsible for choosing the SDK version that matches the
+	/// constraint they are working under (e.g. the version selected by
+	/// <c>global.json</c> + roll-forward).
+	/// </summary>
+	/// <param name="sdkVersion">The exact SDK version, e.g. <c>10.0.202</c>.</param>
+	public CachePathResolver(string sdkVersion)
+		: this()
+	{
+		ArgumentException.ThrowIfNullOrEmpty(sdkVersion);
+		this.netSdkPath = this.LocateSdkPath(sdkVersion) ?? this.GuessSdkPath(sdkVersion);
+	}
+
+	/// <summary>
+	/// Constructs a resolver bound to a specific SDK directory. Use this
+	/// overload when the caller already has the absolute path; no
+	/// directory probing is performed.
+	/// </summary>
+	/// <param name="sdkVersion">
+	/// The SDK version corresponding to <paramref name="sdkPath"/>; recorded
+	/// for diagnostics. Not currently used in resolution.
+	/// </param>
+	/// <param name="sdkPath">Absolute path to the SDK installation directory.</param>
+	public CachePathResolver(string sdkVersion, string sdkPath)
+		: this()
+	{
+		ArgumentException.ThrowIfNullOrEmpty(sdkVersion);
+		ArgumentException.ThrowIfNullOrEmpty(sdkPath);
+		this.netSdkPath = NormalizeFolderPath(sdkPath);
+		this.dotnetRoots = AddSdkDotNetRoot(this.dotnetRoots, this.netSdkPath);
+	}
+
+	/// <summary>
+	/// Test seam: constructs a resolver whose root sets are supplied explicitly
+	/// rather than discovered from the ambient process environment. Pass empty
+	/// lists / <see langword="null"/> for any root that should not contribute to
+	/// resolution. Intended for tests that need full isolation from the system
+	/// <c>dotnet</c> / NuGet / .NET Framework reference assembly install
+	/// (e.g. so a developer machine with <c>Microsoft.NETCore.App.Ref</c>
+	/// installed under <c>C:\Program Files\dotnet\packs\</c> does not leak into
+	/// a synthetic test pack lookup). Not intended for production callers —
+	/// the public constructors above keep their environment-discovery behaviour
+	/// unchanged so the .NET server picks up the host's real installs.
+	/// </summary>
+	/// <param name="sdkVersion">Optional SDK version for <c>&lt;NETSDK&gt;</c> binding (see other ctors).</param>
+	/// <param name="sdkPath">Optional absolute SDK path. When supplied, takes precedence over <paramref name="sdkVersion"/>-based probing.</param>
+	/// <param name="dotnetRoots">Explicit list of dotnet install roots; empty means none.</param>
+	/// <param name="nugetFolders">Explicit list of NuGet package roots; empty means none.</param>
+	/// <param name="netFxRefRoot">Explicit .NET Framework reference assemblies root, or <see langword="null"/> for none. Never discovered from the environment by this constructor.</param>
+	internal CachePathResolver(
+		string? sdkVersion,
+		string? sdkPath,
+		IReadOnlyList<string> dotnetRoots,
+		IReadOnlyList<string> nugetFolders,
+		string? netFxRefRoot)
+	{
+		ArgumentNullException.ThrowIfNull(dotnetRoots);
+		ArgumentNullException.ThrowIfNull(nugetFolders);
+
+		this.dotnetRoots = [.. dotnetRoots.Select(NormalizeFolderPath).Distinct(StringComparers.Paths)];
+		this.nugetFolders = [.. nugetFolders.Select(NormalizeFolderPath).Distinct(StringComparers.Paths)];
+		this.netFxRefRoot = string.IsNullOrEmpty(netFxRefRoot) ? null : NormalizeFolderPath(netFxRefRoot);
+
+		if (!string.IsNullOrEmpty(sdkPath))
+		{
+			this.netSdkPath = NormalizeFolderPath(sdkPath);
+			this.dotnetRoots = AddSdkDotNetRoot(this.dotnetRoots, this.netSdkPath);
+		}
+		else if (!string.IsNullOrEmpty(sdkVersion))
+		{
+			this.netSdkPath = this.LocateSdkPath(sdkVersion) ?? this.GuessSdkPath(sdkVersion);
+		}
+		else
+		{
+			this.netSdkPath = null;
+		}
+	}
+
+	/// <summary>
+	/// <see langword="true"/> when this resolver was constructed with an explicit SDK
+	/// version or path and can resolve <c>&lt;NETSDK&gt;</c> sentinel paths.
+	/// <see langword="false"/> for the default (ambient-only) constructor — callers
+	/// must skip or warn on any <c>&lt;NETSDK&gt;</c> entries in the cache file.
+	/// </summary>
+	public bool IsNetSdkBound => this.netSdkPath is not null;
+
+	private static string[] AddSdkDotNetRoot(string[] dotnetRoots, string sdkPath)
+	{
+		string? dotnetRoot = TryGetDotNetRootFromSdkPath(sdkPath);
+		if (dotnetRoot is null || dotnetRoots.Contains(dotnetRoot, StringComparers.Paths))
+		{
+			return dotnetRoots;
+		}
+
+		return [dotnetRoot, .. dotnetRoots];
+	}
+
+	private static string? TryGetDotNetRootFromSdkPath(string sdkPath)
+	{
+		string sdkDirectory = NormalizeFolderPath(sdkPath);
+		string? sdkParent = Path.GetDirectoryName(sdkDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+		if (sdkParent is null || !string.Equals(Path.GetFileName(sdkParent), "sdk", StringComparison.OrdinalIgnoreCase))
+		{
+			return null;
+		}
+
+		string? dotnetRoot = Path.GetDirectoryName(sdkParent);
+		return dotnetRoot is null ? null : NormalizeFolderPath(dotnetRoot);
+	}
+
+	/// <summary>
+	/// Converts a portable cache path back to an absolute path.
+	/// </summary>
+	public string ToAbsolute(string portablePath, string projectDirectory)
+	{
+		ArgumentNullException.ThrowIfNull(portablePath);
+		ArgumentNullException.ThrowIfNull(projectDirectory);
+
+		// <NUGETPP>/ sentinel requires the project directory to locate the intermediate output.
+		if (TryStripNuGetPpSentinel(portablePath, out string ppBody))
+		{
+			return this.ResolveNuGetPpPath(ppBody, projectDirectory);
+		}
+
+		if (this.TryResolveLeadingSentinel(portablePath) is string resolved)
+		{
+			return resolved;
+		}
+
+		// Project-relative path. ``<PATH>`` is not a valid leading sentinel for ``ToAbsolute``;
+		// it only appears inline within argument strings (handled by ``MakeAbsolute``).
+		return Path.GetFullPath(Path.Join(projectDirectory, portablePath.Replace('/', Path.DirectorySeparatorChar)));
+	}
+
+	private static bool TryStripNuGetPpSentinel(string path, out string body)
+	{
+		if (path.StartsWith(PathSentinels.NugetPp, StringComparison.Ordinal)
+			&& path.Length > PathSentinels.NugetPp.Length
+			&& path[PathSentinels.NugetPp.Length] == '/')
+		{
+			body = path[(PathSentinels.NugetPp.Length + 1)..];
+			return true;
+		}
+		body = string.Empty;
+		return false;
+	}
+
+	/// <summary>
+	/// Defensive guard for the relative suffix of a <c>&lt;NUGETPP&gt;</c> sentinel.
+	/// Lscache content is writer-generated (not user-supplied), so this is defense in
+	/// depth rather than a security boundary — but it ensures the suffix can never
+	/// escape the per-hash directory if a malformed cache or stray external lscache
+	/// were ever read. Rejects rooted paths and any path containing a <c>..</c>
+	/// segment. Returns <see langword="true"/> for safe values.
+	/// </summary>
+	private static bool IsSafeRelativeNuGetPpSuffix(string body)
+	{
+		if (string.IsNullOrEmpty(body)) return false;
+		// Rooted on Unix (`/foo`), rooted on Windows (`\foo`), or a drive letter (`C:`).
+		if (body[0] == '/' || body[0] == '\\') return false;
+		if (Path.IsPathRooted(body)) return false;
+		// Reject any `..` segment. We split on both separators so this works for
+		// either writer output style. We don't reject `.` (current directory) because
+		// it cannot escape, and we don't try to canonicalize — any `..` is suspect.
+		foreach (string segment in body.Split(['/', '\\']))
+		{
+			if (segment == "..") return false;
+		}
+		return true;
+	}
+
+	/// <summary>
+	/// Resolves a <c>&lt;NUGETPP&gt;/{PackageId}/{Version}/...</c> path by scanning for the
+	/// preprocessor hash directory under the project's intermediate output paths.
+	/// The SDK writes preprocessed content to <c>obj/{Config}/{TFM}/NuGet/{Hash}/{PackageId}/...</c>.
+	/// </summary>
+	private string ResolveNuGetPpPath(string packageRelativePath, string projectDirectory)
+	{
+		string objDir = Path.Combine(projectDirectory, "obj");
+
+		// Reject malformed suffixes (rooted or containing `..`) before doing any I/O.
+		// Returning a deliberately non-existent placeholder under `obj/NuGet` keeps
+		// the downstream contract intact (a string path that File.Exists will report
+		// false on) while ensuring we never combine a rooted or traversal-containing
+		// suffix with `objDir`. `Path.Combine(objDir, "NuGet", "<rooted>")` would
+		// otherwise discard the prefix entirely.
+		if (!IsSafeRelativeNuGetPpSuffix(packageRelativePath))
+		{
+			return Path.Combine(objDir, "NuGet");
+		}
+
+		string nativeSuffix = packageRelativePath.Replace('/', Path.DirectorySeparatorChar);
+
+		// Scan obj/**/NuGet/*/<packageRelativePath> for any configuration/TFM combination.
+		try
+		{
+			if (Directory.Exists(objDir))
+			{
+				// Prefer NuGet folders under `obj/Debug/` before any other configuration.
+				// The committed lscaches are always generated in Debug (the refresh-lscache
+				// skill builds Debug, and Aspire/Roslyn/CPS all treat Debug as the universal
+				// local-dev configuration), so paths recorded by the writer correspond to a
+				// Debug-time restore. Without this pass, a stale Release build on the
+				// developer's machine could be picked first purely because the OS enumerates
+				// it before Debug, returning content that doesn't match what was recorded.
+				string? candidate = TryResolveUnderConfiguration(objDir, nativeSuffix, "Debug");
+				if (candidate != null) return candidate;
+
+				// Fallback: any other configuration (Release, custom configs). Rare in
+				// practice, but covers checkouts where the user never built Debug locally.
+				candidate = TryResolveUnderConfiguration(objDir, nativeSuffix, configurationName: null);
+				if (candidate != null) return candidate;
+			}
+		}
+		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+		{
+			// obj/ may not exist yet (e.g. fresh clone before first build)
+		}
+
+		// Fallback: return best-guess path (file won't exist but keeps downstream
+		// consumers from crashing with a null/empty path).
+		return Path.Combine(objDir, "NuGet", nativeSuffix);
+	}
+
+	/// <summary>
+	/// Scans <paramref name="objDir"/> for <c>NuGet/{hash}/{nativeSuffix}</c> matches.
+	/// When <paramref name="configurationName"/> is non-null, only NuGet folders whose
+	/// path contains <c>{sep}obj{sep}{configurationName}{sep}</c> are considered. When
+	/// it is null, NuGet folders that match a previously-considered configuration are
+	/// skipped so the caller can chain "Debug first, others second" without revisiting.
+	/// Within matching NuGet folders, hash directories are ordered by descending
+	/// last-write time so the most recent restore wins. Returns the first
+	/// <c>{hash}/{nativeSuffix}</c> that exists on disk, or <c>null</c> if none match.
+	/// </summary>
+	private static string? TryResolveUnderConfiguration(string objDir, string nativeSuffix, string? configurationName)
+	{
+		string? include = configurationName == null
+			? null
+			: $"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}{configurationName}{Path.DirectorySeparatorChar}";
+		// When falling back (configurationName == null) we want to skip the Debug pass
+		// we already ran. We don't enumerate non-Debug configuration names explicitly
+		// because we don't know them; instead we just exclude the Debug segment.
+		string excludeDebug = $"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}Debug{Path.DirectorySeparatorChar}";
+
+		foreach (string nugetDir in Directory.EnumerateDirectories(objDir, "NuGet", SearchOption.AllDirectories))
+		{
+			if (include != null)
+			{
+				if (nugetDir.IndexOf(include, StringComparison.OrdinalIgnoreCase) < 0) continue;
+			}
+			else
+			{
+				if (nugetDir.IndexOf(excludeDebug, StringComparison.OrdinalIgnoreCase) >= 0) continue;
+			}
+
+			// Order hash directories by descending last-write time so we resolve
+			// against the most recent restore's output. Enumeration order is
+			// otherwise OS-defined (alphabetical on NTFS, inode/insertion order
+			// elsewhere) and bears no relation to chronology. Picking the newest
+			// avoids reading stale preprocessor output if a project property
+			// referenced by a `.pp` token (e.g. `$rootnamespace$`) changed
+			// between restores and the older hash dir was not rewritten.
+			IOrderedEnumerable<string> hashDirsNewestFirst = Directory
+				.EnumerateDirectories(nugetDir)
+				.OrderByDescending(d => Directory.GetLastWriteTimeUtc(d));
+			foreach (string hashDir in hashDirsNewestFirst)
+			{
+				string candidate = Path.Combine(hashDir, nativeSuffix);
+				if (File.Exists(candidate))
+					return candidate;
+			}
+		}
+		return null;
+	}
+
+	/// <summary>
+	/// Replaces a sentinel marker within an arbitrary string with the resolved absolute path prefix.
+	/// Used for command-line arguments and property values that may embed sentinel paths.
+	/// </summary>
+	public string MakeAbsolute(string text, string projectDirectory)
+	{
+		ArgumentNullException.ThrowIfNull(text);
+		ArgumentNullException.ThrowIfNull(projectDirectory);
+
+		// Fast path: no sentinel can be present without an opening ``<``.
+		if (text.IndexOf('<') < 0)
+		{
+			return text;
+		}
+
+		// Sentinels are mutually exclusive in practice, so dispatch on the first one found
+		// in declaration order rather than scanning all five to find the leftmost. ``MakeAbsolute``
+		// is called per command-line argument and per property value during cache load, so the
+		// inner loop cost matters. For path-style sentinels (``<NUGET>``, ``<DOTNET>``,
+		// ``<NETFXREF>``, ``<NETSDK>``) we require a ``/`` separator after the sentinel;
+		// ``<PATH>`` is followed directly by the relative path (writer convention).
+		foreach ((string sentinel, bool requiresSeparator) in InlineSentinels)
+		{
+			int idx = text.IndexOf(sentinel, StringComparison.Ordinal);
+			if (idx < 0)
+			{
+				continue;
+			}
+			if (requiresSeparator && (idx + sentinel.Length >= text.Length || text[idx + sentinel.Length] != '/'))
+			{
+				continue;
+			}
+
+			string prefix = text[..idx];
+			// For path-style sentinels we step past the trailing ``/`` so the resolved path
+			// receives just the body (``a/b`` not ``/a/b``). For ``<PATH>`` we take everything
+			// after the sentinel itself.
+			int bodyStart = idx + sentinel.Length + (requiresSeparator ? 1 : 0);
+			string body = text[bodyStart..];
+			string resolved = this.ResolveSentinelBody(sentinel, body, projectDirectory);
+			return prefix + resolved;
+		}
+
+		return text;
+	}
+
+	private string ResolveSentinelBody(string sentinel, string body, string projectDirectory) => sentinel switch
+	{
+		PathSentinels.Nuget => this.ResolveNuGetPath(body),
+		PathSentinels.NugetPp => this.ResolveNuGetPpPath(body, projectDirectory),
+		PathSentinels.Dotnet => this.ResolveDotNetPath(body),
+		PathSentinels.NetFxRef => this.ResolveNetFrameworkReferenceAssembly(body) ?? body.Replace('/', Path.DirectorySeparatorChar),
+		PathSentinels.NetSdk => JoinWithNativeSeparators(this.RequireNetSdkPath(), body),
+		PathSentinels.Path => Path.GetFullPath(Path.Join(projectDirectory, body.Replace('/', Path.DirectorySeparatorChar))),
+		_ => throw new InvalidOperationException($"Unhandled sentinel '{sentinel}'."),
+	};
+
+	private static readonly (string Sentinel, bool RequiresSeparator)[] InlineSentinels =
+	[
+		(PathSentinels.Nuget, true),
+		(PathSentinels.NugetPp, true),
+		(PathSentinels.Dotnet, true),
+		(PathSentinels.NetFxRef, true),
+		(PathSentinels.NetSdk, true),
+		(PathSentinels.Path, false),
+	];
+
+	/// <summary>
+	/// Resolves a ``relative`` path (no leading separator) under the configured NuGet folders,
+	/// returning the first folder where the file exists, or falling back to the first folder
+	/// if none exist on disk (so callers still get a usable absolute path).
+	/// </summary>
+	private string ResolveNuGetPath(string relative)
+	{
+		foreach (string nugetFolder in this.nugetFolders)
+		{
+			string candidate = JoinWithNativeSeparators(nugetFolder, relative);
+			if (File.Exists(candidate))
+			{
+				return candidate;
+			}
+		}
+
+		if (this.nugetFolders.Length > 0)
+		{
+			return JoinWithNativeSeparators(this.nugetFolders[0], relative);
+		}
+
+		return relative.Replace('/', Path.DirectorySeparatorChar);
+	}
+
+	/// <summary>
+	/// If <paramref name="portablePath"/> starts with a known path-style sentinel followed by
+	/// a ``/`` separator, returns the resolved absolute path. Otherwise returns ``null``.
+	/// Malformed sentinels (no trailing ``/``, or end-of-string) are rejected so the caller
+	/// can fall back to project-relative resolution rather than silently dropping a character.
+	/// </summary>
+	private string? TryResolveLeadingSentinel(string portablePath)
+	{
+		if (TryStripSentinel(portablePath, PathSentinels.Nuget, out string body))
+		{
+			return this.ResolveNuGetPath(body);
+		}
+		if (TryStripSentinel(portablePath, PathSentinels.Dotnet, out body))
+		{
+			return this.ResolveDotNetPath(body);
+		}
+		if (TryStripSentinel(portablePath, PathSentinels.NetFxRef, out body))
+		{
+			return this.ResolveNetFrameworkReferenceAssembly(body) ?? body.Replace('/', Path.DirectorySeparatorChar);
+		}
+		if (TryStripSentinel(portablePath, PathSentinels.NetSdk, out body))
+		{
+			return JoinWithNativeSeparators(this.RequireNetSdkPath(), body);
+		}
+		return null;
+
+		static bool TryStripSentinel(string s, string sentinel, out string body)
+		{
+			if (s.StartsWith(sentinel, StringComparison.Ordinal)
+				&& s.Length > sentinel.Length
+				&& s[sentinel.Length] == '/')
+			{
+				body = s[(sentinel.Length + 1)..];
+				return true;
+			}
+			body = string.Empty;
+			return false;
+		}
+	}
+
+	private string ResolveDotNetPath(string relativePart)
+	{
+		foreach (string root in this.dotnetRoots)
+		{
+			string candidate = JoinWithNativeSeparators(root, relativePart);
+			if (File.Exists(candidate))
+			{
+				return candidate;
+			}
+		}
+
+		if (this.dotnetRoots.Length > 0)
+		{
+			return JoinWithNativeSeparators(this.dotnetRoots[0], relativePart);
+		}
+
+		return relativePart.Replace('/', Path.DirectorySeparatorChar);
+	}
+
+	private string RequireNetSdkPath()
+	{
+		if (this.netSdkPath is null)
+		{
+			throw new InvalidOperationException(
+				"This CachePathResolver was constructed without an SDK binding and cannot resolve <NETSDK> paths. " +
+				"Check IsNetSdkBound before calling ToAbsolute on paths that may contain the <NETSDK> sentinel.");
+		}
+		return this.netSdkPath;
+	}
+
+	private string? LocateSdkPath(string sdkVersion)
+	{
+		foreach (string root in this.dotnetRoots)
+		{
+			string candidate = Path.Join(root, "sdk", sdkVersion);
+			if (Directory.Exists(candidate))
+			{
+				return NormalizeFolderPath(candidate);
+			}
+		}
+		return null;
+	}
+
+	private string GuessSdkPath(string sdkVersion)
+	{
+		// No installed match found. Construct a best-effort absolute path under the
+		// first known dotnet root so callers get a path that is consistent with other
+		// <DOTNET>-rooted resolutions (resolution failures here mirror the existing
+		// "file not found" behavior of <DOTNET> sentinel handling — the caller deals
+		// with missing-on-disk via DTB regeneration, not by us throwing).
+		string root = this.dotnetRoots.Length > 0 ? this.dotnetRoots[0] : string.Empty;
+		return NormalizeFolderPath(Path.Join(root, "sdk", sdkVersion));
+	}
+
+	/// <summary>
+	/// Locates the on-disk directory for an SDK ref pack.
+	/// </summary>
+	/// <param name="packName">The pack name, e.g. <c>Microsoft.NETCore.App.Ref</c>.</param>
+	/// <param name="targetFramework">
+	/// The slice's TFM (e.g. <c>net10.0</c>). When non-null and parseable, only pack
+	/// versions whose major matches the TFM major are considered. When null or unparseable,
+	/// the highest installed version is returned.
+	/// </param>
+	/// <returns>
+	/// The absolute path of the chosen pack version directory (e.g.
+	/// <c>C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\10.0.7</c>),
+	/// or <see langword="null"/> if no installed version is found under any dotnet root.
+	/// </returns>
+	public string? FindRefPackDirectory(string packName, string? targetFramework)
+	{
+		int? requiredMajor = ParseTfmMajor(targetFramework);
+
+		string? bestPath = null;
+		PackageVersion? bestVer = null;
+
+		foreach (string root in this.dotnetRoots)
+		{
+			string packDir = Path.Join(root, "packs", packName);
+			if (!Directory.Exists(packDir)) continue;
+
+			foreach (string versionDir in Directory.EnumerateDirectories(packDir))
+			{
+				string versionName = Path.GetFileName(versionDir);
+				if (!TryParsePackageVersion(versionName, out PackageVersion ver)) continue;
+				if (requiredMajor.HasValue && ver.Major != requiredMajor.Value) continue;
+				if (bestVer is null || ver > bestVer.Value)
+				{
+					bestVer = ver;
+					bestPath = versionDir;
+				}
+			}
+		}
+
+		return bestPath;
+	}
+
+	/// <summary>
+	/// Locates the on-disk directory for an SDK-known ref pack restored through NuGet.
+	/// </summary>
+	/// <param name="packName">The targeting pack package name, e.g. <c>Microsoft.NETCore.App.Ref</c>.</param>
+	/// <param name="targetFramework">The slice's TFM, e.g. <c>net8.0</c>.</param>
+	/// <returns>
+	/// The absolute path of the chosen NuGet package directory, or <see langword="null"/> if
+	/// no matching package is found under any configured NuGet package root.
+	/// </returns>
+	public string? FindNuGetFrameworkPackDirectory(string packName, string? targetFramework)
+	{
+		if (string.IsNullOrWhiteSpace(packName))
+		{
+			return null;
+		}
+
+		if (SdkKnownPackResolver.TryGetTargetingPackVersionForSdk(this.netSdkPath, packName, targetFramework, out string? sdkVersion))
+		{
+			string? exactPath = this.FindNuGetPackageDirectory(packName, sdkVersion);
+			if (exactPath is not null)
+			{
+				return exactPath;
+			}
+		}
+
+		return this.FindHighestNuGetPackageDirectory(packName, ParseTfmMajor(targetFramework));
+	}
+
+	/// <summary>
+	/// Locates the on-disk directory for an SDK-known analyzer package restored through NuGet.
+	/// </summary>
+	/// <param name="packageId">The analyzer package ID, e.g. <c>Microsoft.NET.ILLink.Tasks</c>.</param>
+	/// <param name="targetFramework">The slice's TFM, e.g. <c>net10.0</c>.</param>
+	/// <returns>
+	/// The absolute path of the chosen NuGet package directory, or <see langword="null"/> if
+	/// no matching package is found under any configured NuGet package root.
+	/// </returns>
+	public string? FindSdkAnalyzerPackDirectory(string packageId, string? targetFramework)
+	{
+		if (string.IsNullOrWhiteSpace(packageId))
+		{
+			return null;
+		}
+
+		if (SdkKnownPackResolver.TryGetSdkAnalyzerPackVersionForSdk(this.netSdkPath, packageId, targetFramework, out string? sdkVersion))
+		{
+			string? exactPath = this.FindNuGetPackageDirectory(packageId, sdkVersion);
+			if (exactPath is not null)
+			{
+				return exactPath;
+			}
+		}
+
+		return this.FindHighestNuGetPackageDirectory(packageId, ParseTfmMajor(targetFramework));
+	}
+
+	public string? ResolveNetFrameworkReferenceAssembly(string entry)
+	{
+		if (!IsSafeNetFrameworkReferenceAssemblyEntry(entry))
+		{
+			return null;
+		}
+
+		string? developerPackPath = this.ResolveNetFrameworkDeveloperPackPath(entry);
+		if (developerPackPath is not null)
+		{
+			return developerPackPath;
+		}
+
+		return this.ResolveNetFrameworkNuGetReferenceAssemblyPath(entry);
+	}
+
+	public bool TryResolveNetFrameworkReferenceAssemblyPath(string portablePath, out string? resolvedPath)
+	{
+		const string prefix = PathSentinels.NetFxRef + "/";
+		if (!portablePath.StartsWith(prefix, StringComparison.Ordinal))
+		{
+			resolvedPath = null;
+			return false;
+		}
+
+		resolvedPath = this.ResolveNetFrameworkReferenceAssembly(portablePath[prefix.Length..]);
+		return true;
+	}
+
+	private string? ResolveNetFrameworkDeveloperPackPath(string entry)
+	{
+		if (this.netFxRefRoot is null)
+		{
+			return null;
+		}
+
+		string candidate = JoinWithNativeSeparators(this.netFxRefRoot, entry);
+		return File.Exists(candidate) ? candidate : null;
+	}
+
+	private string? ResolveNetFrameworkNuGetReferenceAssemblyPath(string entry)
+	{
+		int slash = entry.IndexOf('/');
+		if (slash <= 0)
+		{
+			return null;
+		}
+
+		string? packageDirectory = this.ResolveNetFrameworkNuGetReferenceAssemblyPackage(entry[..slash]);
+		if (packageDirectory is null)
+		{
+			return null;
+		}
+
+		string candidate = Path.Join(packageDirectory, "build", ".NETFramework", entry.Replace('/', Path.DirectorySeparatorChar));
+		return File.Exists(candidate) ? candidate : null;
+	}
+
+	private string? ResolveNetFrameworkNuGetReferenceAssemblyPackage(string version)
+	{
+		string? packageId = GetNetFrameworkReferenceAssembliesPackageId(version);
+		if (packageId is not null)
+		{
+			string? packageDirectory = this.FindHighestNuGetPackageDirectory(packageId, requiredMajor: null);
+			if (packageDirectory is not null)
+			{
+				return packageDirectory;
+			}
+		}
+
+		return this.FindHighestNuGetPackageDirectory("Microsoft.NETFramework.ReferenceAssemblies", requiredMajor: null);
+	}
+
+	/// <summary>
+	/// Resolves a stable SDK analyzer-config policy to the selected SDK's concrete globalconfig files.
+	/// Missing SDK bindings or missing files are represented by an empty result.
+	/// </summary>
+	public IEnumerable<string> ResolveSdkAnalyzerConfigPolicy(string policy, string? targetFramework)
+	{
+		if (this.netSdkPath is null || string.IsNullOrWhiteSpace(policy))
+		{
+			yield break;
+		}
+
+		if (!TryParseSdkAnalyzerConfigPolicy(policy, out string? identity, out Dictionary<string, string>? properties))
+		{
+			yield break;
+		}
+
+		if (string.Equals(identity, "Microsoft.NET.Sdk/analyzers", StringComparison.OrdinalIgnoreCase))
+		{
+			string? file = this.ResolveNetAnalyzersConfigFile(properties, targetFramework);
+			if (file is not null)
+			{
+				yield return file;
+			}
+
+			yield break;
+		}
+
+		const string codeStylePrefix = "Microsoft.NET.Sdk/codestyle/";
+		if (identity.StartsWith(codeStylePrefix, StringComparison.OrdinalIgnoreCase))
+		{
+			string language = identity[codeStylePrefix.Length..];
+			if (!IsSafePathSegment(language))
+			{
+				yield break;
+			}
+
+			string? file = this.ResolveCodeStyleConfigFile(language, properties, targetFramework);
+			if (file is not null)
+			{
+				yield return file;
+			}
+		}
+	}
+
+	private string? ResolveNetAnalyzersConfigFile(Dictionary<string, string> properties, string? targetFramework)
+	{
+		SdkAnalysisLevelDefaults defaults = this.GetSdkAnalysisLevelDefaults();
+		string analysisLevel = GetPolicyValue(properties, "AnalysisLevel");
+		SplitAnalysisLevel(analysisLevel, out _, out string analysisLevelSuffix);
+		string effectiveAnalysisLevel = ComputeEffectiveAnalysisLevel(analysisLevel, targetFramework, defaults);
+		string rulesVersion = GetPolicyValue(properties, "MicrosoftCodeAnalysisNetAnalyzersRulesVersion");
+		if (string.IsNullOrWhiteSpace(rulesVersion))
+		{
+			rulesVersion = TrimTrailingDotZero(effectiveAnalysisLevel);
+		}
+
+		if (string.IsNullOrWhiteSpace(rulesVersion))
+		{
+			return null;
+		}
+
+		string mode = GetPolicyValue(properties, "AnalysisLevelSuffix");
+		if (string.IsNullOrWhiteSpace(mode))
+		{
+			mode = analysisLevelSuffix;
+		}
+
+		if (string.IsNullOrWhiteSpace(mode))
+		{
+			mode = GetPolicyValue(properties, "AnalysisMode");
+		}
+
+		mode = NormalizeAnalysisMode(mode);
+		string effectiveWarningsAsErrors = GetPolicyValue(properties, "EffectiveCodeAnalysisTreatWarningsAsErrors");
+		if (string.IsNullOrWhiteSpace(effectiveWarningsAsErrors))
+		{
+			effectiveWarningsAsErrors = GetPolicyValue(properties, "CodeAnalysisTreatWarningsAsErrors");
+		}
+
+		string warnAsErrorSuffix = string.Equals(effectiveWarningsAsErrors, "true", StringComparison.OrdinalIgnoreCase)
+			? "_warnaserror"
+			: string.Empty;
+		string fileName = $"analysislevel_{rulesVersion.Replace(".", "_")}_{mode}{warnAsErrorSuffix}.globalconfig".ToLowerInvariant();
+		string file = Path.Join(this.netSdkPath, "Sdks", "Microsoft.NET.Sdk", "analyzers", "build", "config", fileName);
+		return File.Exists(file) ? file : null;
+	}
+
+	private string? ResolveCodeStyleConfigFile(string language, Dictionary<string, string> properties, string? targetFramework)
+	{
+		SdkAnalysisLevelDefaults defaults = this.GetSdkAnalysisLevelDefaults();
+		string analysisLevel = GetPolicyValue(properties, "AnalysisLevel");
+		string analysisMode = GetPolicyValue(properties, "AnalysisMode");
+		string analysisLevelStyle = GetPolicyValue(properties, "AnalysisLevelStyle");
+		if (string.IsNullOrWhiteSpace(analysisLevelStyle))
+		{
+			analysisLevelStyle = analysisLevel;
+		}
+
+		string analysisModeStyle = GetPolicyValue(properties, "AnalysisModeStyle");
+		if (string.IsNullOrWhiteSpace(analysisModeStyle))
+		{
+			analysisModeStyle = analysisMode;
+		}
+
+		SplitAnalysisLevel(analysisLevel, out _, out string analysisLevelSuffix);
+		SplitAnalysisLevel(analysisLevelStyle, out _, out string analysisLevelSuffixFromStyle);
+		string analysisLevelSuffixStyle = GetPolicyValue(properties, "AnalysisLevelSuffixStyle");
+		if (string.IsNullOrWhiteSpace(analysisLevelSuffixStyle))
+		{
+			analysisLevelSuffixStyle = !string.IsNullOrWhiteSpace(analysisLevelSuffixFromStyle)
+				? analysisLevelSuffixFromStyle
+				: GetPolicyValue(properties, "AnalysisLevelSuffix");
+		}
+
+		if (string.IsNullOrWhiteSpace(analysisLevelSuffixStyle))
+		{
+			analysisLevelSuffixStyle = analysisLevelSuffix;
+		}
+
+		string effectiveAnalysisLevelStyle = ComputeEffectiveAnalysisLevel(analysisLevelStyle, targetFramework, defaults);
+		bool shouldInclude =
+			!string.Equals(analysisLevelStyle, analysisLevel, StringComparison.OrdinalIgnoreCase)
+			|| !string.Equals(analysisModeStyle, analysisMode, StringComparison.OrdinalIgnoreCase)
+			|| VersionGreaterThanOrEquals(effectiveAnalysisLevelStyle, "11.0");
+
+		if (!shouldInclude)
+		{
+			return null;
+		}
+
+		string mode = !string.IsNullOrWhiteSpace(analysisModeStyle) ? analysisModeStyle : analysisLevelSuffixStyle;
+		mode = NormalizeAnalysisMode(mode);
+		string file = Path.Join(this.netSdkPath, "Sdks", "Microsoft.NET.Sdk", "codestyle", language, "build", "config", $"analysislevelstyle_{mode.ToLowerInvariant()}.globalconfig");
+		return File.Exists(file) ? file : null;
+	}
+
+	private static bool TryParseSdkAnalyzerConfigPolicy(string policy, out string identity, out Dictionary<string, string> properties)
+	{
+		identity = string.Empty;
+		properties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+		string[] segments = policy.Split('|');
+		if (segments.Length == 0 || string.IsNullOrWhiteSpace(segments[0]))
+		{
+			return false;
+		}
+
+		identity = segments[0];
+		for (int i = 1; i < segments.Length; i++)
+		{
+			string segment = segments[i];
+			int equals = segment.IndexOf('=');
+			if (equals <= 0)
+			{
+				continue;
+			}
+
+			string name = segment[..equals];
+			string value = UnescapePolicyValue(segment[(equals + 1)..]);
+			if (!string.IsNullOrWhiteSpace(name))
+			{
+				properties[name] = value;
+			}
+		}
+
+		return true;
+	}
+
+	private static string UnescapePolicyValue(string value)
+	{
+		return value
+			.Replace("%3D", "=", StringComparison.OrdinalIgnoreCase)
+			.Replace("%7C", "|", StringComparison.OrdinalIgnoreCase)
+			.Replace("%25", "%", StringComparison.OrdinalIgnoreCase);
+	}
+
+	private static string GetPolicyValue(Dictionary<string, string> properties, string name)
+		=> properties.TryGetValue(name, out string? value) ? value : string.Empty;
+
+	private SdkAnalysisLevelDefaults GetSdkAnalysisLevelDefaults()
+	{
+		if (this.netSdkPath is null)
+		{
+			return SdkAnalysisLevelDefaults.CreateFallback(null);
+		}
+
+		// Wrap the IO+parse step in Lazy so ConcurrentDictionary contention can't run
+		// ParseSdkAnalysisLevelDefaults more than once for the same SDK path.
+		return SdkAnalysisLevelDefaultsCache.GetOrAdd(
+			this.netSdkPath,
+			static path => new Lazy<SdkAnalysisLevelDefaults>(() => ParseSdkAnalysisLevelDefaults(path), LazyThreadSafetyMode.ExecutionAndPublication)).Value;
+	}
+
+	private static SdkAnalysisLevelDefaults ParseSdkAnalysisLevelDefaults(string sdkPath)
+	{
+		string targetsPath = Path.Join(sdkPath, "Sdks", "Microsoft.NET.Sdk", "targets", "Microsoft.NET.Sdk.Analyzers.targets");
+		if (!File.Exists(targetsPath))
+		{
+			return SdkAnalysisLevelDefaults.CreateFallback(ParseSdkMajor(sdkPath));
+		}
+
+		try
+		{
+			string content = File.ReadAllText(targetsPath);
+			string? latest = TryReadSimpleElementValue(content, "_LatestAnalysisLevel");
+			string? preview = TryReadSimpleElementValue(content, "_PreviewAnalysisLevel");
+			string? none = TryReadSimpleElementValue(content, "_NoneAnalysisLevel");
+			SdkAnalysisLevelDefaults fallback = SdkAnalysisLevelDefaults.CreateFallback(ParseSdkMajor(sdkPath));
+			return new SdkAnalysisLevelDefaults(
+				string.IsNullOrWhiteSpace(none) ? fallback.None : none!,
+				string.IsNullOrWhiteSpace(latest) ? fallback.Latest : latest!,
+				string.IsNullOrWhiteSpace(preview) ? fallback.Preview : preview!);
+		}
+		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+		{
+			System.Diagnostics.Trace.TraceWarning(
+				"[lscache] Failed to read SDK analysis-level defaults for {0}: {1}",
+				sdkPath,
+				ex.Message);
+			return SdkAnalysisLevelDefaults.CreateFallback(ParseSdkMajor(sdkPath));
+		}
+	}
+
+	private static string? TryReadSimpleElementValue(string content, string elementName)
+	{
+		string startTag = "<" + elementName + ">";
+		int start = content.IndexOf(startTag, StringComparison.Ordinal);
+		if (start < 0)
+		{
+			return null;
+		}
+
+		start += startTag.Length;
+		string endTag = "</" + elementName + ">";
+		int end = content.IndexOf(endTag, start, StringComparison.Ordinal);
+		if (end < start)
+		{
+			return null;
+		}
+
+		string value = content[start..end].Trim();
+		return value.Length == 0 || value.Contains('<', StringComparison.Ordinal) ? null : value;
+	}
+
+	private static string ComputeEffectiveAnalysisLevel(string analysisLevel, string? targetFramework, SdkAnalysisLevelDefaults defaults)
+	{
+		if (string.IsNullOrWhiteSpace(analysisLevel))
+		{
+			analysisLevel = GetDefaultAnalysisLevel(targetFramework, defaults);
+		}
+
+		SplitAnalysisLevel(analysisLevel, out string prefix, out _);
+		string level = string.IsNullOrWhiteSpace(prefix) ? analysisLevel : prefix;
+		if (string.Equals(level, "none", StringComparison.OrdinalIgnoreCase))
+		{
+			return defaults.None;
+		}
+
+		if (string.Equals(level, "latest", StringComparison.OrdinalIgnoreCase))
+		{
+			return defaults.Latest;
+		}
+
+		if (string.Equals(level, "preview", StringComparison.OrdinalIgnoreCase))
+		{
+			return defaults.Preview;
+		}
+
+		return level;
+	}
+
+	private static string GetDefaultAnalysisLevel(string? targetFramework, SdkAnalysisLevelDefaults defaults)
+	{
+		if (!TryParseTfmVersion(targetFramework, out Version? targetFrameworkVersion))
+		{
+			return string.Empty;
+		}
+
+		if (targetFrameworkVersion.Major < 5)
+		{
+			return string.Empty;
+		}
+
+		return VersionEquals(targetFrameworkVersion, defaults.Latest)
+			? "latest"
+			: $"{targetFrameworkVersion.Major}.{targetFrameworkVersion.Minor}";
+	}
+
+	private static void SplitAnalysisLevel(string analysisLevel, out string prefix, out string suffix)
+	{
+		int separator = analysisLevel.IndexOf('-');
+		if (separator <= 0 || separator == analysisLevel.Length - 1)
+		{
+			prefix = string.Empty;
+			suffix = string.Empty;
+			return;
+		}
+
+		prefix = analysisLevel[..separator];
+		suffix = analysisLevel[(separator + 1)..];
+	}
+
+	private static string NormalizeAnalysisMode(string mode)
+	{
+		if (string.Equals(mode, "AllEnabledByDefault", StringComparison.OrdinalIgnoreCase))
+		{
+			return "All";
+		}
+
+		if (string.Equals(mode, "AllDisabledByDefault", StringComparison.OrdinalIgnoreCase))
+		{
+			return "None";
+		}
+
+		return string.IsNullOrWhiteSpace(mode) ? "Default" : mode;
+	}
+
+	private static string TrimTrailingDotZero(string value)
+	{
+		while (value.EndsWith(".0", StringComparison.Ordinal))
+		{
+			value = value[..^2];
+		}
+
+		return value;
+	}
+
+	private static bool VersionGreaterThanOrEquals(string version, string minimum)
+	{
+		return TryParsePackageVersion(version, out PackageVersion parsed)
+			&& TryParsePackageVersion(minimum, out PackageVersion parsedMinimum)
+			&& parsed >= parsedMinimum;
+	}
+
+	private static bool VersionEquals(Version left, string right)
+	{
+		return TryParsePackageVersion(right, out PackageVersion parsedRight)
+			&& left.Major == parsedRight.Major
+			&& left.Minor == parsedRight.Minor;
+	}
+
+	private static bool TryParseTfmVersion(string? tfm, out Version version)
+	{
+		version = new Version(0, 0);
+		if (string.IsNullOrEmpty(tfm)) return false;
+
+		int start = tfm.StartsWith("netcoreapp", StringComparison.OrdinalIgnoreCase) ? "netcoreapp".Length
+			: tfm.StartsWith("net", StringComparison.OrdinalIgnoreCase) ? "net".Length
+			: -1;
+		if (start < 0) return false;
+
+		int end = start;
+		while (end < tfm.Length && (char.IsDigit(tfm[end]) || tfm[end] == '.')) end++;
+		string versionText = tfm[start..end];
+		if (versionText.Length == 0) return false;
+		if (!versionText.Contains('.', StringComparison.Ordinal))
+		{
+			versionText += ".0";
+		}
+
+		if (Version.TryParse(versionText, out Version? parsedVersion))
+		{
+			version = parsedVersion;
+			return true;
+		}
+
+		return false;
+	}
+
+	private static int? ParseSdkMajor(string sdkPath)
+	{
+		string sdkVersion = Path.GetFileName(sdkPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+		return TryParsePackageVersion(sdkVersion, out PackageVersion version) ? version.Major : null;
+	}
+
+	private readonly struct SdkAnalysisLevelDefaults
+	{
+		public SdkAnalysisLevelDefaults(string none, string latest, string preview)
+		{
+			this.None = none;
+			this.Latest = latest;
+			this.Preview = preview;
+		}
+
+		public string None { get; }
+		public string Latest { get; }
+		public string Preview { get; }
+
+		public static SdkAnalysisLevelDefaults CreateFallback(int? sdkMajor)
+		{
+			int latest = sdkMajor ?? 0;
+			return new SdkAnalysisLevelDefaults(
+				"4.0",
+				latest > 0 ? latest + ".0" : string.Empty,
+				latest > 0 ? (latest + 1) + ".0" : string.Empty);
+		}
+	}
+
+	private string? FindNuGetPackageDirectory(string packageId, string? packageVersion)
+	{
+		if (string.IsNullOrWhiteSpace(packageVersion))
+		{
+			return null;
+		}
+
+		foreach (string nugetFolder in this.nugetFolders)
+		{
+			string? packageRoot = FindChildDirectory(nugetFolder, packageId);
+			if (packageRoot is null) continue;
+
+			string? versionDir = FindChildDirectory(packageRoot, packageVersion);
+			if (versionDir is not null)
+			{
+				return versionDir;
+			}
+		}
+
+		return null;
+	}
+
+	private string? FindHighestNuGetPackageDirectory(string packageId, int? requiredMajor)
+	{
+		string? bestPath = null;
+		PackageVersion? bestVer = null;
+
+		foreach (string nugetFolder in this.nugetFolders)
+		{
+			string? packageRoot = FindChildDirectory(nugetFolder, packageId);
+			if (packageRoot is null) continue;
+
+			foreach (string versionDir in Directory.EnumerateDirectories(packageRoot))
+			{
+				string versionName = Path.GetFileName(versionDir);
+				if (!TryParsePackageVersion(versionName, out PackageVersion ver)) continue;
+				if (requiredMajor.HasValue && ver.Major != requiredMajor.Value) continue;
+				if (bestVer is null || ver > bestVer.Value)
+				{
+					bestVer = ver;
+					bestPath = versionDir;
+				}
+			}
+		}
+
+		return bestPath;
+	}
+
+	private static string? FindChildDirectory(string parent, string childName)
+	{
+		string direct = Path.Join(parent, childName);
+		if (Directory.Exists(direct))
+		{
+			return direct;
+		}
+
+		string lower = Path.Join(parent, childName.ToLowerInvariant());
+		if (Directory.Exists(lower))
+		{
+			return lower;
+		}
+
+		return null;
+	}
+
+	private static bool IsSafePathSegment(string value)
+	{
+		return !string.IsNullOrWhiteSpace(value)
+			&& value.IndexOfAny(Path.GetInvalidFileNameChars()) < 0
+			&& !value.Contains("..", StringComparison.Ordinal)
+			&& !value.Contains('/', StringComparison.Ordinal)
+			&& !value.Contains('\\', StringComparison.Ordinal);
+	}
+
+	private static bool IsSafeNetFrameworkReferenceAssemblyEntry(string entry)
+	{
+		if (string.IsNullOrWhiteSpace(entry)
+			|| !entry.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)
+			|| entry.Contains('\\', StringComparison.Ordinal)
+			|| entry.Contains("../", StringComparison.Ordinal)
+			|| entry.StartsWith("/", StringComparison.Ordinal))
+		{
+			return false;
+		}
+
+		int slash = entry.IndexOf('/');
+		return slash > 0 && IsSafeNetFrameworkVersion(entry[..slash]);
+	}
+
+	private static bool IsSafeNetFrameworkVersion(string version)
+		=> version.StartsWith("v", StringComparison.OrdinalIgnoreCase)
+			&& Version.TryParse(version[1..], out _)
+			&& !version.Contains('/', StringComparison.Ordinal)
+			&& !version.Contains('\\', StringComparison.Ordinal);
+
+	private static string? GetNetFrameworkReferenceAssembliesPackageId(string version)
+	{
+		if (!IsSafeNetFrameworkVersion(version))
+		{
+			return null;
+		}
+
+		string[] parts = version[1..].Split('.');
+		return parts.Length switch
+		{
+			2 => "Microsoft.NETFramework.ReferenceAssemblies.net" + parts[0] + parts[1],
+			3 => "Microsoft.NETFramework.ReferenceAssemblies.net" + parts[0] + parts[1] + parts[2],
+			_ => null,
+		};
+	}
+
+	private static int? ParseTfmMajor(string? tfm)
+	{
+		if (string.IsNullOrEmpty(tfm)) return null;
+		// netN.M  → N (e.g. net10.0 → 10)
+		// netcoreappN.M → N
+		int start = tfm.StartsWith("netcoreapp", StringComparison.OrdinalIgnoreCase) ? "netcoreapp".Length
+				   : tfm.StartsWith("net", StringComparison.OrdinalIgnoreCase) ? "net".Length
+				   : -1;
+		if (start < 0) return null;
+		int end = start;
+		while (end < tfm.Length && char.IsDigit(tfm[end])) end++;
+		if (end == start) return null;
+		return int.TryParse(tfm.AsSpan(start, end - start), out int n) ? n : null;
+	}
+
+	private static bool TryParsePackageVersion(string? versionName, out PackageVersion version)
+	{
+		version = default;
+		if (string.IsNullOrWhiteSpace(versionName))
+		{
+			return false;
+		}
+
+		string numericVersion = versionName;
+		int prereleaseIndex = numericVersion.IndexOf('-', StringComparison.Ordinal);
+		if (prereleaseIndex >= 0)
+		{
+			numericVersion = numericVersion[..prereleaseIndex];
+		}
+
+		if (!Version.TryParse(numericVersion, out Version? parsed))
+		{
+			return false;
+		}
+
+		version = new PackageVersion(parsed, IsPrerelease: prereleaseIndex >= 0, Original: versionName);
+		return true;
+	}
+
+	private readonly record struct PackageVersion(Version Version, bool IsPrerelease, string Original) : IComparable<PackageVersion>
+	{
+		public int Major => this.Version.Major;
+
+		public int Minor => this.Version.Minor;
+
+		public int CompareTo(PackageVersion other)
+		{
+			int versionComparison = this.Version.CompareTo(other.Version);
+			if (versionComparison != 0)
+			{
+				return versionComparison;
+			}
+
+			if (this.IsPrerelease != other.IsPrerelease)
+			{
+				return this.IsPrerelease ? -1 : 1;
+			}
+
+			return string.Compare(this.Original, other.Original, StringComparison.OrdinalIgnoreCase);
+		}
+
+		public static bool operator >(PackageVersion left, PackageVersion right) => left.CompareTo(right) > 0;
+
+		public static bool operator <(PackageVersion left, PackageVersion right) => left.CompareTo(right) < 0;
+
+		public static bool operator >=(PackageVersion left, PackageVersion right) => left.CompareTo(right) >= 0;
+
+		public static bool operator <=(PackageVersion left, PackageVersion right) => left.CompareTo(right) <= 0;
+	}
+
+	private static string[] ResolveNuGetFoldersFromEnvironment()
+	{
+		string? nugetPackages = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+		if (!string.IsNullOrWhiteSpace(nugetPackages))
+		{
+			return [NormalizeFolderPath(nugetPackages)];
+		}
+
+		string userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+		if (!string.IsNullOrEmpty(userProfile))
+		{
+			string defaultFolder = Path.Join(userProfile, ".nuget", "packages");
+			return [NormalizeFolderPath(defaultFolder)];
+		}
+
+		return [];
+	}
+
+	private static string[] ResolveDotNetRootsFromEnvironment()
+	{
+		return [.. EnumerateCandidates()
+			.Where(Directory.Exists)
+			.Select(NormalizeFolderPath)
+			.Distinct(StringComparers.Paths)];
+
+		static IEnumerable<string> EnumerateCandidates()
+		{
+			string? dotnetRoot = Environment.GetEnvironmentVariable("DOTNET_ROOT");
+			if (!string.IsNullOrWhiteSpace(dotnetRoot))
+			{
+				yield return dotnetRoot;
+			}
+
+			if (OperatingSystem.IsWindows())
+			{
+				string programFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+				if (!string.IsNullOrEmpty(programFiles))
+				{
+					yield return Path.Join(programFiles, "dotnet");
+				}
+			}
+			else
+			{
+				yield return "/usr/share/dotnet";
+				yield return "/usr/local/share/dotnet";
+			}
+
+			string? userHome = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+			if (string.IsNullOrEmpty(userHome))
+			{
+				userHome = Environment.GetEnvironmentVariable("HOME");
+			}
+
+			if (!string.IsNullOrEmpty(userHome))
+			{
+				yield return Path.Join(userHome, ".dotnet");
+			}
+		}
+	}
+
+	private static string? ResolveNetFxRefRootFromEnvironment()
+	{
+		if (OperatingSystem.IsWindows())
+		{
+			string programFilesX86 = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
+			if (!string.IsNullOrEmpty(programFilesX86))
+			{
+				string candidate = Path.Join(programFilesX86, "Reference Assemblies", "Microsoft", "Framework", ".NETFramework");
+				if (Directory.Exists(candidate))
+				{
+					return NormalizeFolderPath(candidate);
+				}
+			}
+		}
+
+		return null;
+	}
+
+	private static string NormalizeFolderPath(string path)
+	{
+		string full = Path.GetFullPath(path);
+
+		if (!full.EndsWith(Path.DirectorySeparatorChar))
+		{
+			full += Path.DirectorySeparatorChar;
+		}
+
+		return full;
+	}
+
+	private static string JoinWithNativeSeparators(string root, string portablePath)
+	{
+		return string.Create(root.Length + portablePath.Length, (root, portablePath), static (span, state) =>
+		{
+			state.root.CopyTo(span);
+			Span<char> suffix = span[state.root.Length..];
+			state.portablePath.CopyTo(suffix);
+			suffix.Replace('/', Path.DirectorySeparatorChar);
+		});
+	}
+}

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/DTOs/CachedEmbeddedResource.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/DTOs/CachedEmbeddedResource.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.NET.ProjectData;
 

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/DTOs/CachedEmbeddedResource.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/DTOs/CachedEmbeddedResource.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+namespace Microsoft.NET.ProjectData;
+
+/// <summary>
+/// Represents a cached embedded resource item from the <c>[embeddedResources]</c> section
+/// of a <c>.lscache</c> file, with its associated metadata.
+/// </summary>
+public sealed record CachedEmbeddedResource
+{
+	public required string FilePath { get; init; }
+	public string? Generator { get; init; }
+	public string? LastGenOutput { get; init; }
+	public string? CustomToolNamespace { get; init; }
+}

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/DTOs/CachedMetadataReference.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/DTOs/CachedMetadataReference.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System.Collections.Immutable;
+
+namespace Microsoft.NET.ProjectData;
+
+public sealed record CachedMetadataReference
+{
+	public required string FilePath { get; init; }
+	public required ImmutableArray<string> Aliases { get; init; }
+	public bool EmbedInteropTypes { get; init; }
+}

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/DTOs/CachedMetadataReference.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/DTOs/CachedMetadataReference.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
 

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/DTOs/CachedSliceData.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/DTOs/CachedSliceData.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
 

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/DTOs/CachedSliceData.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/DTOs/CachedSliceData.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System.Collections.Immutable;
+
+namespace Microsoft.NET.ProjectData;
+
+/// <summary>
+/// Represents the parsed data of a single project configuration slice from a <c>.lscache</c> file.
+/// </summary>
+public sealed record CachedSliceData
+{
+	public required string LanguageName { get; init; }
+	public required string ProjectFilePath { get; init; }
+	public required ImmutableDictionary<string, string> SliceDimensions { get; init; }
+	public required ImmutableArray<string> CommandLineArguments { get; init; }
+	public required ImmutableArray<CachedSourceFile> SourceFiles { get; init; }
+	public required ImmutableArray<CachedMetadataReference> MetadataReferences { get; init; }
+	public required ImmutableArray<string> AnalyzerReferences { get; init; }
+	public required ImmutableArray<string> AnalyzerConfigFiles { get; init; }
+	public required ImmutableArray<string> AdditionalFiles { get; init; }
+	public ImmutableArray<CachedEmbeddedResource> EmbeddedResources { get; init; } = [];
+	public required ImmutableArray<string> ProjectReferences { get; init; }
+	public required ImmutableArray<string> Capabilities { get; init; }
+	public required ImmutableDictionary<string, string> Properties { get; init; }
+	public bool IsPrimary { get; init; }
+	public bool LastDesignTimeBuildSucceeded { get; init; }
+}

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/DTOs/CachedSourceFile.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/DTOs/CachedSourceFile.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.NET.ProjectData;
 

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/DTOs/CachedSourceFile.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/DTOs/CachedSourceFile.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+namespace Microsoft.NET.ProjectData;
+
+public sealed record CachedSourceFile
+{
+	public required string FilePath { get; init; }
+	public string? Link { get; init; }
+}

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/FrameworkListExpander.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/FrameworkListExpander.cs
@@ -1,0 +1,105 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using System.Xml.Linq;
+
+namespace Microsoft.NET.ProjectData;
+
+/// <summary>
+/// Expands an SDK ref-pack directory into the list of managed metadata references
+/// and CS analyzer references it contributes, by reading the pack's
+/// <c>data/FrameworkList.xml</c> manifest. Mirrors what the SDK targets do at build
+/// time (<c>ResolveTargetingPackAssets</c>) and what
+/// <c>dotnet run file.cs</c> does in the C# file fast path.
+/// </summary>
+internal static class FrameworkListExpander
+{
+	private static readonly ConcurrentDictionary<string, Lazy<ExpansionResult>> Cache = new(StringComparers.Paths);
+
+	internal sealed class ExpansionResult
+	{
+		public required ImmutableArray<string> ManagedAssemblyPaths { get; init; }
+		public required ImmutableArray<string> AnalyzerCsPaths { get; init; }
+
+		public static readonly ExpansionResult Empty = new()
+		{
+			ManagedAssemblyPaths = [],
+			AnalyzerCsPaths = [],
+		};
+	}
+
+	/// <summary>
+	/// Reads <c>FrameworkList.xml</c> under <paramref name="packDir"/>/data/ and returns
+	/// the absolute paths of <c>Type="Managed"</c> entries (metadata references) and
+	/// <c>Type="Analyzer" Language="cs"</c> entries (analyzer references). Results are
+	/// cached by <paramref name="packDir"/> for the lifetime of the process.
+	/// </summary>
+	public static ExpansionResult Expand(string packDir)
+	{
+		// Wrap the IO+XML parse in Lazy so racing callers can't trigger duplicate parses.
+		return Cache.GetOrAdd(
+			packDir,
+			static dir => new Lazy<ExpansionResult>(() => ParseFrameworkList(dir), LazyThreadSafetyMode.ExecutionAndPublication)).Value;
+	}
+
+	private static ExpansionResult ParseFrameworkList(string packDir)
+	{
+		string manifestPath = Path.Join(packDir, "data", "FrameworkList.xml");
+		if (!File.Exists(manifestPath))
+		{
+			return ExpansionResult.Empty;
+		}
+
+		XDocument doc;
+		try
+		{
+			doc = XDocument.Load(manifestPath, LoadOptions.None);
+		}
+		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or System.Xml.XmlException)
+		{
+			System.Diagnostics.Trace.TraceWarning(
+				"[lscache] Failed to parse framework-list manifest at {0}: {1}",
+				manifestPath,
+				ex.Message);
+			return ExpansionResult.Empty;
+		}
+
+		ImmutableArray<string>.Builder managed = ImmutableArray.CreateBuilder<string>();
+		ImmutableArray<string>.Builder analyzers = ImmutableArray.CreateBuilder<string>();
+
+		XElement? root = doc.Root;
+		if (root is null)
+		{
+			return ExpansionResult.Empty;
+		}
+
+		foreach (XElement file in root.Elements("File"))
+		{
+			string? type = (string?)file.Attribute("Type");
+			string? path = (string?)file.Attribute("Path");
+			if (string.IsNullOrEmpty(path)) continue;
+
+			string absolutePath = Path.Join(packDir, path.Replace('/', Path.DirectorySeparatorChar));
+
+			if (string.Equals(type, "Managed", StringComparison.OrdinalIgnoreCase))
+			{
+				managed.Add(absolutePath);
+			}
+			else if (string.Equals(type, "Analyzer", StringComparison.OrdinalIgnoreCase))
+			{
+				string? language = (string?)file.Attribute("Language");
+				if (string.Equals(language, "cs", StringComparison.OrdinalIgnoreCase))
+				{
+					analyzers.Add(absolutePath);
+				}
+			}
+		}
+
+		return new ExpansionResult
+		{
+			ManagedAssemblyPaths = managed.ToImmutable(),
+			AnalyzerCsPaths = analyzers.ToImmutable(),
+		};
+	}
+}

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/FrameworkListExpander.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/FrameworkListExpander.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Concurrent;
 using System.Collections.Immutable;

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/HexEncoder.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/HexEncoder.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.NET.ProjectData;
 

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/HexEncoder.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/HexEncoder.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+namespace Microsoft.NET.ProjectData;
+
+/// <summary>
+/// Lowercase-hex byte-to-string encoder used by cache file fingerprinting and hashing.
+/// </summary>
+/// <remarks>
+/// .NET 5+ ships <c>Convert.ToHexString</c> and .NET 9+ ships <c>Convert.ToHexStringLower</c>,
+/// but this file is source-linked into the ``Microsoft.NET.ProjectData.Tasks`` MSBuild task
+/// assembly which targets ``netstandard2.0``. Neither BCL API exists there, so we keep a
+/// manual implementation that compiles cleanly on both target frameworks.
+/// </remarks>
+internal static class HexEncoder
+{
+	private const string LowerHexChars = "0123456789abcdef";
+
+	/// <summary>
+	/// Converts <paramref name="bytes"/> to a lowercase hexadecimal string. The returned
+	/// string has exactly <c>bytes.Length * 2</c> characters.
+	/// </summary>
+	public static string ToLowerHex(byte[] bytes)
+	{
+		char[] chars = new char[bytes.Length * 2];
+		for (int i = 0; i < bytes.Length; i++)
+		{
+			chars[i * 2] = LowerHexChars[bytes[i] >> 4];
+			chars[i * 2 + 1] = LowerHexChars[bytes[i] & 0xF];
+		}
+		return new string(chars);
+	}
+}

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/Microsoft.NET.ProjectData.csproj
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/Microsoft.NET.ProjectData.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- Library is consumed by the server (and source-linked into Tasks); not packaged on its own. -->
+    <IsPackable>false</IsPackable>
+    <IsTrimmable>true</IsTrimmable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.NET.ProjectData.Generators\Microsoft.NET.ProjectData.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all" />
+    <AdditionalFiles Include="..\Microsoft.NET.ProjectData.Generators\project-data-schema.json" />
+    <InternalsVisibleTo Include="Microsoft.NET.ProjectData.Tests" Key="$(VsPublicKey)" />
+    <InternalsVisibleTo Include="CSDevKit.Tests" Key="$(VsPublicKey)" />
+  </ItemGroup>
+
+</Project>

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/Microsoft.NET.ProjectData.csproj
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/Microsoft.NET.ProjectData.csproj
@@ -8,8 +8,16 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.NET.ProjectData.Generators\Microsoft.NET.ProjectData.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all" />
+
+    <!-- The generator depends on System.Text.Json, so pass its runtime dependency closure as /analyzer inputs to the compiler. This is needed for
+         us to build under net472 compilers which we do in our test-rebuild validation in CI. -->
+    <PackageReference Include="System.IO.Pipelines" GeneratePathProperty="true" ExcludeAssets="all" PrivateAssets="all" />
+    <PackageReference Include="System.Text.Json" GeneratePathProperty="true" ExcludeAssets="all" PrivateAssets="all" />
+    <Analyzer Include="$(PkgSystem_IO_Pipelines)\lib\netstandard2.0\System.IO.Pipelines.dll" />
+    <Analyzer Include="$(PkgSystem_Text_Json)\lib\netstandard2.0\System.Text.Json.dll" />
+
     <AdditionalFiles Include="..\Microsoft.NET.ProjectData.Generators\project-data-schema.json" />
-    <InternalsVisibleTo Include="Microsoft.NET.ProjectData.Tests" Key="$(VsPublicKey)" />
+    <InternalsVisibleTo Include="Microsoft.NET.ProjectData.UnitTests" Key="$(VsPublicKey)" />
     <InternalsVisibleTo Include="CSDevKit.Tests" Key="$(VsPublicKey)" />
   </ItemGroup>
 

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/Model/KeySchema.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/Model/KeySchema.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System.Collections.Frozen;
+
+namespace Microsoft.NET.ProjectData;
+
+/// <summary>
+/// Maps string keys to array indices for O(1) lookup in <see cref="KeyValueCollection"/>.
+/// Instances are shared across all snapshots, so keys are defined once and reused.
+/// </summary>
+public sealed class KeySchema
+{
+	private readonly FrozenDictionary<string, int> keyToIndex;
+	private readonly string[] indexToKey;
+
+	public KeySchema(IReadOnlyList<string> keys)
+		: this(keys, StringComparers.PropertyName)
+	{
+	}
+
+	public KeySchema(IReadOnlyList<string> keys, StringComparer comparer)
+	{
+		this.indexToKey = new string[keys.Count];
+		Dictionary<string, int> map = new(keys.Count, comparer);
+
+		for (int i = 0; i < keys.Count; i++)
+		{
+			this.indexToKey[i] = keys[i];
+			map[keys[i]] = i;
+		}
+
+		this.keyToIndex = map.ToFrozenDictionary(comparer);
+	}
+
+	/// <summary>
+	/// Gets the number of keys in this schema.
+	/// </summary>
+	public int Count => this.indexToKey.Length;
+
+	/// <summary>
+	/// Gets the key name at the specified index.
+	/// </summary>
+	public string GetKey(int index) => this.indexToKey[index];
+
+	/// <summary>
+	/// Tries to get the index for a given key name.
+	/// </summary>
+	public bool TryGetIndex(string key, out int index) => this.keyToIndex.TryGetValue(key, out index);
+
+	/// <summary>
+	/// Gets the index for a given key name, or -1 if not found.
+	/// </summary>
+	public int GetIndexOrNegativeOne(string key) => this.keyToIndex.TryGetValue(key, out int index) ? index : -1;
+}

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/Model/KeySchema.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/Model/KeySchema.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Frozen;
 

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/Model/KeyValueCollection.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/Model/KeyValueCollection.cs
@@ -1,0 +1,135 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+
+namespace Microsoft.NET.ProjectData;
+
+/// <summary>
+/// Optimized key-value collection that exploits the regular key structure of
+/// project data. Keys are defined by a shared <see cref="KeySchema"/>, and values
+/// are stored as a flat array of strings indexed by the schema. This avoids
+/// dictionary overhead for what is essentially a fixed set of known keys.
+/// </summary>
+public readonly struct KeyValueCollection
+{
+	private readonly KeySchema schema;
+	private readonly ImmutableArray<string?> values;
+
+	public KeyValueCollection(KeySchema schema, ImmutableArray<string?> values)
+	{
+		Debug.Assert(schema is not null, "KeyValueCollection must be constructed with a non-null schema.");
+		Debug.Assert(!values.IsDefault, "KeyValueCollection must be constructed with a non-default values array.");
+		Debug.Assert(values.Length <= schema.Count, $"Values array length ({values.Length}) exceeds schema key count ({schema.Count}).");
+
+		this.schema = schema;
+		this.values = values;
+	}
+
+	public static KeyValueCollection Empty { get; } = new(new KeySchema([]), []);
+
+	/// <summary>
+	/// Gets the schema that defines the key layout.
+	/// </summary>
+	public KeySchema Schema => this.schema;
+
+	/// <summary>
+	/// Gets whether this collection has no values (was constructed with an empty values array).
+	/// </summary>
+	public bool IsEmpty => this.values.IsEmpty;
+
+	/// <summary>
+	/// Tries to get the value for a given key.
+	/// Returns <see langword="true"/> if the key exists and has a non-null value.
+	/// </summary>
+	public bool TryGetValue(string key, out string? value)
+	{
+		Debug.Assert(this.schema is not null, "KeyValueCollection used before initialization.");
+
+		if (this.schema.TryGetIndex(key, out int index) && index < this.values.Length)
+		{
+			value = this.values[index];
+			return value is not null;
+		}
+
+		value = null;
+		return false;
+	}
+
+	/// <summary>
+	/// Gets the value for a given key, or <see langword="null"/> if not present.
+	/// </summary>
+	public string? this[string key]
+	{
+		get
+		{
+			this.TryGetValue(key, out string? value);
+			return value;
+		}
+	}
+
+	/// <summary>
+	/// Enumerates all non-null key-value pairs.
+	/// </summary>
+	public Enumerator GetEnumerator() => new(this);
+
+	/// <summary>
+	/// Converts to a dictionary for serialization across process boundaries.
+	/// Only includes non-null values.
+	/// </summary>
+	public Dictionary<string, string> ToDictionary()
+	{
+		Debug.Assert(this.schema is not null, "KeyValueCollection used before initialization.");
+
+		Dictionary<string, string> dict = new(StringComparers.PropertyName);
+
+		if (!this.values.IsEmpty)
+		{
+			for (int i = 0; i < this.values.Length; i++)
+			{
+				if (this.values[i] is string value)
+				{
+					dict[this.schema.GetKey(i)] = value;
+				}
+			}
+		}
+
+		return dict;
+	}
+
+	public struct Enumerator
+	{
+		private readonly KeyValueCollection collection;
+		private int index;
+
+		internal Enumerator(KeyValueCollection collection)
+		{
+			this.collection = collection;
+			this.index = -1;
+		}
+
+		public KeyValuePair<string, string> Current
+		{
+			get
+			{
+				string key = this.collection.schema.GetKey(this.index);
+				string value = this.collection.values[this.index]!;
+				return new(key, value);
+			}
+		}
+
+		public bool MoveNext()
+		{
+			if (this.collection.values.IsEmpty)
+				return false;
+
+			// values.Length <= schema.Count is enforced by the constructor.
+			while (++this.index < this.collection.values.Length)
+			{
+				if (this.collection.values[this.index] is not null)
+					return true;
+			}
+			return false;
+		}
+	}
+}

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/Model/KeyValueCollection.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/Model/KeyValueCollection.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
 using System.Diagnostics;

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/Model/ProjectDataItem.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/Model/ProjectDataItem.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+namespace Microsoft.NET.ProjectData;
+
+/// <summary>
+/// A single immutable item in a project (e.g., a source file, a reference).
+/// </summary>
+public readonly struct ProjectDataItem
+{
+	public ProjectDataItem(string itemSpec, KeyValueCollection metadata)
+	{
+		this.ItemSpec = itemSpec;
+		this.Metadata = metadata;
+	}
+
+	/// <summary>The item specification (typically a file path).</summary>
+	public string ItemSpec { get; }
+
+	/// <summary>Per-item metadata (e.g., Aliases, Link, EmbedInteropTypes).</summary>
+	public KeyValueCollection Metadata { get; }
+}

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/Model/ProjectDataItem.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/Model/ProjectDataItem.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 namespace Microsoft.NET.ProjectData;
 

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/Model/ProjectDataSnapshot.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/Model/ProjectDataSnapshot.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System.Collections.Immutable;
+
+namespace Microsoft.NET.ProjectData;
+
+/// <summary>
+/// Immutable snapshot of all data for a single project configuration slice.
+/// </summary>
+public sealed class ProjectDataSnapshot
+{
+	public ProjectDataSnapshot(
+		string projectPath,
+		ImmutableDictionary<string, string> dimensions,
+		KeyValueCollection properties,
+		ImmutableDictionary<string, ImmutableArray<ProjectDataItem>> itemsByType,
+		bool isPrimary,
+		bool lastDesignTimeBuildSucceeded,
+		ImmutableArray<string> capabilities = default)
+	{
+		this.ProjectPath = projectPath;
+		this.Dimensions = dimensions;
+		this.Properties = properties;
+		this.ItemsByType = itemsByType;
+		this.IsPrimary = isPrimary;
+		this.LastDesignTimeBuildSucceeded = lastDesignTimeBuildSucceeded;
+		this.Capabilities = capabilities.IsDefault ? [] : capabilities;
+	}
+
+	/// <summary>The absolute path of the project file.</summary>
+	public string ProjectPath { get; }
+
+	/// <summary>The project configuration slice dimensions (e.g., TargetFramework=net10.0).</summary>
+	public ImmutableDictionary<string, string> Dimensions { get; }
+
+	/// <summary>Project properties (e.g., AssemblyName, RootNamespace, TargetPath).</summary>
+	public KeyValueCollection Properties { get; }
+
+	/// <summary>Items grouped by type (e.g., Compile, MetadataReference, AnalyzerReference).</summary>
+	public ImmutableDictionary<string, ImmutableArray<ProjectDataItem>> ItemsByType { get; }
+
+	/// <summary>Whether this is the primary slice for project-level queries.</summary>
+	public bool IsPrimary { get; }
+
+	/// <summary>Whether the last design-time build succeeded.</summary>
+	public bool LastDesignTimeBuildSucceeded { get; }
+
+	/// <summary>Capabilities exported by this project slice.</summary>
+	public ImmutableArray<string> Capabilities { get; }
+}

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/Model/ProjectDataSnapshot.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/Model/ProjectDataSnapshot.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
 

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/Model/ProjectDataSnapshotFactory.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/Model/ProjectDataSnapshotFactory.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
 

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/Model/ProjectDataSnapshotFactory.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/Model/ProjectDataSnapshotFactory.cs
@@ -1,0 +1,448 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System.Collections.Immutable;
+
+namespace Microsoft.NET.ProjectData;
+
+/// <summary>
+/// Converts parsed <see cref="CachedSliceData"/> from project-data cache files
+/// into canonical immutable <see cref="ProjectDataSnapshot"/> instances.
+/// </summary>
+public static class ProjectDataSnapshotFactory
+{
+	/// <summary>
+	/// The schema for project-level properties. All properties from the cache file
+	/// are stored here, along with the well-known properties from the schema.
+	/// </summary>
+	/// <remarks>
+	/// This schema is shared across all snapshots and is the basis for O(1) property lookups.
+	/// Additional properties found in cache files that aren't in this schema are still accessible
+	/// through a per-snapshot schema extension.
+	/// </remarks>
+	private static readonly KeySchema PropertySchema = new(ProjectProperties.All);
+
+	/// <summary>
+	/// Well-known item metadata schemas.
+	/// </summary>
+	private static readonly KeySchema SourceFileMetadataSchema = new([ProjectItems.Compile.Link], StringComparers.ItemMetadataName);
+	private static readonly KeySchema MetadataReferenceMetadataSchema = new([ProjectItems.MetadataReference.Aliases, ProjectItems.MetadataReference.EmbedInteropTypes], StringComparers.ItemMetadataName);
+	private static readonly KeySchema EmbeddedResourceMetadataSchema = new([ProjectItems.EmbeddedResource.Generator, ProjectItems.EmbeddedResource.LastGenOutput, ProjectItems.EmbeddedResource.CustomToolNamespace], StringComparers.ItemMetadataName);
+
+	/// <summary>
+	/// Converts a set of parsed cache slices into canonical project-data snapshots.
+	/// </summary>
+	/// <param name="slices">The parsed cache slices.</param>
+	/// <param name="solutionPath">
+	/// Runtime-injected solution path. Overrides any stale <c>SolutionPath</c> value
+	/// that may exist in the cache. When <see langword="null"/> or empty, the key is
+	/// omitted from the snapshot properties so consumers see "no solution."
+	/// </param>
+	public static ImmutableArray<ProjectDataSnapshot> CreateSnapshots(ImmutableArray<CachedSliceData> slices, string? solutionPath = null)
+	{
+		if (slices.IsDefaultOrEmpty)
+			return [];
+
+		// The cache file produces a "shared" slice (no dimensions) with common data
+		// (source files, analyzers, common properties) and per-TFM slices with
+		// TFM-specific data (metadata references, TFM properties). Merge shared data
+		// into each TFM slice so consumers get the complete picture per slice.
+		CachedSliceData? sharedSlice = null;
+		List<CachedSliceData>? tfmSlices = null;
+
+		foreach (CachedSliceData slice in slices)
+		{
+			if (slice.SliceDimensions.IsEmpty)
+				sharedSlice = slice;
+			else
+			{
+				tfmSlices ??= [];
+				tfmSlices.Add(slice);
+			}
+		}
+
+		if (sharedSlice is not null && tfmSlices is { Count: > 0 })
+		{
+			// Multi-TFM: merge shared data into each TFM slice, drop the shared slice.
+			ImmutableArray<ProjectDataSnapshot>.Builder builder = ImmutableArray.CreateBuilder<ProjectDataSnapshot>(tfmSlices.Count);
+			ProjectDataSnapshot sharedSnapshot = CreateSnapshot(sharedSlice, solutionPath);
+
+			foreach (CachedSliceData tfmSlice in tfmSlices)
+			{
+				ProjectDataSnapshot tfmSnapshot = CreateSnapshot(tfmSlice, solutionPath);
+				builder.Add(MergeSharedIntoSlice(sharedSnapshot, tfmSnapshot));
+			}
+
+			return builder.MoveToImmutable();
+		}
+
+		// Single-TFM or no shared slice: produce snapshots as-is.
+		ImmutableArray<ProjectDataSnapshot>.Builder result = ImmutableArray.CreateBuilder<ProjectDataSnapshot>(slices.Length);
+		foreach (CachedSliceData slice in slices)
+		{
+			result.Add(CreateSnapshot(slice, solutionPath));
+		}
+
+		return result.MoveToImmutable();
+	}
+
+	/// <summary>
+	/// Validates that required properties and item types from the schema are present in every snapshot.
+	/// Returns a list of missing required names (empty if all present).
+	/// </summary>
+	public static IReadOnlyList<string> ValidateRequiredData(ImmutableArray<ProjectDataSnapshot> snapshots)
+	{
+		if (snapshots.IsDefaultOrEmpty)
+			return [];
+
+		List<string>? missing = null;
+		foreach (ProjectDataSnapshot snapshot in snapshots)
+		{
+			foreach (string requiredProp in ProjectProperties.Required)
+			{
+				if (!snapshot.Properties.TryGetValue(requiredProp, out _))
+				{
+					missing ??= [];
+					string sliceLabel = snapshot.Dimensions.TryGetValue(ProjectProperties.TargetFramework, out string? tf) ? tf : "default";
+					missing.Add($"property:{requiredProp} (slice:{sliceLabel})");
+				}
+			}
+
+			foreach (string requiredItem in ProjectItems.RequiredItemTypes)
+			{
+				if (!snapshot.ItemsByType.ContainsKey(requiredItem))
+				{
+					missing ??= [];
+					string sliceLabel = snapshot.Dimensions.TryGetValue(ProjectProperties.TargetFramework, out string? tf) ? tf : "default";
+					missing.Add($"item:{requiredItem} (slice:{sliceLabel})");
+				}
+			}
+		}
+
+		return missing ?? (IReadOnlyList<string>)[];
+	}
+
+	/// <summary>
+	/// Converts a single parsed cache slice into a canonical project-data snapshot.
+	/// </summary>
+	public static ProjectDataSnapshot CreateSnapshot(CachedSliceData slice, string? solutionPath = null)
+	{
+		KeyValueCollection properties = BuildProperties(slice, solutionPath);
+		ImmutableDictionary<string, ImmutableArray<ProjectDataItem>> itemsByType = BuildItems(slice);
+
+		return new ProjectDataSnapshot(
+			projectPath: slice.ProjectFilePath,
+			dimensions: slice.SliceDimensions,
+			properties: properties,
+			itemsByType: itemsByType,
+			isPrimary: slice.IsPrimary,
+			lastDesignTimeBuildSucceeded: slice.LastDesignTimeBuildSucceeded,
+			capabilities: slice.Capabilities);
+	}
+
+	/// <summary>
+	/// Merges items and properties from the shared (dimensionless) slice into a per-TFM slice.
+	/// TFM-specific items and properties take priority; shared data fills in the gaps.
+	/// </summary>
+	private static ProjectDataSnapshot MergeSharedIntoSlice(ProjectDataSnapshot shared, ProjectDataSnapshot tfmSlice)
+	{
+		// Merge items: start with shared, overlay TFM-specific.
+		ImmutableDictionary<string, ImmutableArray<ProjectDataItem>>.Builder mergedItems =
+			ImmutableDictionary.CreateBuilder<string, ImmutableArray<ProjectDataItem>>(StringComparer.OrdinalIgnoreCase);
+
+		foreach (KeyValuePair<string, ImmutableArray<ProjectDataItem>> kvp in shared.ItemsByType)
+			mergedItems[kvp.Key] = kvp.Value;
+
+		foreach (KeyValuePair<string, ImmutableArray<ProjectDataItem>> kvp in tfmSlice.ItemsByType)
+		{
+			if (mergedItems.TryGetValue(kvp.Key, out ImmutableArray<ProjectDataItem> existing))
+				mergedItems[kvp.Key] = existing.AddRange(kvp.Value);
+			else
+				mergedItems[kvp.Key] = kvp.Value;
+		}
+
+		// Properties: merge shared as base, TFM-specific overrides.
+		KeyValueCollection mergedProperties;
+		if (tfmSlice.Properties.IsEmpty)
+		{
+			mergedProperties = shared.Properties;
+		}
+		else if (shared.Properties.IsEmpty)
+		{
+			mergedProperties = tfmSlice.Properties;
+		}
+		else
+		{
+			// Merge via dictionaries since the collections may have different schemas
+			// (different sets of extra properties beyond the well-known schema).
+			Dictionary<string, string> merged = shared.Properties.ToDictionary();
+			foreach (KeyValuePair<string, string> kvp in tfmSlice.Properties)
+			{
+				merged[kvp.Key] = kvp.Value;
+			}
+
+			// Rebuild a KeyValueCollection from the merged dictionary using the shared schema.
+			mergedProperties = BuildKeyValueCollection(merged, shared.Properties.Schema);
+		}
+
+		return new ProjectDataSnapshot(
+			projectPath: tfmSlice.ProjectPath,
+			dimensions: tfmSlice.Dimensions,
+			properties: mergedProperties,
+			itemsByType: mergedItems.ToImmutable(),
+			isPrimary: tfmSlice.IsPrimary,
+			lastDesignTimeBuildSucceeded: tfmSlice.LastDesignTimeBuildSucceeded || shared.LastDesignTimeBuildSucceeded,
+			capabilities: MergeCapabilities(shared.Capabilities, tfmSlice.Capabilities));
+	}
+
+	private static ImmutableArray<string> MergeCapabilities(ImmutableArray<string> sharedCapabilities, ImmutableArray<string> sliceCapabilities)
+	{
+		if (sharedCapabilities.IsDefaultOrEmpty)
+			return sliceCapabilities.IsDefault ? [] : sliceCapabilities;
+		if (sliceCapabilities.IsDefaultOrEmpty)
+			return sharedCapabilities;
+
+		return sharedCapabilities
+			.AddRange(sliceCapabilities)
+			.Distinct(StringComparer.OrdinalIgnoreCase)
+			.OrderBy(static c => c, StringComparer.OrdinalIgnoreCase)
+			.ToImmutableArray();
+	}
+
+	private static KeyValueCollection BuildProperties(CachedSliceData slice, string? solutionPath)
+	{
+		// Build the properties array using the schema for fast lookups.
+		// Properties not in the schema are stored via a dynamic approach.
+		ImmutableArray<string?>.Builder values = ImmutableArray.CreateBuilder<string?>(PropertySchema.Count);
+		values.Count = PropertySchema.Count;
+
+		// Collect any properties not in the schema.
+		List<string>? extraKeys = null;
+		List<string?>? extraValues = null;
+
+		foreach (KeyValuePair<string, string> kvp in slice.Properties)
+		{
+			if (PropertySchema.TryGetIndex(kvp.Key, out int index))
+			{
+				values[index] = kvp.Value;
+			}
+			else
+			{
+				// Property not in the well-known schema; still store it.
+				// We'll build a dynamic schema extension.
+				extraKeys ??= [];
+				extraValues ??= [];
+				extraKeys.Add(kvp.Key);
+				extraValues.Add(kvp.Value);
+			}
+		}
+
+		// Inject runtime SolutionPath; overrides any stale value from the cache.
+		// When empty/null, clear the slot so consumers see "no solution" rather than "".
+		if (PropertySchema.TryGetIndex(ProjectProperties.SolutionPath, out int solutionPathIndex))
+		{
+			values[solutionPathIndex] = string.IsNullOrEmpty(solutionPath) ? null : solutionPath;
+		}
+
+		if (extraKeys is not null)
+		{
+			return BuildKeyValueCollection(PropertySchema, values.MoveToImmutable(), extraKeys, extraValues!);
+		}
+
+		return new KeyValueCollection(PropertySchema, values.MoveToImmutable());
+	}
+
+	private static KeyValueCollection BuildKeyValueCollection(Dictionary<string, string> valuesByKey, KeySchema baseSchema)
+	{
+		ImmutableArray<string?>.Builder values = ImmutableArray.CreateBuilder<string?>(baseSchema.Count);
+		values.Count = baseSchema.Count;
+
+		List<string>? extraKeys = null;
+		List<string?>? extraValues = null;
+
+		foreach (KeyValuePair<string, string> kvp in valuesByKey)
+		{
+			if (baseSchema.TryGetIndex(kvp.Key, out int index))
+			{
+				values[index] = kvp.Value;
+			}
+			else
+			{
+				extraKeys ??= [];
+				extraValues ??= [];
+				extraKeys.Add(kvp.Key);
+				extraValues.Add(kvp.Value);
+			}
+		}
+
+		if (extraKeys is null)
+		{
+			return new KeyValueCollection(baseSchema, values.MoveToImmutable());
+		}
+
+		return BuildKeyValueCollection(baseSchema, values.MoveToImmutable(), extraKeys, extraValues!);
+	}
+
+	private static KeyValueCollection BuildKeyValueCollection(KeySchema baseSchema, ImmutableArray<string?> values, List<string> extraKeys, List<string?> extraValues)
+	{
+		// Build a combined schema that includes both well-known and extra properties.
+		List<string> allKeys = new(baseSchema.Count + extraKeys.Count);
+		for (int i = 0; i < baseSchema.Count; i++)
+		{
+			allKeys.Add(baseSchema.GetKey(i));
+		}
+		allKeys.AddRange(extraKeys);
+
+		KeySchema combinedSchema = new(allKeys);
+		ImmutableArray<string?>.Builder combinedValues = ImmutableArray.CreateBuilder<string?>(allKeys.Count);
+		combinedValues.Count = allKeys.Count;
+
+		// Copy known values.
+		for (int i = 0; i < values.Length; i++)
+		{
+			combinedValues[i] = values[i];
+		}
+
+		// Copy extra values.
+		for (int i = 0; i < extraValues.Count; i++)
+		{
+			combinedValues[baseSchema.Count + i] = extraValues[i];
+		}
+
+		return new KeyValueCollection(combinedSchema, combinedValues.MoveToImmutable());
+	}
+
+	private static ImmutableDictionary<string, ImmutableArray<ProjectDataItem>> BuildItems(CachedSliceData slice)
+	{
+		ImmutableDictionary<string, ImmutableArray<ProjectDataItem>>.Builder items =
+			ImmutableDictionary.CreateBuilder<string, ImmutableArray<ProjectDataItem>>(StringComparers.ItemType);
+
+		// Source files → Compile items
+		AddItems(items, ProjectItems.Compile.ItemType, slice.SourceFiles, BuildSourceFileItems);
+
+		// Metadata references → MetadataReference items
+		AddItems(items, ProjectItems.MetadataReference.ItemType, slice.MetadataReferences, BuildMetadataReferenceItems);
+
+		// Analyzer references → AnalyzerReference items
+		AddSimpleItems(items, ProjectItems.AnalyzerReference, slice.AnalyzerReferences);
+
+		// Analyzer config files → AnalyzerConfigFile items
+		AddSimpleItems(items, ProjectItems.AnalyzerConfigFile, slice.AnalyzerConfigFiles);
+
+		// Additional files → AdditionalFile items
+		AddSimpleItems(items, ProjectItems.AdditionalFile, slice.AdditionalFiles);
+
+		// Embedded resources → EmbeddedResource items
+		AddItems(items, ProjectItems.EmbeddedResource.ItemType, slice.EmbeddedResources, BuildEmbeddedResourceItems);
+
+		// Project references → ProjectReference items
+		AddSimpleItems(items, ProjectItems.ProjectReference, slice.ProjectReferences);
+
+		// Command-line arguments → CommandLineArgument items
+		AddSimpleItems(items, ProjectItems.CommandLineArgument, slice.CommandLineArguments);
+
+		return items.ToImmutable();
+	}
+
+	/// <summary>
+	/// Adds items to the builder. Always adds the key (even with an empty array) so that
+	/// required item types are present for validation and downstream consumers.
+	/// </summary>
+	private static void AddItems<T>(
+		ImmutableDictionary<string, ImmutableArray<ProjectDataItem>>.Builder items,
+		string itemType,
+		ImmutableArray<T> source,
+		Func<ImmutableArray<T>, ImmutableArray<ProjectDataItem>> builder)
+	{
+		items[itemType] = source.IsDefaultOrEmpty ? [] : builder(source);
+	}
+
+	private static void AddSimpleItems(
+		ImmutableDictionary<string, ImmutableArray<ProjectDataItem>>.Builder items,
+		string itemType,
+		ImmutableArray<string> source)
+	{
+		items[itemType] = source.IsDefaultOrEmpty ? [] : BuildSimpleItems(source);
+	}
+
+	private static ImmutableArray<ProjectDataItem> BuildSourceFileItems(ImmutableArray<CachedSourceFile> sourceFiles)
+	{
+		ImmutableArray<ProjectDataItem>.Builder builder = ImmutableArray.CreateBuilder<ProjectDataItem>(sourceFiles.Length);
+
+		foreach (CachedSourceFile file in sourceFiles)
+		{
+			ImmutableArray<string?>.Builder metaValues = ImmutableArray.CreateBuilder<string?>(SourceFileMetadataSchema.Count);
+			metaValues.Count = SourceFileMetadataSchema.Count;
+
+			if (!string.IsNullOrEmpty(file.Link))
+			{
+				metaValues[0] = file.Link;
+			}
+
+			builder.Add(new ProjectDataItem(
+				file.FilePath,
+				new KeyValueCollection(SourceFileMetadataSchema, metaValues.MoveToImmutable())));
+		}
+
+		return builder.MoveToImmutable();
+	}
+
+	private static ImmutableArray<ProjectDataItem> BuildMetadataReferenceItems(ImmutableArray<CachedMetadataReference> references)
+	{
+		ImmutableArray<ProjectDataItem>.Builder builder = ImmutableArray.CreateBuilder<ProjectDataItem>(references.Length);
+
+		foreach (CachedMetadataReference reference in references)
+		{
+			ImmutableArray<string?>.Builder metaValues = ImmutableArray.CreateBuilder<string?>(MetadataReferenceMetadataSchema.Count);
+			metaValues.Count = MetadataReferenceMetadataSchema.Count;
+
+			if (!reference.Aliases.IsDefaultOrEmpty)
+			{
+				metaValues[0] = string.Join(",", reference.Aliases); // aliases
+			}
+
+			if (reference.EmbedInteropTypes)
+			{
+				metaValues[1] = ""; // embedInteropTypes (flag)
+			}
+
+			builder.Add(new ProjectDataItem(
+				reference.FilePath,
+				new KeyValueCollection(MetadataReferenceMetadataSchema, metaValues.MoveToImmutable())));
+		}
+
+		return builder.MoveToImmutable();
+	}
+
+	private static ImmutableArray<ProjectDataItem> BuildEmbeddedResourceItems(ImmutableArray<CachedEmbeddedResource> resources)
+	{
+		ImmutableArray<ProjectDataItem>.Builder builder = ImmutableArray.CreateBuilder<ProjectDataItem>(resources.Length);
+
+		foreach (CachedEmbeddedResource resource in resources)
+		{
+			ImmutableArray<string?>.Builder metaValues = ImmutableArray.CreateBuilder<string?>(EmbeddedResourceMetadataSchema.Count);
+			metaValues.Count = EmbeddedResourceMetadataSchema.Count;
+
+			metaValues[0] = resource.Generator; // Generator
+			metaValues[1] = resource.LastGenOutput; // LastGenOutput
+			metaValues[2] = resource.CustomToolNamespace; // CustomToolNamespace
+
+			builder.Add(new ProjectDataItem(
+				resource.FilePath,
+				new KeyValueCollection(EmbeddedResourceMetadataSchema, metaValues.MoveToImmutable())));
+		}
+
+		return builder.MoveToImmutable();
+	}
+
+	private static ImmutableArray<ProjectDataItem> BuildSimpleItems(ImmutableArray<string> paths)
+	{
+		ImmutableArray<ProjectDataItem>.Builder builder = ImmutableArray.CreateBuilder<ProjectDataItem>(paths.Length);
+
+		foreach (string path in paths)
+		{
+			builder.Add(new ProjectDataItem(path, KeyValueCollection.Empty));
+		}
+
+		return builder.MoveToImmutable();
+	}
+}

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/SdkKnownFrameworkReferenceResolver.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/SdkKnownFrameworkReferenceResolver.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Concurrent;
 using System.Xml.Linq;

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/SdkKnownFrameworkReferenceResolver.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/SdkKnownFrameworkReferenceResolver.cs
@@ -1,0 +1,290 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System.Collections.Concurrent;
+using System.Xml.Linq;
+
+namespace Microsoft.NET.ProjectData;
+
+/// <summary>
+/// Reads the selected .NET SDK's bundled-version tables so cache files can
+/// represent SDK-known NuGet packs by logical package name.
+/// </summary>
+internal static class SdkKnownPackResolver
+{
+	private static readonly ConcurrentDictionary<string, Lazy<SdkKnownPackSet>> Cache = new(StringComparers.Paths);
+	private static readonly KnownPackItemMetadata[] KnownAnalyzerPackItemMetadata =
+	[
+		new("KnownILLinkPack", "ILLinkPackVersion"),
+	];
+
+	public static bool TryGetTargetingPackVersionForSdk(
+		string? sdkPath,
+		string packName,
+		string? targetFramework,
+		out string? targetingPackVersion)
+	{
+		targetingPackVersion = null;
+		if (string.IsNullOrWhiteSpace(sdkPath) || string.IsNullOrWhiteSpace(packName) || string.IsNullOrWhiteSpace(targetFramework))
+			return false;
+
+		return GetReferenceSet(sdkPath!).TryGetTargetingPackVersion(packName, targetFramework, out targetingPackVersion);
+	}
+
+	public static bool TryGetSdkAnalyzerPackVersionForSdk(
+		string? sdkPath,
+		string packageId,
+		string? targetFramework,
+		out string? packageVersion)
+	{
+		packageVersion = null;
+		if (string.IsNullOrWhiteSpace(sdkPath)
+			|| string.IsNullOrWhiteSpace(packageId)
+			|| string.IsNullOrWhiteSpace(targetFramework))
+		{
+			return false;
+		}
+
+		return GetReferenceSet(sdkPath!).TryGetSdkAnalyzerPackVersion(packageId, targetFramework, out packageVersion);
+	}
+
+	private static SdkKnownPackSet GetReferenceSet(string sdkPath)
+	{
+		string normalizedSdkPath = NormalizeSdkPath(sdkPath);
+		// Wrap the IO+XML parse in Lazy so racing callers can't trigger duplicate parses.
+		return Cache.GetOrAdd(
+			normalizedSdkPath,
+			static path => new Lazy<SdkKnownPackSet>(() => ParseReferences(path), LazyThreadSafetyMode.ExecutionAndPublication)).Value;
+	}
+
+	private static SdkKnownPackSet ParseReferences(string sdkPath)
+	{
+		string propsPath = Path.Combine(sdkPath, "Microsoft.NETCoreSdk.BundledVersions.props");
+		if (!File.Exists(propsPath))
+		{
+			return SdkKnownPackSet.Empty;
+		}
+
+		XDocument doc;
+		try
+		{
+			doc = XDocument.Load(propsPath, LoadOptions.None);
+		}
+		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or System.Xml.XmlException)
+		{
+			System.Diagnostics.Trace.TraceWarning(
+				"[lscache] Failed to parse known-pack metadata from {0}: {1}",
+				propsPath,
+				ex.Message);
+			return SdkKnownPackSet.Empty;
+		}
+
+		List<KnownFrameworkReference> references = [];
+		List<KnownSdkAnalyzerPack> analyzerPacks = [];
+		foreach (XElement element in doc.Descendants())
+		{
+			if (element.Name.LocalName == "KnownFrameworkReference")
+			{
+				string? targetFramework = (string?)element.Attribute("TargetFramework");
+				string? targetingPackName = (string?)element.Attribute("TargetingPackName");
+				string? targetingPackVersion = (string?)element.Attribute("TargetingPackVersion");
+				if (string.IsNullOrWhiteSpace(targetFramework)
+					|| string.IsNullOrWhiteSpace(targetingPackName)
+					|| string.IsNullOrWhiteSpace(targetingPackVersion))
+				{
+					continue;
+				}
+
+				references.Add(new KnownFrameworkReference(targetFramework!, targetingPackName!, targetingPackVersion!));
+				continue;
+			}
+
+			if (TryGetKnownAnalyzerPackVersionMetadata(element.Name.LocalName, out string? versionMetadataName))
+			{
+				string? targetFramework = (string?)element.Attribute("TargetFramework");
+				string? packageId = (string?)element.Attribute("Include");
+				string? packageVersion = (string?)element.Attribute(versionMetadataName);
+				if (string.IsNullOrWhiteSpace(targetFramework)
+					|| string.IsNullOrWhiteSpace(packageId)
+					|| string.IsNullOrWhiteSpace(packageVersion))
+				{
+					continue;
+				}
+
+				analyzerPacks.Add(new KnownSdkAnalyzerPack(targetFramework!, packageId!, packageVersion!));
+			}
+		}
+
+		return new SdkKnownPackSet(references.ToArray(), analyzerPacks.ToArray());
+	}
+
+	private static string NormalizeSdkPath(string sdkPath)
+	{
+		string full = Path.GetFullPath(sdkPath);
+		if (string.Equals(Path.GetFileName(full.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)), "Sdks", StringComparison.OrdinalIgnoreCase))
+		{
+			full = Path.GetDirectoryName(full.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)) ?? full;
+		}
+
+		return full;
+	}
+
+	private static bool TryGetKnownAnalyzerPackVersionMetadata(string itemType, out string versionMetadataName)
+	{
+		foreach (KnownPackItemMetadata metadata in KnownAnalyzerPackItemMetadata)
+		{
+			if (string.Equals(metadata.ItemType, itemType, StringComparison.OrdinalIgnoreCase))
+			{
+				versionMetadataName = metadata.VersionMetadataName;
+				return true;
+			}
+		}
+
+		versionMetadataName = string.Empty;
+		return false;
+	}
+
+	private sealed class SdkKnownPackSet
+	{
+		public static readonly SdkKnownPackSet Empty = new([], []);
+
+		private readonly KnownFrameworkReference[] references;
+		private readonly KnownSdkAnalyzerPack[] analyzerPacks;
+
+		public SdkKnownPackSet(KnownFrameworkReference[] references, KnownSdkAnalyzerPack[] analyzerPacks)
+		{
+			this.references = references;
+			this.analyzerPacks = analyzerPacks;
+		}
+
+		public bool TryGetTargetingPackVersion(string packName, string targetFramework, out string? targetingPackVersion)
+		{
+			foreach (KnownFrameworkReference reference in this.references)
+			{
+				if (TargetFrameworkMatches(reference.TargetFramework, targetFramework)
+					&& string.Equals(reference.TargetingPackName, packName, StringComparison.OrdinalIgnoreCase))
+				{
+					targetingPackVersion = reference.TargetingPackVersion;
+					return true;
+				}
+			}
+
+			targetingPackVersion = null;
+			return false;
+		}
+
+		public bool TryGetSdkAnalyzerPackVersion(string packageId, string targetFramework, out string? packageVersion)
+		{
+			foreach (KnownSdkAnalyzerPack pack in this.analyzerPacks)
+			{
+				if (TargetFrameworkMatches(pack.TargetFramework, targetFramework)
+					&& string.Equals(pack.PackageId, packageId, StringComparison.OrdinalIgnoreCase))
+				{
+					packageVersion = pack.PackageVersion;
+					return true;
+				}
+			}
+
+			packageVersion = null;
+			return false;
+		}
+
+		private static bool TargetFrameworkMatches(string knownTargetFramework, string requestedTargetFramework)
+		{
+			if (string.Equals(knownTargetFramework, requestedTargetFramework, StringComparison.OrdinalIgnoreCase))
+			{
+				return true;
+			}
+
+			// Match on identifier + (major, minor) rather than identifier + major alone.
+			// Earlier the fallback compared only the first digit run, so ``net4.8`` matched
+			// ``net4.0`` and a request for ``net8.1`` could resolve against ``net8.0`` data.
+			if (!TryParseTfm(knownTargetFramework, out string knownId, out Version knownVersion)
+				|| !TryParseTfm(requestedTargetFramework, out string requestedId, out Version requestedVersion))
+			{
+				return false;
+			}
+
+			return string.Equals(knownId, requestedId, StringComparison.OrdinalIgnoreCase)
+				&& knownVersion.Major == requestedVersion.Major
+				&& knownVersion.Minor == requestedVersion.Minor;
+		}
+
+		private static bool TryParseTfm(string? tfm, out string identifier, out Version version)
+		{
+			identifier = string.Empty;
+			version = new Version(0, 0);
+			if (string.IsNullOrEmpty(tfm))
+			{
+				return false;
+			}
+
+			int versionStart = -1;
+			for (int i = 0; i < tfm.Length; i++)
+			{
+				if (char.IsDigit(tfm[i]))
+				{
+					versionStart = i;
+					break;
+				}
+			}
+			if (versionStart <= 0)
+			{
+				return false;
+			}
+
+			identifier = tfm[..versionStart];
+			string versionPart = tfm[versionStart..];
+			// ``Version.TryParse`` requires at least ``major.minor``; pad bare ``net8`` → ``8.0``.
+			if (!versionPart.Contains('.'))
+			{
+				versionPart += ".0";
+			}
+			if (Version.TryParse(versionPart, out Version? parsed))
+			{
+				version = parsed;
+				return true;
+			}
+			return false;
+		}
+	}
+
+	private readonly struct KnownFrameworkReference
+	{
+		public KnownFrameworkReference(string targetFramework, string targetingPackName, string targetingPackVersion)
+		{
+			this.TargetFramework = targetFramework;
+			this.TargetingPackName = targetingPackName;
+			this.TargetingPackVersion = targetingPackVersion;
+		}
+
+		public string TargetFramework { get; }
+		public string TargetingPackName { get; }
+		public string TargetingPackVersion { get; }
+	}
+
+	private readonly struct KnownSdkAnalyzerPack
+	{
+		public KnownSdkAnalyzerPack(string targetFramework, string packageId, string packageVersion)
+		{
+			this.TargetFramework = targetFramework;
+			this.PackageId = packageId;
+			this.PackageVersion = packageVersion;
+		}
+
+		public string TargetFramework { get; }
+		public string PackageId { get; }
+		public string PackageVersion { get; }
+	}
+
+	private readonly struct KnownPackItemMetadata
+	{
+		public KnownPackItemMetadata(string itemType, string versionMetadataName)
+		{
+			this.ItemType = itemType;
+			this.VersionMetadataName = versionMetadataName;
+		}
+
+		public string ItemType { get; }
+		public string VersionMetadataName { get; }
+	}
+}

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/StringComparers.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/StringComparers.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Runtime.InteropServices;
 

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/StringComparers.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/StringComparers.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System.Runtime.InteropServices;
+
+namespace Microsoft.NET.ProjectData;
+
+/// <summary>
+/// Well-known string comparers and comparisons for Data Model types.
+/// </summary>
+/// <remarks>
+/// This pattern is borrowed from dotnet-project-system, where centralizing comparison
+/// semantics avoids scattered <see cref="StringComparer"/> and <see cref="StringComparison"/>
+/// choices throughout the codebase.
+/// </remarks>
+public static class StringComparers
+{
+	/// <summary>Comparer for item type names (e.g., "Compile", "MetadataReference").</summary>
+	public static StringComparer ItemType { get; } = StringComparer.OrdinalIgnoreCase;
+
+	/// <summary>Comparer for item metadata key names (e.g., "aliases", "folderNames").</summary>
+	public static StringComparer ItemMetadataName { get; } = StringComparer.OrdinalIgnoreCase;
+
+	/// <summary>Comparer for property names (e.g., "AssemblyName", "TargetPath").</summary>
+	public static StringComparer PropertyName { get; } = StringComparer.OrdinalIgnoreCase;
+
+	/// <summary>Comparer for capability names (e.g., "SupportsHotReload", "SupportsIncrementalBuild").</summary>
+	public static StringComparer Capabilities { get; } = StringComparer.OrdinalIgnoreCase;
+
+	/// <summary>Comparer for item spec values (file paths or identifiers).</summary>
+	public static StringComparer ItemSpec { get; } =
+		RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
+
+	/// <summary>Comparer for file paths, respecting platform case sensitivity.</summary>
+	public static StringComparer Paths { get; } =
+		RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
+}
+
+/// <summary>
+/// Well-known string comparisons for Data Model types.
+/// </summary>
+public static class StringComparisons
+{
+	/// <summary>Comparison for item type names.</summary>
+	public static StringComparison ItemType => StringComparison.OrdinalIgnoreCase;
+
+	/// <summary>Comparison for item metadata key names.</summary>
+	public static StringComparison ItemMetadataName => StringComparison.OrdinalIgnoreCase;
+
+	/// <summary>Comparison for property names.</summary>
+	public static StringComparison PropertyName => StringComparison.OrdinalIgnoreCase;
+
+	/// <summary>Comparison for file paths, respecting platform case sensitivity.</summary>
+	public static StringComparison Paths { get; } =
+		RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
+}

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/StringPool.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/StringPool.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/StringPool.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/StringPool.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.NET.ProjectData;
+
+/// <summary>
+/// A thread-safe string deduplication pool. Ensures that equal strings share a single
+/// object instance, reducing memory when many projects carry identical paths (SDK refs,
+/// analyzer paths, NuGet packages, capabilities, property keys, etc.).
+///
+/// <para>Internally uses striped <see cref="ConcurrentDictionary{TKey, TValue}"/>s so
+/// concurrent readers and writers experience minimal contention. Striping improves
+/// cache locality across the 16 independent buckets.</para>
+///
+/// <para>The pool is intended to live as long as the data it deduplicates (e.g. scoped to
+/// the <c>DataModelSharedState</c> lifetime). It is not self-evicting — entries stay until
+/// the pool is collected.</para>
+/// </summary>
+public sealed class StringPool
+{
+	private const int StripeCount = 16; // power of two for fast masking
+	private const int StripeMask = StripeCount - 1;
+
+	private readonly ConcurrentDictionary<string, string>[] stripes;
+
+	public StringPool()
+	{
+		this.stripes = new ConcurrentDictionary<string, string>[StripeCount];
+		for (int i = 0; i < StripeCount; i++)
+			this.stripes[i] = new(StringComparer.Ordinal);
+	}
+
+	/// <summary>
+	/// Returns the canonical instance of <paramref name="value"/>. If an equal string
+	/// is already in the pool, the pooled instance is returned and <paramref name="value"/>
+	/// becomes eligible for GC. Otherwise <paramref name="value"/> is added to the pool
+	/// and returned as-is.
+	/// </summary>
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public string GetOrAdd(string value)
+	{
+		int stripe = value.GetHashCode() & StripeMask;
+		return this.stripes[stripe].GetOrAdd(value, static v => v);
+	}
+}
+

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/UnsupportedProjectDataMarker.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/UnsupportedProjectDataMarker.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/UnsupportedProjectDataMarker.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/UnsupportedProjectDataMarker.cs
@@ -1,0 +1,263 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Microsoft.NET.ProjectData;
+
+/// <summary>
+/// Reads and writes the user-cache sidecar that records projects known not to produce ProjectData.
+/// </summary>
+public static class UnsupportedProjectDataMarker
+{
+	public const int SchemaVersion = 1;
+	public const int RulesVersion = 2;
+
+	private const string MarkerExtension = ".unsupported";
+	private static readonly Encoding Utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+	private static readonly string[] AncestorInputFileNames =
+	[
+		"Directory.Build.props",
+		"Directory.Build.targets",
+		"Directory.Packages.props",
+		"global.json",
+	];
+
+	public static string GetMarkerFilePath(string projectFilePath) => UserFolderCachePath.Compute(projectFilePath) + MarkerExtension;
+
+	public static bool TryReadValid(string projectFilePath, out UnsupportedProjectDataMarkerData marker)
+	{
+		marker = new UnsupportedProjectDataMarkerData();
+		string markerPath = GetMarkerFilePath(projectFilePath);
+		if (!File.Exists(markerPath))
+		{
+			return false;
+		}
+
+		try
+		{
+			Dictionary<string, string> values = ReadValues(markerPath);
+			if (!TryGetInt(values, "version", out int version) || version != SchemaVersion)
+			{
+				return false;
+			}
+
+			if (!TryGetInt(values, "rulesVersion", out int rulesVersion) || rulesVersion != RulesVersion)
+			{
+				return false;
+			}
+
+			if (!values.TryGetValue("project", out string? markerProjectPath) ||
+				!PathsEqual(markerProjectPath, Path.GetFullPath(projectFilePath)))
+			{
+				return false;
+			}
+
+			string projectFingerprint = ComputeProjectFingerprint(projectFilePath);
+			if (!values.TryGetValue("projectFingerprint", out string? markerProjectFingerprint) ||
+				!string.Equals(markerProjectFingerprint, projectFingerprint, StringComparison.Ordinal))
+			{
+				return false;
+			}
+
+			string inputsFingerprint = ComputeAncestorInputsFingerprint(projectFilePath);
+			if (!values.TryGetValue("inputsFingerprint", out string? markerInputsFingerprint) ||
+				!string.Equals(markerInputsFingerprint, inputsFingerprint, StringComparison.Ordinal))
+			{
+				return false;
+			}
+
+			marker = new UnsupportedProjectDataMarkerData
+			{
+				ProjectFilePath = markerProjectPath,
+				Reason = values.TryGetValue("reason", out string? reason) ? reason : string.Empty,
+				MarkerFilePath = markerPath,
+				ProjectFingerprint = projectFingerprint,
+				InputsFingerprint = inputsFingerprint,
+			};
+			return true;
+		}
+		catch (Exception ex) when (IsRecoverableMarkerReadException(ex))
+		{
+			System.Diagnostics.Trace.TraceWarning(
+				"[lscache] Failed to read unsupported-project marker for {0}: {1}",
+				projectFilePath,
+				ex.Message);
+			return false;
+		}
+	}
+
+	public static string Write(string projectFilePath, string reason)
+	{
+		if (string.IsNullOrWhiteSpace(reason))
+		{
+			reason = "Unsupported";
+		}
+
+		string markerPath = GetMarkerFilePath(projectFilePath);
+		string? directory = Path.GetDirectoryName(markerPath);
+		if (!string.IsNullOrEmpty(directory))
+		{
+			Directory.CreateDirectory(directory);
+		}
+
+		string content =
+			$"version={SchemaVersion}\n" +
+			$"rulesVersion={RulesVersion}\n" +
+			$"project={Path.GetFullPath(projectFilePath)}\n" +
+			$"projectFingerprint={ComputeProjectFingerprint(projectFilePath)}\n" +
+			$"inputsFingerprint={ComputeAncestorInputsFingerprint(projectFilePath)}\n" +
+			$"reason={reason}\n";
+
+		WriteAllTextAtomically(markerPath, content);
+		return markerPath;
+	}
+
+	public static void Delete(string projectFilePath)
+	{
+		string markerPath = GetMarkerFilePath(projectFilePath);
+		try
+		{
+			File.Delete(markerPath);
+		}
+		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+		{
+			System.Diagnostics.Trace.TraceWarning(
+				"[lscache] Failed to delete unsupported-project marker for {0}: {1}",
+				projectFilePath,
+				ex.Message);
+		}
+	}
+
+	public static string ComputeProjectFingerprint(string projectFilePath)
+		=> ComputeFileFingerprint(Path.GetFullPath(projectFilePath));
+
+	public static string ComputeAncestorInputsFingerprint(string projectFilePath)
+	{
+		string? directory = Path.GetDirectoryName(Path.GetFullPath(projectFilePath));
+		List<string> inputs = [];
+		while (!string.IsNullOrEmpty(directory))
+		{
+			foreach (string fileName in AncestorInputFileNames)
+			{
+				string candidate = Path.Combine(directory, fileName);
+				if (File.Exists(candidate))
+				{
+					inputs.Add(Path.GetFullPath(candidate));
+				}
+			}
+
+			DirectoryInfo? parent = Directory.GetParent(directory);
+			if (parent is null || string.Equals(parent.FullName, directory, StringComparison.Ordinal))
+			{
+				break;
+			}
+
+			directory = parent.FullName;
+		}
+
+		inputs.Sort(PathComparer);
+		StringBuilder builder = new();
+		foreach (string input in inputs)
+		{
+			builder.AppendLine(NormalizePathForFingerprint(input));
+			builder.AppendLine(ComputeFileFingerprint(input));
+		}
+
+		return ComputeStringFingerprint(builder.ToString());
+	}
+
+	private static Dictionary<string, string> ReadValues(string markerPath)
+	{
+		Dictionary<string, string> values = new(StringComparer.Ordinal);
+		foreach (string line in File.ReadAllLines(markerPath))
+		{
+			int separatorIndex = line.IndexOf('=');
+			if (separatorIndex <= 0)
+			{
+				continue;
+			}
+
+			values[line.Substring(0, separatorIndex)] = line.Substring(separatorIndex + 1);
+		}
+
+		return values;
+	}
+
+	private static bool TryGetInt(Dictionary<string, string> values, string key, out int value)
+	{
+		value = 0;
+		return values.TryGetValue(key, out string? text) && int.TryParse(text, out value);
+	}
+
+	private static string ComputeFileFingerprint(string path)
+	{
+		using FileStream stream = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+		using SHA256 sha256 = SHA256.Create();
+		byte[] hash = sha256.ComputeHash(stream);
+		return HexEncoder.ToLowerHex(hash);
+	}
+
+	private static string ComputeStringFingerprint(string value)
+	{
+		using SHA256 sha256 = SHA256.Create();
+		byte[] hash = sha256.ComputeHash(Utf8NoBom.GetBytes(value));
+		return HexEncoder.ToLowerHex(hash);
+	}
+
+	private static void WriteAllTextAtomically(string path, string content)
+	{
+		string tempPath = path + "." + Guid.NewGuid().ToString("N") + ".tmp";
+		try
+		{
+			File.WriteAllText(tempPath, content, Utf8NoBom);
+			if (File.Exists(path))
+			{
+				File.Replace(tempPath, path, destinationBackupFileName: null);
+			}
+			else
+			{
+				File.Move(tempPath, path);
+			}
+		}
+		finally
+		{
+			try
+			{
+				File.Delete(tempPath);
+			}
+			catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+			{
+			}
+		}
+	}
+
+	private static bool PathsEqual(string left, string right)
+		=> string.Equals(Path.GetFullPath(left), Path.GetFullPath(right), IsCaseSensitiveFileSystem() ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase);
+
+	private static bool IsRecoverableMarkerReadException(Exception ex)
+		=> ex is IOException or UnauthorizedAccessException or FormatException or ArgumentException or NotSupportedException or CryptographicException;
+
+	private static string NormalizePathForFingerprint(string path)
+	{
+		string normalized = Path.GetFullPath(path);
+		return IsCaseSensitiveFileSystem()
+			? normalized
+			: normalized.ToLowerInvariant();
+	}
+
+	private static int PathComparer(string left, string right)
+		=> string.Compare(left, right, IsCaseSensitiveFileSystem() ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase);
+
+	private static bool IsCaseSensitiveFileSystem() => RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+}
+
+public sealed class UnsupportedProjectDataMarkerData
+{
+	public string ProjectFilePath { get; set; } = string.Empty;
+	public string Reason { get; set; } = string.Empty;
+	public string MarkerFilePath { get; set; } = string.Empty;
+	public string ProjectFingerprint { get; set; } = string.Empty;
+	public string InputsFingerprint { get; set; } = string.Empty;
+}

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/UserFolderCachePath.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/UserFolderCachePath.cs
@@ -1,4 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/UserFolderCachePath.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/UserFolderCachePath.cs
@@ -1,0 +1,108 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Microsoft.NET.ProjectData;
+
+/// <summary>
+/// Computes the user-folder location for a project's <c>.lscache</c> file.
+///
+/// <para>This file is the single source of truth for the layout. The MSBuild
+/// task (writer/merger) and the runtime reader both call <see cref="Compute"/>
+/// so the path the writer produces is exactly the path the reader looks for.
+/// The Tasks project links this source file into its own assembly via a
+/// <c>&lt;Compile Include=...&gt;</c> reference rather than taking a project
+/// dependency on the cache assembly.</para>
+/// </summary>
+public static class UserFolderCachePath
+{
+	private const string CacheFileExtension = ".lscache";
+	private const string CacheBaseDirectoryEnvVar = "DOTNET_PROJECTDATA_CACHE_DIR";
+	private const string XdgCacheHomeEnvVar = "XDG_CACHE_HOME";
+	private const string CacheDirectoryName = "dotnet-projectdata";
+
+	/// <summary>
+	/// Returns the absolute path of the user-folder cache file for
+	/// <paramref name="projectFilePath"/>. Layout (matches the v1 reader):
+	/// <c>&lt;base&gt;/&lt;sha1[0..2]&gt;/&lt;sha1[2..]&gt;</c> where the SHA-1
+	/// hash is taken over the lower-cased project path on case-insensitive
+	/// filesystems (Windows / macOS) and the original casing on Linux.
+	/// </summary>
+	public static string Compute(string projectFilePath)
+	{
+		if (string.IsNullOrEmpty(projectFilePath))
+			throw new ArgumentException("Project file path must be non-empty.", nameof(projectFilePath));
+
+		bool caseSensitive = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+		string hashInput = caseSensitive ? projectFilePath : projectFilePath.ToLowerInvariant();
+
+		byte[] inputBytes = Encoding.UTF8.GetBytes(hashInput);
+		byte[] hashBytes;
+#if NET5_0_OR_GREATER
+		hashBytes = SHA1.HashData(inputBytes);
+#else
+		using (var sha1 = SHA1.Create())
+		{
+			hashBytes = sha1.ComputeHash(inputBytes);
+		}
+#endif
+
+		string hex = HexEncoder.ToLowerHex(hashBytes);
+		string baseDir = GetCacheBaseDirectory();
+		return Path.Combine(baseDir, hex.Substring(0, 2), hex.Substring(2));
+	}
+
+	/// <summary>
+	/// Returns the cache root directory used by <see cref="Compute"/>.
+	///
+	/// <para>Set <c>DOTNET_PROJECTDATA_CACHE_DIR</c> to override the cache root
+	/// exactly. Otherwise the cache is stored under the platform's user-local
+	/// cache directory.</para>
+	/// </summary>
+	public static string GetCacheBaseDirectory()
+	{
+		string? envOverride = Environment.GetEnvironmentVariable(CacheBaseDirectoryEnvVar);
+		if (!string.IsNullOrWhiteSpace(envOverride))
+		{
+			return envOverride!;
+		}
+
+		if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+		{
+			string localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+			if (!string.IsNullOrWhiteSpace(localAppData))
+			{
+				return Path.Combine(localAppData, "Microsoft", CacheDirectoryName);
+			}
+		}
+		else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+		{
+			string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+			if (!string.IsNullOrWhiteSpace(home))
+			{
+				return Path.Combine(home, "Library", "Caches", CacheDirectoryName);
+			}
+		}
+		else
+		{
+			string? xdgCacheHome = Environment.GetEnvironmentVariable(XdgCacheHomeEnvVar);
+			if (!string.IsNullOrWhiteSpace(xdgCacheHome))
+			{
+				return Path.Combine(xdgCacheHome!, CacheDirectoryName);
+			}
+
+			string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+			if (!string.IsNullOrWhiteSpace(home))
+			{
+				return Path.Combine(home, ".cache", CacheDirectoryName);
+			}
+		}
+
+		throw new InvalidOperationException($"Unable to determine the ProjectData cache root. Set {CacheBaseDirectoryEnvVar}.");
+	}
+
+	/// <summary>The cache file extension (currently <c>.lscache</c>).</summary>
+	public static string FileExtension => CacheFileExtension;
+}


### PR DESCRIPTION
This migrates the .lscache reading code into the Roslyn repository, and then pulls it into the C# extension's project system code so we can load state from the cache. The cache is only used to get things initialized faster -- even projects that load from the cache will still be queued for a regular load to ensure things are up to date, but hopefully that's a no-op in most cases.

Commit-at-a-time recommended; the first commit is the direct copying of the code from the current internal repo, and it's intentionally copied verbatim so the diff of what we've changed applies second. The expectation is we're going to have a small window of time where we're keeping the code in sync in both repositories, and making the diff explicit (and minimizing unrelated churn) is easiest for now. Eventually that repo will consume the NuGet packages produced by this repo, and then we'll migrate this code further to Roslyn code styles and patterns.

This PR will get a few follow-ups:

1. _Improved queue management._ What we should do is prioritize projects that could not be loaded from a cache over projects that are. This will require a replacement for AsyncBatchingWorkQueue, so we'll ignore that in this PR. It also means that right now our auto-load behavior for progress reporting will wait for all projects, when maybe we should only wait for the ones that didn't load from the cache.
2. _Telemetry reporting._ Right now we're not reporting telemetry for success rates or how much faster cache loads were. We should do that. The code's gotten pretty messy so I want to do a follow up to clean that up before trying to write that.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84790)