### PR TITLE
Fix/84847 source generated rename conflict

### DIFF
--- a/src/EditorFeatures/Test2/Rename/CSharp/SourceGeneratorTests.vb
+++ b/src/EditorFeatures/Test2/Rename/CSharp/SourceGeneratorTests.vb
@@ -95,6 +95,37 @@ public class [|$$RegularClass|]
         End Function
 
         <Theory, CombinatorialData>
+        <WorkItem("https://github.com/dotnet/roslyn/issues/84847")>
+        Public Sub RenameWithUnrelatedGeneratedDocumentContainingReplacementText(host As RenameTestHost)
+            ' Regression test: a source-generated document that is unrelated to the rename can still be pulled into
+            ' the candidate set of documents to check because it happens to contain text matching the replacement
+            ' name. If that document ends up not actually needing any rename edits, it is dropped from the set of
+            ' documents being annotated/renamed, but it remains part of the full per-project document set that is
+            ' consulted when looking for declaration conflicts. That path used to call the DocumentId overload of
+            ' GetRequiredDocument, which throws for source-generated DocumentIds instead of returning the document -
+            ' this crashed with "GetRequiredDocument was given a source-generated DocumentId".
+            Using result = RenameEngineResult.Create(_outputHelper,
+                    <Workspace>
+                        <Project Language="C#" AssemblyName="ClassLibrary1" CommonReferences="true">
+                            <Document>
+public class TypeData
+{
+    public int [|$$Type|];
+}
+                            </Document>
+                            <DocumentFromSourceGenerator>
+public class Unrelated
+{
+    public int Value;
+}
+                            </DocumentFromSourceGenerator>
+                        </Project>
+                    </Workspace>, host:=host, renameTo:="Value")
+
+            End Using
+        End Sub
+
+        <Theory, CombinatorialData>
         <WorkItem("https://github.com/dotnet/roslyn/issues/51537")>
         Public Sub RenameWithCascadeIntoGeneratedFile(host As RenameTestHost)
             Using result = RenameEngineResult.Create(_outputHelper,

--- a/src/EditorFeatures/Test2/Rename/CSharp/SourceGeneratorTests.vb
+++ b/src/EditorFeatures/Test2/Rename/CSharp/SourceGeneratorTests.vb
@@ -97,13 +97,6 @@ public class [|$$RegularClass|]
         <Theory, CombinatorialData>
         <WorkItem("https://github.com/dotnet/roslyn/issues/84847")>
         Public Sub RenameWithUnrelatedGeneratedDocumentContainingReplacementText(host As RenameTestHost)
-            ' Regression test: a source-generated document that is unrelated to the rename can still be pulled into
-            ' the candidate set of documents to check because it happens to contain text matching the replacement
-            ' name. If that document ends up not actually needing any rename edits, it is dropped from the set of
-            ' documents being annotated/renamed, but it remains part of the full per-project document set that is
-            ' consulted when looking for declaration conflicts. That path used to call the DocumentId overload of
-            ' GetRequiredDocument, which throws for source-generated DocumentIds instead of returning the document -
-            ' this crashed with "GetRequiredDocument was given a source-generated DocumentId".
             Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" AssemblyName="ClassLibrary1" CommonReferences="true">

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.Session.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.Session.cs
@@ -324,7 +324,11 @@ internal static partial class ConflictResolver
                 {
                     foreach (var documentId in documentIdsForConflictResolution)
                     {
-                        var newDocument = conflictResolution.CurrentSolution.GetRequiredDocument(documentId);
+                        // documentIdsForConflictResolution may contain ids for source-generated documents (for
+                        // example, a rename location that lives in Razor-generated code), so we must use the
+                        // overload that knows how to look those up instead of throwing on them.
+                        var newDocument = await conflictResolution.CurrentSolution.GetRequiredDocumentAsync(
+                            documentId, includeSourceGenerated: true, _cancellationToken).ConfigureAwait(false);
                         var syntaxRoot = await newDocument.GetRequiredSyntaxRootAsync(_cancellationToken).ConfigureAwait(false);
 
                         var nodesOrTokensWithConflictCheckAnnotations = GetNodesOrTokensToCheckForConflicts(syntaxRoot);
@@ -442,9 +446,14 @@ internal static partial class ConflictResolver
                     // the annotated spans in these documents to reverseMappedLocations.
                     foreach (var unprocessedDocumentIdWithPotentialDeclarationConflicts in allDocumentIdsInProject.Where(d => !documentIdsForConflictResolution.Contains(d)))
                     {
-                        var newDocument = conflictResolution.CurrentSolution.GetRequiredDocument(unprocessedDocumentIdWithPotentialDeclarationConflicts);
+                        // allDocumentIdsInProject may contain ids for source-generated documents (for example, a
+                        // rename location that lives in Razor-generated code), so we must use the overload that
+                        // knows how to look those up instead of throwing on them.
+                        var newDocument = await conflictResolution.CurrentSolution.GetRequiredDocumentAsync(
+                            unprocessedDocumentIdWithPotentialDeclarationConflicts, includeSourceGenerated: true, _cancellationToken).ConfigureAwait(false);
                         var syntaxRoot = await newDocument.GetRequiredSyntaxRootAsync(_cancellationToken).ConfigureAwait(false);
-                        var baseDocument = conflictResolution.OldSolution.GetRequiredDocument(unprocessedDocumentIdWithPotentialDeclarationConflicts);
+                        var baseDocument = await conflictResolution.OldSolution.GetRequiredDocumentAsync(
+                            unprocessedDocumentIdWithPotentialDeclarationConflicts, includeSourceGenerated: true, _cancellationToken).ConfigureAwait(false);
                         var baseSyntaxTree = await baseDocument.GetRequiredSyntaxTreeAsync(_cancellationToken).ConfigureAwait(false);
 
                         var nodesOrTokensWithConflictCheckAnnotations = GetNodesOrTokensToCheckForConflicts(syntaxRoot);

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.Session.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.Session.cs
@@ -324,9 +324,6 @@ internal static partial class ConflictResolver
                 {
                     foreach (var documentId in documentIdsForConflictResolution)
                     {
-                        // documentIdsForConflictResolution may contain ids for source-generated documents (for
-                        // example, a rename location that lives in Razor-generated code), so we must use the
-                        // overload that knows how to look those up instead of throwing on them.
                         var newDocument = await conflictResolution.CurrentSolution.GetRequiredDocumentAsync(
                             documentId, includeSourceGenerated: true, _cancellationToken).ConfigureAwait(false);
                         var syntaxRoot = await newDocument.GetRequiredSyntaxRootAsync(_cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
Fixes #84847
Claude generated fixes for #84847 :

- include source generated files (razor) in rename operations, 
- use GetRequiredDocumentAsync instead of GetRequiredDocument

- a test was also added, it contains a comment quite large, but LLMs are wordy...
... and feels a little incomplete since it only tests that that rename didn't modify 
... and shouldn't the field in the Unrelated class have the original name (i.e. Type) to test that the rename operation didn't mistakenly change it?

PRing untested in coordination with @CyrusNajmabadi after conversation in discord.

just creating the PR for now, it's easier to talk about stuff that is there.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84849)