### PR TITLE
[release/dev18.0] Skip applying optimization data

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -41,7 +41,8 @@ parameters:
 
 - name: SkipApplyOptimizationData
   type: boolean
-  default: false
+  # release/dev18.0 no longer inserts into VS, so OptProf data is not needed.
+  default: true
 
 - name: SkipTests
   type: boolean


### PR DESCRIPTION
Build [3047282](https://dev.azure.com/dnceng/internal/_build/results?buildId=3047282&view=results) attempted to locate OptProf data for `rel/d18.0` and failed with `StoreNotFoundException`.

`release/dev18.0` no longer inserts into VS, so restore the release-specific `SkipApplyOptimizationData` default to `true`. This default was unintentionally changed by the auth backport in #84095.

[Test Run](https://dev.azure.com/dnceng/internal/_build/results?buildId=3048974&view=results)

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84899)