### PR TITLE
[release/dev17.12] Restore official build authentication

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -262,13 +262,19 @@ extends:
         # Authenticate with service connections to be able to publish packages to external nuget feeds.
         - task: NuGetAuthenticate@1
           inputs:
-            nuGetServiceConnections: azure-public/vs-impl, azure-public/vssdk, devdiv/dotnet-core-internal-tooling
+            nuGetServiceConnections: azure-public/vs-impl, azure-public/vssdk
 
         # Authenticate to DevDiv engineering feed via WIF service connection
         - task: NuGetAuthenticate@1
           inputs:
             azureDevOpsServiceConnection: devdiv-engineering-feed-r-wif
             feedUrl: https://devdiv.pkgs.visualstudio.com/_packaging/Engineering/nuget/v3/index.json
+
+        # Authenticate to DevDiv dotnet-core-internal-tooling feed via WIF service connection
+        - task: NuGetAuthenticate@1
+          inputs:
+            azureDevOpsServiceConnection: dnceng-devdiv-dotnet-core-internal-tooling-feed-rw-wif
+            feedUrl: https://pkgs.dev.azure.com/devdiv/_packaging/dotnet-core-internal-tooling/nuget/v3/index.json
 
         # Needed for SBOM tool
         - task: UseDotNet@2

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -62,7 +62,6 @@ variables:
   # DevDiv drop access token is acquired via WIF service connection (dnceng-devdiv-drop-rw-code-rw-wif)
   # Get $AccessToken-dotnet-build-bot-public-repo from DotNet-Versions-Publish
   - group: DotNet-Versions-Publish
-  - group: DotNet-VSTS-Infra-Access
   - group: DotNet-DevDiv-Insertion-Workflow-Variables
   - group: AzureDevOps-Artifact-Feeds-Pats
   - name: _DevDivDropAccessToken

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -431,8 +431,7 @@ extends:
               demands: ImageOverride -equals 1es-windows-2022
 
     - stage: insert
-      dependsOn:
-      - publish_using_darc
+      trigger: manual
       displayName: Insert to VS
 
       jobs:

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -262,7 +262,13 @@ extends:
         # Authenticate with service connections to be able to publish packages to external nuget feeds.
         - task: NuGetAuthenticate@1
           inputs:
-            nuGetServiceConnections: azure-public/vs-impl, azure-public/vssdk, devdiv/engineering, devdiv/dotnet-core-internal-tooling
+            nuGetServiceConnections: azure-public/vs-impl, azure-public/vssdk, devdiv/dotnet-core-internal-tooling
+
+        # Authenticate to DevDiv engineering feed via WIF service connection
+        - task: NuGetAuthenticate@1
+          inputs:
+            azureDevOpsServiceConnection: devdiv-engineering-feed-r-wif
+            feedUrl: https://devdiv.pkgs.visualstudio.com/_packaging/Engineering/nuget/v3/index.json
 
         # Needed for SBOM tool
         - task: UseDotNet@2

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -259,10 +259,17 @@ extends:
           inputs:
             versionSpec: '4.9.2'
 
-        # Authenticate with service connections to be able to publish packages to external nuget feeds.
+        # Authenticate to azure-public/vs-impl feed via WIF service connection
         - task: NuGetAuthenticate@1
           inputs:
-            nuGetServiceConnections: azure-public/vs-impl, azure-public/vssdk
+            azureDevOpsServiceConnection: dnceng-azure-public-vs-impl-push
+            feedUrl: https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json
+
+        # Authenticate to azure-public/vssdk feed via WIF service connection
+        - task: NuGetAuthenticate@1
+          inputs:
+            azureDevOpsServiceConnection: dnceng-azure-public-vs-impl-push
+            feedUrl: https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json
 
         # Authenticate to DevDiv engineering feed via WIF service connection
         - task: NuGetAuthenticate@1

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -29,12 +29,10 @@ parameters:
   - real
   - test
 
-- name: SkipApplyOptimizationData
-  type: boolean
 # This branch no longer inserts into VS, so it doesn't need opt-prof
 - name: SkipApplyOptimizationData
-type: boolean
-default: true
+  type: boolean
+  default: true
 
 - name: SkipTests
   type: boolean

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -31,7 +31,10 @@ parameters:
 
 - name: SkipApplyOptimizationData
   type: boolean
-  default: false
+# This branch no longer inserts into VS, so it doesn't need opt-prof
+- name: SkipApplyOptimizationData
+type: boolean
+default: true
 
 - name: SkipTests
   type: boolean

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -54,6 +54,9 @@ schedules:
     batch: false # Do not run the pipeline if the previously scheduled run is in-progress
 
 variables:
+  # Defines $(DncEngInternalBuildPool)
+  - template: /eng/common/templates-official/variables/pool-providers.yml@self
+
   - group: DotNet-Roslyn-SDLValidation-Params
   - name: Codeql.Enabled
     value: true
