### PR TITLE
Keep a fallback component's derived tag helpers during discovery

### DIFF
--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/RazorSourceGenerator.Helpers.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/RazorSourceGenerator.Helpers.cs
@@ -38,6 +38,28 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
         }
 
         /// <summary>
+        /// Returns the name of the component type a descriptor belongs to. A component descriptor's owning
+        /// type is itself, but descriptors derived from a component -- child content and bind, for example --
+        /// carry the owning component's namespace and identifier while their own <see cref="TagHelperDescriptor.TypeName"/>
+        /// is suffixed (e.g. <c>Ns.Card.Header</c> for the <c>Header</c> child content of <c>Ns.Card</c>).
+        /// Reconstructing the owning name from the namespace and identifier lets ownership filtering keep or
+        /// exclude a fallback component and all its derived descriptors together, rather than only the
+        /// component descriptor whose <see cref="TagHelperDescriptor.TypeName"/> matches exactly.
+        /// </summary>
+        internal static string GetOwningTypeName(TagHelperDescriptor descriptor)
+        {
+            var identifier = descriptor.TypeNameIdentifier;
+            if (identifier is null)
+            {
+                return descriptor.TypeName;
+            }
+
+            return descriptor.TypeNamespace is { Length: > 0 } typeNamespace
+                ? typeNamespace + "." + identifier
+                : identifier;
+        }
+
+        /// <summary>
         /// Returns the hint name for the decl half of a Razor component generated source given
         /// the impl half's hint name. The decl file substitutes <c>.decl.g.cs</c> for the
         /// trailing <c>.g.cs</c> -- e.g. <c>Component1_razor.g.cs</c> →

--- a/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/RazorSourceGenerator.cs
+++ b/src/Razor/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/RazorSourceGenerator.cs
@@ -222,7 +222,7 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
                         return TagHelperCollection.Empty;
                     }
 
-                    return all.Where(fallbackTypeNames, static (descriptor, names) => names.Contains(StripGenericArity(descriptor.TypeName)));
+                    return all.Where(fallbackTypeNames, static (descriptor, names) => names.Contains(StripGenericArity(GetOwningTypeName(descriptor))));
                 })
                 .WithLambdaComparer(static (a, b) => a!.SequenceEqual(b!))
                 .WithTrackingName("SlowTagHelpers");
@@ -239,7 +239,7 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
                     var ((fast, slow), fallbackTypeNames) = pair;
                     var fastOwned = fallbackTypeNames.IsEmpty
                         ? fast
-                        : fast.Where(fallbackTypeNames, static (descriptor, names) => !names.Contains(StripGenericArity(descriptor.TypeName)));
+                        : fast.Where(fallbackTypeNames, static (descriptor, names) => !names.Contains(StripGenericArity(GetOwningTypeName(descriptor))));
                     return TagHelperCollection.Merge(fastOwned, slow);
                 })
                 .WithTrackingName("TagHelpersFromCompilation");

--- a/src/Razor/src/Compiler/test/Microsoft.NET.Sdk.Razor.SourceGenerators.UnitTests/RazorSourceGeneratorComponentTests.cs
+++ b/src/Razor/src/Compiler/test/Microsoft.NET.Sdk.Razor.SourceGenerators.UnitTests/RazorSourceGeneratorComponentTests.cs
@@ -1329,6 +1329,52 @@ public sealed class RazorSourceGeneratorComponentTests : RazorSourceGeneratorTes
         Assert.Equal(2, result.GeneratedSources.Length);
     }
 
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/84817")]
+    public async Task Component_FallbackComponent_ChildContentParameters()
+    {
+        // A fallback component (unsplittable via @inherits) exposes RenderFragment child-content
+        // parameters. A consumer referencing them as child elements must resolve them, i.e. no
+        // RZ10012 "unexpected name" for Header/ChildContent.
+        var project = CreateTestProject(new()
+        {
+            ["Shared/Card.razor"] = """
+                @inherits EmptyBase
+
+                <header>@Header</header>
+                <main>@ChildContent</main>
+
+                @code {
+                    [Parameter]
+                    public RenderFragment? Header { get; set; }
+
+                    [Parameter]
+                    public RenderFragment? ChildContent { get; set; }
+                }
+                """,
+            ["Shared/Consumer.razor"] = """
+                <Card>
+                    <Header>Expected header</Header>
+                    <ChildContent>Expected content</ChildContent>
+                </Card>
+                """,
+        }, new()
+        {
+            ["EmptyBase.cs"] = """
+                using Microsoft.AspNetCore.Components;
+
+                public abstract class EmptyBase : ComponentBase;
+                """,
+        });
+        var compilation = await project.GetCompilationAsync();
+        var driver = await GetDriverAsync(project);
+
+        // Act
+        var result = RunGenerator(compilation!, ref driver);
+
+        // Assert -- no RZ10012 for the fallback component's child-content parameters
+        result.Diagnostics.Verify();
+    }
+
     [Fact]
     public async Task Component_WithImplicitContext_NestedInWrapper()
     {


### PR DESCRIPTION
## Summary

Fixes #84817 -- a Sonic (split Razor declarations) regression where a fallback component's child content parameters were lost, causing spurious `RZ10012` warnings (e.g. `unexpected name 'Header'` / `'ChildContent'`) at every consumer.

## Root cause

Discovery splits into a fast path (components with a split declaration) and a slow path (fallback components with no split -- `@inherits`/`@implements`/`@typeparam` or unroutable body markup). The slow path *owns* a fallback component's tag helpers and filters the discovered set down to the fallback type names, and fast discovery excludes those same names to avoid duplicates.

Both filters matched each descriptor by its own `TypeName`. That is correct for the component descriptor itself, but a component's **derived** descriptors -- notably child content descriptors produced by `ComponentTagHelperProducer` -- carry a `TypeName` of the component suffixed with the property name (`Card.Header`, `Card.ChildContent`). Those names are not in the fallback type set, so the child content descriptors failed the filter and were silently dropped. The consumer then saw `Card` without its child content parameters and warned `RZ10012` on `<Header>` / `<ChildContent>`.

## Fix

Filter on the *owning component's* name, reconstructed from the descriptor's `TypeNamespace` + `TypeNameIdentifier` (both point at the owning component for a component descriptor **and** its derived descriptors). A new `GetOwningTypeName` helper does the reconstruction and both ownership predicates use it, so a fallback component and its derived descriptors are kept -- or excluded from fast discovery -- as a unit.

## Testing

- New `Component_FallbackComponent_ChildContentParameters` reproduces the regression (fallback `Card` with `Header`/`ChildContent` `RenderFragment` params, consumed with child-content elements) and asserts no `RZ10012`.
- Full source-generator suite green (219 passed / 1 skipped).
- Compiler discovery/component/tag-helper tests green (544 passed).


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84818)