### PR TITLE
Enable preview versions for .NET SDK in PR Val

### DIFF
--- a/azure-pipelines-pr-validation.yml
+++ b/azure-pipelines-pr-validation.yml
@@ -233,6 +233,7 @@ extends:
           inputs:
             packageType: sdk
             useGlobalJson: true
+            includePreviewVersions: true
             workingDirectory: '$(Build.SourcesDirectory)'
 
         - task: MicroBuildSigningPlugin@4


### PR DESCRIPTION
This is needed for our move to .NET 11 Preview 6 SDK
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84802)