@@ -101,7 +104,7 @@ extends:
       autoBaseline: true
     sdl:
       sourceAnalysisPool:
-        name: NetCore1ESPool-Svc-Internal
+        name: $(DncEngInternalBuildPool)
         image: 1es-windows-2022
         os: windows
       sbom:
@@ -112,7 +115,7 @@ extends:
         enabled: true
         configFile: '$(Build.SourcesDirectory)/eng/TSAConfig.gdntsa'
     pool:
-      name: NetCore1ESPool-Svc-Internal
+      name: $(DncEngInternalBuildPool)
       image: windows.vs2022.amd64
       os: windows
     customBuildTags:
@@ -402,7 +405,7 @@ extends:
           dependsOn:
           - OfficialBuild
           pool:
-            name: NetCore1ESPool-Svc-Internal
+            name: $(DncEngInternalBuildPool)
             demands: ImageOverride -equals windows.vs2022.amd64
 
       - ${{ if eq(variables.enableSourceIndex, 'true') }}:

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -239,6 +239,10 @@ extends:
             scriptLocation: inlineScript
             inlineScript: |
               $token = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv
+              if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($token)) {
+                throw "Failed to acquire a DevDiv drop access token."
+              }
+
               Write-Host "##vso[task.setvariable variable=_DevDivDropAccessToken;issecret=true]$token"
               Write-Host "##vso[task.setvariable variable=ArtifactServices.Drop.PAT;issecret=true]$token"
           condition: succeeded()
@@ -364,14 +368,22 @@ extends:
             targetType: inline
             script: |
               $feedUrl = "https://pkgs.dev.azure.com/devdiv/_packaging/VS/nuget/v3/index.json"
-              $packages = Get-ChildItem -Path "$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)\DevDivPackages" -Recurse -Filter "*.nupkg"
+              $packagePath = "$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)\DevDivPackages"
+              if (-not (Test-Path -LiteralPath $packagePath -PathType Container)) {
+                throw "CoreXT package directory does not exist: $packagePath"
+              }
+
+              $packages = @(Get-ChildItem -LiteralPath $packagePath -Recurse -Filter "*.nupkg" -File -ErrorAction Stop)
+              if ($packages.Count -eq 0) {
+                throw "No CoreXT packages were found under: $packagePath"
+              }
+
               Write-Host "Found $($packages.Count) packages to push"
               foreach ($pkg in $packages) {
                 Write-Host "Pushing $($pkg.Name)..."
                 & dotnet nuget push $pkg.FullName --source $feedUrl --api-key AzureDevOps --skip-duplicate
                 if ($LASTEXITCODE -ne 0) {
-                  Write-Error "Failed to push $($pkg.Name)"
-                  exit 1
+                  throw "Failed to push $($pkg.Name)"
                 }
               }
               Write-Host "Successfully pushed $($packages.Count) packages"

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -59,16 +59,16 @@ variables:
     value: true
 
   # To retrieve OptProf data we need to authenticate to the VS drop storage.
-  # Get access token with $dn-bot-devdiv-drop-rw-code-rw and dn-bot-dnceng-build-rw-code-rw from DotNet-VSTS-Infra-Access
+  # DevDiv drop access token is acquired via WIF service connection (dnceng-devdiv-drop-rw-code-rw-wif)
   # Get $AccessToken-dotnet-build-bot-public-repo from DotNet-Versions-Publish
   - group: DotNet-Versions-Publish
   - group: DotNet-VSTS-Infra-Access
   - group: DotNet-DevDiv-Insertion-Workflow-Variables
   - group: AzureDevOps-Artifact-Feeds-Pats
   - name: _DevDivDropAccessToken
-    value: $(dn-bot-devdiv-drop-rw-code-rw)
+    value: ''
   - name: ArtifactServices.Drop.PAT
-    value: $(dn-bot-devdiv-drop-rw-code-rw)
+    value: ''
   - group: AzureDevOps-Artifact-Feeds-Pats
 
   - name: BuildConfiguration
@@ -239,6 +239,18 @@ extends:
         - powershell: Write-Host "##vso[task.setvariable variable=VisualStudio.DropName]Products/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranchName)/$(Build.BuildNumber)"
           displayName: Setting VisualStudio.DropName variable
 
+        - task: AzureCLI@2
+          displayName: Get DevDiv Drop Access Token
+          inputs:
+            azureSubscription: 'dnceng-devdiv-drop-rw-code-rw-wif'
+            scriptType: pscore
+            scriptLocation: inlineScript
+            inlineScript: |
+              $token = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv
+              Write-Host "##vso[task.setvariable variable=_DevDivDropAccessToken;issecret=true]$token"
+              Write-Host "##vso[task.setvariable variable=ArtifactServices.Drop.PAT;issecret=true]$token"
+          condition: succeeded()
+
         - task: NodeTool@0
           inputs:
             versionSpec: '16.x'
