### PR TITLE
Restore public GetCSharpDocument() and GeneratedCode for runtime compilation

### DIFF
--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorCSharpDocument.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorCSharpDocument.cs
@@ -29,6 +29,12 @@ public sealed class RazorCSharpDocument
     /// </summary>
     public bool IsStubDocument { get; }
 
+    /// <summary>
+    /// The generated C# code as a string. Prefer <see cref="Text"/>, which avoids materializing the
+    /// whole document as a single string.
+    /// </summary>
+    public string GeneratedCode => Text.ToString();
+
     public RazorCSharpDocument(
         RazorCodeDocument codeDocument,
         SourceText text,

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorCodeDocumentExtensions.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorCodeDocumentExtensions.cs
@@ -16,6 +16,15 @@ namespace Microsoft.AspNetCore.Razor.Language;
 
 public static class RazorCodeDocumentExtensions
 {
+    /// <summary>
+    /// Returns the implementation C# document for <paramref name="codeDocument"/> -- the generated code
+    /// containing the render method and, for a non-component document, the complete class. A component
+    /// that split has its declaration surface in a separate declaration document; the implementation
+    /// document is the code the source generator emits as the document's primary output.
+    /// </summary>
+    public static RazorCSharpDocument GetCSharpDocument(this RazorCodeDocument codeDocument)
+        => codeDocument.GetRequiredCSharpDocument(declarationDocument: false);
+
     public static bool TryComputeClassName(this RazorCodeDocument codeDocument, [NotNullWhen(true)] out string? className)
     {
         var filePath = codeDocument.Source.RelativePath ?? codeDocument.Source.FilePath;


### PR DESCRIPTION
## Problem
The Razor decl/impl split (flowed into the VMR via dotnet/dotnet#8179) removed two **public** members that ASP.NET Core's runtime Razor view compiler (`Mvc.Razor.RuntimeCompilation.RuntimeViewCompiler`) depends on, breaking its build in the product:

- `RazorCodeDocumentExtensions.GetCSharpDocument(this RazorCodeDocument)` → replaced by the internal, declaration-aware `RazorCodeDocument.GetCSharpDocument(bool declarationDocument)`.
- `RazorCSharpDocument.GeneratedCode` (`string`) → replaced by `public SourceText Text`.

`RuntimeViewCompiler.CompileAndEmit` calls `codeDocument.GetCSharpDocument().GeneratedCode`. Both members are still listed in the compiler's public API baselines, so this is an unshipped-public-API break rather than an internal refactor.

## Fix
Re-expose both as thin shims over the new API:

- `GetCSharpDocument()` returns the implementation document (`GetRequiredCSharpDocument(declarationDocument: false)`).
- `GeneratedCode` returns `Text.ToString()`.

`SetCSharpDocument` (also in the old baseline) is intentionally **not** restored — it was a mutating `void` on what is now an immutable type, and nothing consumes it; it should be dropped from the baseline instead.

## Correctness for the runtime path
Runtime compilation only handles MVC `.cshtml` (Legacy) views; the markup split phase early-returns for non-components, so no declaration half is produced and the implementation document is the complete, standalone-compilable class. Blazor components are build-time only (the source generator emits decl + impl as two partials into one compilation), so nothing compiles a component through this public runtime accessor. A probe over the default engine confirms `.cshtml` → complete non-partial class, 0 diagnostics; `.razor` → the implementation partial half.

## Validation
- `Microsoft.CodeAnalysis.Razor.Compiler` builds clean (netstandard2.0 + net10.0), 0 warnings.
- `Microsoft.AspNetCore.Mvc.Razor.Extensions` `CodeGenerationIntegrationTest`: 48/48 (these compile `.cshtml` generated code to a real assembly — the runtime-compilation path).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84813)