### PR TITLE
Ensure we report test results with a name the helix monitor expects

### DIFF
--- a/src/Tools/RunTests/HelixTestRunner.cs
+++ b/src/Tools/RunTests/HelixTestRunner.cs
@@ -747,7 +747,7 @@ internal sealed partial class HelixTestRunner
         builder.AppendLine($@"/Platform:{platform}");
 
         // The xml file must end in test-results.xml for the Azure Pipelines reporter to pick it up.
-        builder.AppendLine($@"/Logger:xunit;LogFilePath=work-item-test-results.xml");
+        builder.AppendLine($@"/Logger:xunit;LogFilePath=test-results.xml");
 
         // Also add a console logger so that the helix log reports results as we go.
         builder.AppendLine($@"/Logger:console;verbosity=detailed");


### PR DESCRIPTION
the old helix test reporter allowed test result files with an expected suffix - https://github.com/dotnet/arcade/blob/4fa23debba6c3cd194ee45d56bb516596f92f884/src/Microsoft.DotNet.Helix/Sdk/tools/azure-pipelines/reporter/test_results_reader/__init__.py#L44-L59

the new helix monitor version only allows exact names - https://github.com/dotnet/arcade/blob/4fa23debba6c3cd194ee45d56bb516596f92f884/src/Microsoft.DotNet.Helix/Sdk/tools/Microsoft.DotNet.Helix.Sdk.MonoQueue.targets#L30-L48