@@ -327,7 +339,7 @@ extends:
           condition: succeeded()
 
         # Publish OptProf configuration files to the artifact service
-        # This uses the ArtifactServices.Drop.PAT build variable which is required to enable cross account access using PAT (dnceng -> devdiv)
+        # ArtifactServices.Drop.PAT is set via WIF service connection for cross account access (dnceng -> devdiv)
         - task: 1ES.PublishArtifactsDrop@1
           inputs:
             dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -171,16 +171,6 @@ extends:
             accessToken: $(_DevDivDropAccessToken)
             dropRetentionDays: 90
 
-          # Publish insertion packages to CoreXT store.
-          - output: nuget
-            displayName: 'Publish CoreXT Packages'
-            condition: succeeded()
-            packageParentPath: '$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)\DevDivPackages'
-            packagesToPush: '$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)\DevDivPackages\**\*.nupkg'
-            allowPackageConflicts: true
-            nuGetFeedType: external
-            publishFeedCredentials: 'DevDiv - VS package feed'
-
           # Publish an artifact that the RoslynInsertionTool is able to find by its name.
           - output: pipelineArtifact
             displayName: 'Publish Artifact VSSetup'
@@ -283,6 +273,12 @@ extends:
             azureDevOpsServiceConnection: dnceng-devdiv-dotnet-core-internal-tooling-feed-rw-wif
             feedUrl: https://pkgs.dev.azure.com/devdiv/_packaging/dotnet-core-internal-tooling/nuget/v3/index.json
 
+        # Authenticate to DevDiv VS (CoreXT) feed via WIF service connection
+        - task: NuGetAuthenticate@1
+          inputs:
+            azureDevOpsServiceConnection: dnceng-devdiv-vs-feed-push
+            feedUrl: https://pkgs.dev.azure.com/devdiv/_packaging/VS/nuget/v3/index.json
+
         # Needed for SBOM tool
         - task: UseDotNet@2
           displayName: 'Use .NET Core 3.1 runtime'
@@ -355,6 +351,27 @@ extends:
             filePath: 'eng\publish-assets.ps1'
             arguments: '-configuration $(BuildConfiguration)'
           condition: succeeded()
+
+        # Publish insertion packages to CoreXT store (DevDiv/VS feed)
+        # Uses ambient credentials from NuGetAuthenticate@1 above
+        - task: PowerShell@2
+          displayName: 'Publish CoreXT Packages'
+          condition: succeeded()
+          inputs:
+            targetType: inline
+            script: |
+              $feedUrl = "https://pkgs.dev.azure.com/devdiv/_packaging/VS/nuget/v3/index.json"
+              $packages = Get-ChildItem -Path "$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)\DevDivPackages" -Recurse -Filter "*.nupkg"
+              Write-Host "Found $($packages.Count) packages to push"
+              foreach ($pkg in $packages) {
+                Write-Host "Pushing $($pkg.Name)..."
+                & dotnet nuget push $pkg.FullName --source $feedUrl --api-key AzureDevOps --skip-duplicate
+                if ($LASTEXITCODE -ne 0) {
+                  Write-Error "Failed to push $($pkg.Name)"
+                  exit 1
+                }
+              }
+              Write-Host "Successfully pushed $($packages.Count) packages"
 
         # Publish OptProf configuration files to the artifact service
         # ArtifactServices.Drop.PAT is set via WIF service connection for cross account access (dnceng -> devdiv)


### PR DESCRIPTION
## Summary

Backport the official-build authentication and pool-provider fixes from `main` to `release/dev17.12`.

Build [3046248](https://dev.azure.com/dnceng/internal/_build/results?buildId=3046248&view=results) fails during YAML expansion because the removed `DotNet-VSTS-Infra-Access` variable group is still referenced. Earlier builds on this branch also exposed a 401 restoring from the DevDiv Engineering feed.

This change:

- acquires the DevDiv drop token through the authorized WIF service connection
- removes the dead variable-group reference
- migrates Engineering, dotnet-core-internal-tooling, azure-public, and CoreXT/VS feeds from PAT-backed endpoints to WIF
- publishes CoreXT packages with `dotnet nuget push` and ambient `NuGetAuthenticate` credentials
- uses Arcade's `DncEngInternalBuildPool` provider while retaining the branch's VS2022 image

The superseded #84487 implementation is intentionally omitted; its WIF connection type is incompatible with the 1ES `output: nuget` path. The corrected #84490 implementation is included directly.

Backports #83726, #84382, #83918, #84414, #84457, #84490, and #81047.

## Validation

- Parsed `azure-pipelines-official.yml` successfully
- Confirmed the dead variable group and legacy feed service-connection references are absent
- Confirmed all five WIF authentication paths and centralized pool references are present
[Test Run](https://dev.azure.com/dnceng/internal/_build/results?buildId=3048977&view=results)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84900)