### PR TITLE
Discover only fallback types in the slow tag-helper path

### DIFF
--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/TagHelperDiscoverer.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/TagHelperDiscoverer.cs
@@ -168,4 +168,59 @@ internal sealed class TagHelperDiscoverer(ImmutableArray<TagHelperProducer> prod
             builder.Dispose();
         }
     }
+
+    /// <summary>
+    ///  Discovers tag helpers for a known set of types rather than walking an entire assembly.
+    /// </summary>
+    /// <remarks>
+    ///  Only type producers run here; assembly-level static tag helpers are intentionally skipped because a
+    ///  caller with a specific type set already owns discovery of the rest of the assembly. Producers examine
+    ///  each type independently, so restricting the input to a subset yields the same descriptors those types
+    ///  would produce during a full assembly walk. Results are not assembly-cached because the input is a
+    ///  per-request slice rather than a whole assembly.
+    /// </remarks>
+    public TagHelperCollection GetTagHelpers(ImmutableArray<INamedTypeSymbol> types, CancellationToken cancellationToken = default)
+    {
+        if (producers.IsDefaultOrEmpty || types.IsDefaultOrEmpty)
+        {
+            return TagHelperCollection.Empty;
+        }
+
+        var builder = new TagHelperCollection.RefBuilder();
+        try
+        {
+            using var _ = ArrayPool<TagHelperProducer>.Shared.GetPooledArraySpan(
+                minimumLength: producers.Length, clearOnReturn: true, out var typeProducers);
+
+            var index = 0;
+            foreach (var producer in producers)
+            {
+                if (producer.SupportsTypes)
+                {
+                    typeProducers[index++] = producer;
+                }
+            }
+
+            typeProducers = typeProducers[..index];
+
+            foreach (var type in types)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                foreach (var producer in typeProducers)
+                {
+                    if (producer.IsCandidateType(type))
+                    {
+                        producer.AddTagHelpersForType(type, ref builder, cancellationToken);
+                    }
+                }
+            }
+
+            return builder.ToCollection();
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
 }

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/RazorSourceGenerator.Helpers.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/RazorSourceGenerator.Helpers.cs
@@ -2,12 +2,17 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Text;
+using System.Threading;
 using Microsoft.AspNetCore.Mvc.Razor.Extensions;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Compiler.CSharp;
 
@@ -130,6 +135,38 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
             });
 
             return tagHelperFeature;
+        }
+
+        /// <summary>
+        ///  Resolves the fallback component type symbols declared by the discovery-only decl trees, so the
+        ///  slow discovery path can target just those types instead of walking the whole augmented assembly.
+        /// </summary>
+        private static ImmutableArray<INamedTypeSymbol> ResolveFallbackTypes(
+            Compilation compilation,
+            ImmutableArray<SyntaxTree> trees,
+            CancellationToken cancellationToken)
+        {
+            using var builder = new PooledArrayBuilder<INamedTypeSymbol>();
+            var seen = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+
+            foreach (var tree in trees)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var semanticModel = compilation.GetSemanticModel(tree);
+                var root = tree.GetRoot(cancellationToken);
+
+                foreach (var typeDeclaration in root.DescendantNodes().OfType<TypeDeclarationSyntax>())
+                {
+                    if (semanticModel.GetDeclaredSymbol(typeDeclaration, cancellationToken) is INamedTypeSymbol typeSymbol &&
+                        seen.Add(typeSymbol))
+                    {
+                        builder.Add(typeSymbol);
+                    }
+                }
+            }
+
+            return builder.ToImmutable();
         }
 
         private static SourceGeneratorProjectEngine GetGenerationProjectEngine(

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/RazorSourceGenerator.Helpers.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/RazorSourceGenerator.Helpers.cs
@@ -4,15 +4,12 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 using System.Text;
 using System.Threading;
 using Microsoft.AspNetCore.Mvc.Razor.Extensions;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Compiler.CSharp;
 
@@ -138,31 +135,37 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
         }
 
         /// <summary>
-        ///  Resolves the fallback component type symbols declared by the discovery-only decl trees, so the
-        ///  slow discovery path can target just those types instead of walking the whole augmented assembly.
+        ///  Resolves the fallback component type symbols so the slow discovery path can target just those
+        ///  types instead of walking the whole augmented assembly. Uses the compilation's declaration table
+        ///  (no semantic models): a fallback type name is namespace-qualified, so the fast predicate keys off
+        ///  its final segment and over-selects; the caller's descriptor-name filter trims any collisions.
         /// </summary>
         private static ImmutableArray<INamedTypeSymbol> ResolveFallbackTypes(
             Compilation compilation,
-            ImmutableArray<SyntaxTree> trees,
+            ImmutableHashSet<string> fallbackTypeNames,
             CancellationToken cancellationToken)
         {
-            using var builder = new PooledArrayBuilder<INamedTypeSymbol>();
-            var seen = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+            if (fallbackTypeNames.IsEmpty)
+            {
+                return [];
+            }
 
-            foreach (var tree in trees)
+            var shortNames = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var name in fallbackTypeNames)
+            {
+                var lastDot = name.LastIndexOf('.');
+                shortNames.Add(lastDot >= 0 ? name.Substring(lastDot + 1) : name);
+            }
+
+            using var builder = new PooledArrayBuilder<INamedTypeSymbol>();
+
+            foreach (var symbol in compilation.GetSymbolsWithName(shortNames.Contains, SymbolFilter.Type, cancellationToken))
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                var semanticModel = compilation.GetSemanticModel(tree);
-                var root = tree.GetRoot(cancellationToken);
-
-                foreach (var typeDeclaration in root.DescendantNodes().OfType<TypeDeclarationSyntax>())
+                if (symbol is INamedTypeSymbol typeSymbol)
                 {
-                    if (semanticModel.GetDeclaredSymbol(typeDeclaration, cancellationToken) is INamedTypeSymbol typeSymbol &&
-                        seen.Add(typeSymbol))
-                    {
-                        builder.Add(typeSymbol);
-                    }
+                    builder.Add(typeSymbol);
                 }
             }
 

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/RazorSourceGenerator.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/RazorSourceGenerator.cs
@@ -215,14 +215,29 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
                     }
 
                     var augmented = compilation.AddSyntaxTrees(fallbackTrees);
