### PR TITLE
Prefetch only metadata on assembly metadata references.

### DIFF
--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -207,7 +207,8 @@ namespace Microsoft.CodeAnalysis
             return (path, properties) =>
             {
                 var peStream = FileSystem.OpenFileWithNormalizedException(path, FileMode.Open, FileAccess.Read, FileShare.Read);
-                return MetadataReference.CreateFromFile(peStream, path, PEStreamOptions.PrefetchEntireImage, properties, documentation: null);
+                var options = properties.Kind == MetadataImageKind.Assembly ? PEStreamOptions.PrefetchMetadata : PEStreamOptions.PrefetchEntireImage;
+                return MetadataReference.CreateFromFile(peStream, path, options, properties, documentation: null);
             };
         }
 

--- a/src/Workspaces/Core/Portable/Workspace/Host/Metadata/MetadataServiceFactory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Metadata/MetadataServiceFactory.cs
@@ -1,12 +1,14 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Immutable;
 using System.Composition;
 using System.IO;
 using System.Reflection.PortableExecutable;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Host;
@@ -40,6 +42,39 @@ internal sealed class MetadataServiceFactory() : IWorkspaceServiceFactory
             => _metadataReferenceCacheService.GetReference(
                 resolvedPath, properties, _createReference);
 
+        private static ModuleMetadata CreateModuleMetadata(string path, bool prefetchEntireImage)
+        {
+            var fileStream = FileUtilities.OpenRead(path);
+
+            var options = PEStreamOptions.PrefetchMetadata;
+            if (prefetchEntireImage)
+            {
+                options |= PEStreamOptions.PrefetchEntireImage;
+            }
+
+            return ModuleMetadata.CreateFromStream(fileStream, options);
+        }
+
+        private static ImmutableArray<ModuleMetadata> GetAllModules(ModuleMetadata manifestModule, string assemblyDir)
+        {
+            var moduleNames = manifestModule.GetModuleNames();
+            if (moduleNames is [])
+            {
+                return [manifestModule];
+            }
+
+            var moduleBuilder = ArrayBuilder<ModuleMetadata>.GetInstance(moduleNames.Length + 1);
+            moduleBuilder.Add(manifestModule);
+
+            foreach (var moduleName in moduleNames)
+            {
+                var module = CreateModuleMetadata(PathUtilities.CombineAbsoluteAndRelativePaths(assemblyDir, moduleName)!, prefetchEntireImage: false);
+                moduleBuilder.Add(module);
+            }
+
+            return moduleBuilder.ToImmutableAndFree();
+        }
+
         private PortableExecutableReference CreateReference(
             string path, MetadataReferenceProperties properties)
         {
@@ -47,28 +82,28 @@ internal sealed class MetadataServiceFactory() : IWorkspaceServiceFactory
 
             try
             {
-                var peStream = FileUtilities.OpenRead(path);
-                // Assemblies only need prefetching metadata.
-                var options = properties.Kind == MetadataImageKind.Assembly ? PEStreamOptions.PrefetchMetadata : PEStreamOptions.PrefetchEntireImage;
-                var module = ModuleMetadata.CreateFromStream(peStream, options);
-
                 if (properties.Kind == MetadataImageKind.Module)
                 {
+                    var module = CreateModuleMetadata(path, prefetchEntireImage: true);
                     return module.GetReference(documentationProvider, filePath: path, display: null).WithProperties(properties);
                 }
 
-                // any additional modules constituting the assembly will be read lazily:
-                var assembly = AssemblyMetadata.Create(module);
+                var primaryModule = CreateModuleMetadata(path, prefetchEntireImage: false);
+
+                // Get all the modules, and load them. Create an assembly metadata.
+                var allModules = GetAllModules(primaryModule, PathUtilities.GetDirectoryName(path));
+
+                var assembly = AssemblyMetadata.Create(allModules);
                 return assembly.GetReference(documentationProvider, filePath: path, display: null).WithProperties(properties);
             }
-            catch (IOException e)
+            catch (Exception e) when (e is IOException or BadImageFormatException)
             {
                 // Store failed references in the cache so that the behavior stays consistent once we observe the failure.
                 return new ThrowingExecutableReference(path, properties, documentationProvider, e);
             }
         }
 
-        private sealed class ThrowingExecutableReference(string resolvedPath, MetadataReferenceProperties properties, DocumentationProvider documentationProvider, IOException exception)
+        private sealed class ThrowingExecutableReference(string resolvedPath, MetadataReferenceProperties properties, DocumentationProvider documentationProvider, Exception exception)
             : PortableExecutableReference(properties, resolvedPath)
         {
             protected override DocumentationProvider CreateDocumentationProvider()

--- a/src/Workspaces/Core/Portable/Workspace/Host/Metadata/MetadataServiceFactory.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Metadata/MetadataServiceFactory.cs
@@ -1,11 +1,13 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;
 using System.Composition;
 using System.IO;
+using System.Reflection.PortableExecutable;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Host;
 
@@ -45,7 +47,19 @@ internal sealed class MetadataServiceFactory() : IWorkspaceServiceFactory
 
             try
             {
-                return MetadataReference.CreateFromFile(path, properties, documentationProvider);
+                var peStream = FileUtilities.OpenRead(path);
+                // Assemblies only need prefetching metadata.
+                var options = properties.Kind == MetadataImageKind.Assembly ? PEStreamOptions.PrefetchMetadata : PEStreamOptions.PrefetchEntireImage;
+                var module = ModuleMetadata.CreateFromStream(peStream, options);
+
+                if (properties.Kind == MetadataImageKind.Module)
+                {
+                    return module.GetReference(documentationProvider, filePath: path, display: null).WithProperties(properties);
+                }
+
+                // any additional modules constituting the assembly will be read lazily:
+                var assembly = AssemblyMetadata.Create(module);
+                return assembly.GetReference(documentationProvider, filePath: path, display: null).WithProperties(properties);
             }
             catch (IOException e)
             {

--- a/src/Workspaces/CoreTest/SolutionTests/MetadataServiceTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/MetadataServiceTests.cs
@@ -117,9 +117,7 @@ public sealed class MetadataServiceTests : TestBase
         var invalidModuleName = Temp.CreateFile().WriteAllBytes(TestResources.MetadataTests.Invalid.InvalidModuleName);
 
         var reference = metadataService.GetReference(invalidModuleName.Path, MetadataReferenceProperties.Assembly);
-        var metadata = Assert.IsType<AssemblyMetadata>(reference.GetMetadata());
-
-        Assert.Throws<BadImageFormatException>(() => metadata.GetModules());
+        Assert.Throws<BadImageFormatException>(() => reference.GetMetadata());
     }
 
     private sealed class RecordingMetadataService(IMetadataService underlyingService) : IMetadataService


### PR DESCRIPTION
Contributes to #24939.

This PR updates the `MetadataReference` loading code in `CommonCompiler` and `Workspaces` to load PE files with `PEStreamOptions.PrefetchMetadata` if we are resolving `MetadataReference`s of `MetadataImageKind.Assembly`. This will reduce the memory footprint of metadata references.

The metadata reference cache of `VBCSCompiler` [is already doing this](https://github.com/dotnet/roslyn/blob/9624511b64ead198424267624ff96ce9a7869307/src/Compilers/Server/VBCSCompiler/MetadataCache.cs#L23-L35).

My original plan of doing this on the public `MetadataReference` factory APIs was postponed for now, due to multiple test failures.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84887)