### PR TITLE
Remove unnecessary toolset compiler

### DIFF
--- a/eng/targets/CachingCompiler.props
+++ b/eng/targets/CachingCompiler.props
@@ -8,10 +8,4 @@
     <PathMap Condition="'$(PathMap)' != ''">$(RepoRoot)=/_/,$(PathMap)</PathMap>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" PrivateAssets="all" VersionOverride="5.8.0-1.26228.20">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Toolset compiler should not be necessary anymore for the caching compiler features (since we are on .net 11 preview now).

Also fixes these warnings that appear in roslyn-CI (and locally if you have caching compiler enabled):

```
warning CS9057: Analyzer assembly 'D:\a\_work\1\s\.dotnet\sdk\11.0.100-preview.6.26359.118\Sdks\Microsoft.NET.Sdk\codestyle\cs\Microsoft.CodeAnalysis.CodeStyle.dll' cannot be used because it references version '5.9.0.0' of the compiler, which is newer than the currently running version '5.8.0.0'.
```

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84826)