-                    var tagHelperFeature = GetStaticTagHelperFeature(augmented);
-                    var all = tagHelperFeature.GetTagHelpers(augmented.Assembly, cancellationToken);
-                    if (all.IsEmpty)
+
+                    // Discover only the fallback components' own types rather than re-walking the whole
+                    // augmented assembly. fastDiscovery already covered every splittable component, so the
+                    // full walk here would rediscover all of them just to keep the few fallback types. The
+                    // fallback types are exactly the ones declared by the discovery-only decl trees we just
+                    // added, and tag-helper producers examine each type independently, so discovering just
+                    // those yields the same descriptors the full walk would for them.
+                    var fallbackTypes = ResolveFallbackTypes(augmented, fallbackTrees, cancellationToken);
+                    if (fallbackTypes.IsDefaultOrEmpty)
                     {
                         return TagHelperCollection.Empty;
                     }
 
-                    return all.Where(fallbackTypeNames, static (descriptor, names) => names.Contains(StripGenericArity(descriptor.TypeName)));
+                    var tagHelperFeature = GetStaticTagHelperFeature(augmented);
+                    var discovered = tagHelperFeature.GetTagHelpers(fallbackTypes, cancellationToken);
+                    if (discovered.IsEmpty)
+                    {
+                        return TagHelperCollection.Empty;
+                    }
+
+                    // A resolved type can be a partial that also produces a non-fallback descriptor name;
+                    // keep only the fallback components' types, matching the ownership split with fastDiscovery.
+                    return discovered.Where(fallbackTypeNames, static (descriptor, names) => names.Contains(StripGenericArity(descriptor.TypeName)));
                 })
                 .WithLambdaComparer(static (a, b) => a!.SequenceEqual(b!))
                 .WithTrackingName("SlowTagHelpers");

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/RazorSourceGenerator.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/RazorSourceGenerator.cs
@@ -222,7 +222,7 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
                     // fallback types are exactly the ones declared by the discovery-only decl trees we just
                     // added, and tag-helper producers examine each type independently, so discovering just
                     // those yields the same descriptors the full walk would for them.
-                    var fallbackTypes = ResolveFallbackTypes(augmented, fallbackTrees, cancellationToken);
+                    var fallbackTypes = ResolveFallbackTypes(augmented, fallbackTypeNames, cancellationToken);
                     if (fallbackTypes.IsDefaultOrEmpty)
                     {
                         return TagHelperCollection.Empty;

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/StaticCompilationTagHelperFeature.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/StaticCompilationTagHelperFeature.cs
@@ -31,6 +31,22 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
             return _discoverer.GetTagHelpers(assembly, cancellationToken);
         }
 
+        public TagHelperCollection GetTagHelpers(ImmutableArray<INamedTypeSymbol> types, CancellationToken cancellationToken)
+        {
+            if (_discoveryService is null)
+            {
+                return [];
+            }
+
+            if (_discoverer is null &&
+                !_discoveryService.TryGetDiscoverer(compilation, out _discoverer))
+            {
+                return [];
+            }
+
+            return _discoverer.GetTagHelpers(types, cancellationToken);
+        }
+
         TagHelperCollection ITagHelperFeature.GetTagHelpers(CancellationToken cancellationToken)
         {
             if (_discoveryService is null)


### PR DESCRIPTION
Draft for RPS validation. Addresses the `CLR_BytesAllocated` regression seen on the Roslyn->VS insertion (`RazorEditingTests.CompletionInCohostingForComponents`, MudBlazor).

## Root cause
The decl/impl split's slow tag-helper discovery re-walks the whole compilation whenever any component falls back (an `@inherits`/`@implements`/`@typeparam` header or unroutable body markup). It kept only the fallback types but rebuilt descriptors for every already-discovered splittable component. On large component libraries like MudBlazor (hundreds of components, most falling back), that is a redundant near-full second descriptor build -> the observed cold-classification allocation regression.

## Change
`slowTagHelpers` now resolves just the fallback component type symbols (from the discovery-only decl trees) and discovers only those, via a new per-type `TagHelperDiscoverer.GetTagHelpers(ImmutableArray<INamedTypeSymbol>)`. Correct because `ComponentTagHelperProducer.AddTagHelpersForType` is per-type/independent, so the descriptors are identical to the full walk's for those types; the existing `fallbackTypeNames` ownership filter is retained as a safety net.

## Validation
- `Microsoft.CodeAnalysis.Razor.Compiler` builds clean (netstandard2.0 + net10.0), 0 warnings.
- `Microsoft.NET.Sdk.Razor.SourceGenerators.UnitTests`: 218 passed, 1 skipped, 0 failed.
- `Microsoft.CodeAnalysis.Razor.UnitTests` (TagHelper/Component/Discovery): 544 passed.

Opening as **draft** to run through RPS and quantify the allocation win before review.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84808)