### PR TITLE
[release/dev17.8] Restore official build authentication

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -54,21 +54,23 @@ schedules:
     batch: false # Do not run the pipeline if the previously scheduled run is in-progress
 
 variables:
+  # Defines $(DncEngInternalBuildPool)
+  - template: /eng/common/templates-official/variables/pool-providers.yml@self
+
   - group: DotNet-Roslyn-SDLValidation-Params
   - name: Codeql.Enabled
     value: true
 
   # To retrieve OptProf data we need to authenticate to the VS drop storage.
-  # Get access token with $dn-bot-devdiv-drop-rw-code-rw and dn-bot-dnceng-build-rw-code-rw from DotNet-VSTS-Infra-Access
+  # DevDiv drop access token is acquired via WIF service connection (dnceng-devdiv-drop-rw-code-rw-wif)
   # Get $AccessToken-dotnet-build-bot-public-repo from DotNet-Versions-Publish
-  - group: DotNet-VSTS-Infra-Access
+  - group: DotNet-Versions-Publish
   - group: DotNet-DevDiv-Insertion-Workflow-Variables
   - group: AzureDevOps-Artifact-Feeds-Pats
   - name: _DevDivDropAccessToken
-    value: $(dn-bot-devdiv-drop-rw-code-rw)
+    value: ''
   - name: ArtifactServices.Drop.PAT
-    value: $(dn-bot-devdiv-drop-rw-code-rw)
-  - group: DotNet-Roslyn-Insertion-Variables
+    value: ''
 
   - name: BuildConfiguration
     value: release
@@ -97,7 +99,7 @@ extends:
       autoBaseline: true
     sdl:
       sourceAnalysisPool:
-        name: NetCore1ESPool-Svc-Internal
+        name: $(DncEngInternalBuildPool)
         image: 1es-windows-2022
         os: windows
       sbom:
@@ -105,7 +107,7 @@ extends:
       suppression:
         suppressionFile: $(Build.SourcesDirectory)\eng\config\guardian\.gdnsuppres
     pool:
-      name: NetCore1ESPool-Svc-Internal
+      name: $(DncEngInternalBuildPool)
       image: windows.vs2022.amd64
       os: windows
     customBuildTags:
@@ -162,16 +164,6 @@ extends:
             dropFolder: 'artifacts\VSSetup\$(BuildConfiguration)\Insertion'
             dropName: $(VisualStudio.DropName)
             accessToken: $(_DevDivDropAccessToken)
-
-          # Publish insertion packages to CoreXT store.
-          - output: nuget
-            displayName: 'Publish CoreXT Packages'
-            condition: succeeded()
-            packageParentPath: '$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)\DevDivPackages'
-            packagesToPush: '$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)\DevDivPackages\**\*.nupkg'
-            allowPackageConflicts: true
-            nuGetFeedType: external
-            publishFeedCredentials: 'DevDiv - VS package feed'
 
           # Publish an artifact that the RoslynInsertionTool is able to find by its name.
           - output: pipelineArtifact
@@ -230,6 +222,22 @@ extends:
         - powershell: Write-Host "##vso[task.setvariable variable=VisualStudio.DropName]Products/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranchName)/$(Build.BuildNumber)"
           displayName: Setting VisualStudio.DropName variable
 
+        - task: AzureCLI@2
+          displayName: Get DevDiv Drop Access Token
+          inputs:
+            azureSubscription: 'dnceng-devdiv-drop-rw-code-rw-wif'
+            scriptType: pscore
+            scriptLocation: inlineScript
+            inlineScript: |
+              $token = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv
+              if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($token)) {
+                throw "Failed to acquire a DevDiv drop access token."
+              }
+
+              Write-Host "##vso[task.setvariable variable=_DevDivDropAccessToken;issecret=true]$token"
+              Write-Host "##vso[task.setvariable variable=ArtifactServices.Drop.PAT;issecret=true]$token"
+          condition: succeeded()
+
         - task: NodeTool@0
           inputs:
             versionSpec: '16.x'
@@ -239,10 +247,35 @@ extends:
           inputs:
             versionSpec: '4.9.2'
 
-        # Authenticate with service connections to be able to publish packages to external nuget feeds.
+        # Authenticate to azure-public/vs-impl feed via WIF service connection
         - task: NuGetAuthenticate@1
           inputs:
-            nuGetServiceConnections: azure-public/vs-impl, azure-public/vssdk, devdiv/engineering, devdiv/dotnet-core-internal-tooling
+            azureDevOpsServiceConnection: dnceng-azure-public-vs-impl-push
+            feedUrl: https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json
+
+        # Authenticate to azure-public/vssdk feed via WIF service connection
+        - task: NuGetAuthenticate@1
+          inputs:
+            azureDevOpsServiceConnection: dnceng-azure-public-vs-impl-push
+            feedUrl: https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json
+
+        # Authenticate to DevDiv engineering feed via WIF service connection
+        - task: NuGetAuthenticate@1
+          inputs:
+            azureDevOpsServiceConnection: devdiv-engineering-feed-r-wif
+            feedUrl: https://devdiv.pkgs.visualstudio.com/_packaging/Engineering/nuget/v3/index.json
+
+        # Authenticate to DevDiv dotnet-core-internal-tooling feed via WIF service connection
+        - task: NuGetAuthenticate@1
+          inputs:
+            azureDevOpsServiceConnection: dnceng-devdiv-dotnet-core-internal-tooling-feed-rw-wif
+            feedUrl: https://pkgs.dev.azure.com/devdiv/_packaging/dotnet-core-internal-tooling/nuget/v3/index.json
+
+        # Authenticate to DevDiv VS (CoreXT) feed via WIF service connection
+        - task: NuGetAuthenticate@1
+          inputs:
+            azureDevOpsServiceConnection: dnceng-devdiv-vs-feed-push
+            feedUrl: https://pkgs.dev.azure.com/devdiv/_packaging/VS/nuget/v3/index.json
 
         # Needed for SBOM tool
         - task: UseDotNet@2
@@ -317,8 +350,37 @@ extends:
             arguments: '-configuration $(BuildConfiguration)'
           condition: succeeded()
 
+        # Publish insertion packages to CoreXT store using credentials from NuGetAuthenticate.
+        - task: PowerShell@2
+          displayName: Publish CoreXT Packages
+          condition: succeeded()
+          inputs:
+            targetType: inline
+            script: |
+              $feedUrl = "https://pkgs.dev.azure.com/devdiv/_packaging/VS/nuget/v3/index.json"
+              $packagePath = "$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)\DevDivPackages"
+              if (-not (Test-Path -LiteralPath $packagePath -PathType Container)) {
+                throw "CoreXT package directory does not exist: $packagePath"
+              }
+
+              $packages = @(Get-ChildItem -LiteralPath $packagePath -Recurse -Filter "*.nupkg" -File -ErrorAction Stop)
+              if ($packages.Count -eq 0) {
+                throw "No CoreXT packages were found under: $packagePath"
+              }
+
+              Write-Host "Found $($packages.Count) packages to push"
+              foreach ($package in $packages) {
+                Write-Host "Pushing $($package.Name)..."
+                & dotnet nuget push $package.FullName --source $feedUrl --api-key AzureDevOps --skip-duplicate
+                if ($LASTEXITCODE -ne 0) {
+                  throw "Failed to push $($package.Name)"
+                }
+              }
+
+              Write-Host "Successfully pushed $($packages.Count) packages"
+
         # Publish OptProf configuration files to the artifact service
-        # This uses the ArtifactServices.Drop.PAT build variable which is required to enable cross account access using PAT (dnceng -> devdiv)
+        # ArtifactServices.Drop.PAT is set via WIF service connection for cross account access (dnceng -> devdiv)
         - task: 1ES.PublishArtifactsDrop@1
           inputs:
             dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'
@@ -343,10 +405,11 @@ extends:
       - template: /eng/common/templates-official/job/publish-build-assets.yml@self
         parameters:
           publishUsingPipelines: true
+          publishAssetsImmediately: true
           dependsOn:
           - OfficialBuild
           pool:
-            name: NetCore1ESPool-Svc-Internal
+            name: $(DncEngInternalBuildPool)
             demands: ImageOverride -equals windows.vs2022.amd64
 
     - stage: insert
@@ -365,7 +428,6 @@ extends:
           displayName: Get Branch Name
         - template: /eng/pipelines/insert.yml@self
           parameters:
-            devDivAzdoToken: $(dn-bot-devdiv-build-e-code-full-release-e-packaging-r)
             dncEngAzureSubscription: 'DncEng Insertion: Roslyn and Razor'
             componentBuildProjectName: internal
             sourceBranch: "$(ComponentBranchName)"
@@ -376,24 +438,7 @@ extends:
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       - template: /eng/common/templates-official/post-build/post-build.yml@self
         parameters:
-          publishingInfraVersion: 3
-          # Symbol validation is not entirely reliable as of yet, so should be turned off until
-          # https://github.com/dotnet/arcade/issues/2871 is resolved.
-          enableSymbolValidation: false
+          publishAssetsImmediately: true
+          enableSigningValidation: false
+          enableNugetValidation: false
           enableSourceLinkValidation: false
-          # Enable SDL validation, passing through values from the 'DotNet-Roslyn-SDLValidation-Params' group.
-          SDLValidationParameters:
-            enable: true
-            params: >-
-              -SourceToolsList @("policheck","credscan")
-              -ArtifactToolsList @("binskim")
-              -BinskimAdditionalRunConfigParams @("IgnorePdbLoadError < True","Recurse < True","SymbolsPath < SRV*https://msdl.microsoft.com/download/symbols")
-              -TsaInstanceURL $(_TsaInstanceURL)
-              -TsaProjectName $(_TsaProjectName)
-              -TsaNotificationEmail $(_TsaNotificationEmail)
-              -TsaCodebaseAdmin $(_TsaCodebaseAdmin)
-              -TsaBugAreaPath $(_TsaBugAreaPath)
-              -TsaIterationPath $(_TsaIterationPath)
-              -TsaRepositoryName $(_TsaRepositoryName)
-              -TsaCodebaseName $(_TsaCodebaseName)
-              -TsaPublish $True

--- a/azure-pipelines-pr-validation.yml
+++ b/azure-pipelines-pr-validation.yml
@@ -33,7 +33,6 @@ variables:
   - name: _DotNetValidationArtifactsCategory
     value: .NETCoreValidation
   - group: DotNet-Roslyn-SDLValidation-Params
-  - group: DotNet-Roslyn-Insertion-Variables
 
   # To retrieve OptProf data we need to authenticate to the VS drop storage.
   # If the pipeline is running in DevDiv, the account has access to the VS drop storage.
@@ -88,10 +87,20 @@ stages:
       inputs:
         versionSpec: '4.9.2'
 
-    # Authenticate with service connections to be able to publish packages to external nuget feeds.
-    - task: NuGetAuthenticate@0
+    # Authenticate to azure-public/vs-impl feed via WIF service connection
+    - task: NuGetAuthenticate@1
       inputs:
-        nuGetServiceConnections: azure-public/vs-impl, azure-public/vssdk
+        azureDevOpsServiceConnection: dnceng-azure-public-vs-impl-push
+        feedUrl: https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json
+
+    # Authenticate to azure-public/vssdk feed via WIF service connection
+    - task: NuGetAuthenticate@1
+      inputs:
+        azureDevOpsServiceConnection: dnceng-azure-public-vs-impl-push
+        feedUrl: https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json
+
+    # Authenticate to feeds in the current Azure DevOps organization.
+    - task: NuGetAuthenticate@1
 
     # Needed because the build fails the NuGet Tools restore without it
     - task: UseDotNet@2
@@ -261,11 +270,9 @@ stages:
         createDraftPR: true
         autoComplete: false
         insertToolset: ${{ parameters.InsertToolset }}
-        devDivAzdoToken: $(dn-bot-devdiv-build-e-code-full-release-e-packaging-r)
         dncEngAzureSubscription: 'DncEng Insertion: Roslyn and Razor'
         vsBranchName: ${{ parameters.VisualStudioBranchName }}
         titlePrefix: ${{ parameters.OptionalTitlePrefix }}
         sourceBranch: $(SourceBranchName)
         publishDataURI: "https://raw.githubusercontent.com/dotnet/roslyn/$(SourceBranchName)/eng/config/PublishData.json"
         queueSpeedometerValidation: true
-

--- a/eng/pipelines/insert.yml
+++ b/eng/pipelines/insert.yml
@@ -20,6 +20,7 @@ parameters:
 
   - name: devDivAzdoToken
     type: string
+    default: ''
   - name: dncEngAzureSubscription
     type: string
     default: 'DncEng Insertion: Roslyn and Razor'
@@ -168,11 +169,15 @@ steps:
       inlineScript: |
         # Acquire AzDO token explicitly from the WIF SP login context.
         # DefaultAzureCredential is unreliable on hosted agents (picks up agent MI).
-        $dncEngAzdoToken = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv
-        if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($dncEngAzdoToken)) {
-          Write-Error 'Failed to acquire dnceng AzDO access token via WIF service connection.'
+        # The WIF SP is enrolled in both dnceng and devdiv, so a single token works for both orgs.
+        $azdoToken = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv
+        if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($azdoToken)) {
+          Write-Error 'Failed to acquire AzDO access token via WIF service connection.'
           exit 1
         }
+
+        # Use WIF for DevDiv unless a legacy PAT is explicitly provided.
+        $devDivToken = if ([string]::IsNullOrWhiteSpace($Env:DevDivToken)) { $azdoToken } else { $Env:DevDivToken }
 
         $arguments = @(
           "create-insertion"
@@ -188,8 +193,8 @@ steps:
           "--run-speedometer-in-validation", "${{ parameters.queueSpeedometerValidation }}"
           "--retain-inserted-build", "${{ parameters.retainInsertedBuild }}"
           "--reviewer-guid", "6c25b447-1d90-4840-8fde-d8b22cb8733e"
-          "--devdiv-azdo-token", $Env:DevDivToken
-          "--dnceng-azdo-token", $dncEngAzdoToken
+          "--devdiv-azdo-token", $devDivToken
+          "--dnceng-azdo-token", $azdoToken
           "--ci"
         )
 


### PR DESCRIPTION
## Summary

Backport the official-build authentication and infrastructure changes required by the current Azure DevOps and Arcade configuration.

Build [3046172](https://dev.azure.com/dnceng/internal/_build/results?buildId=3046172&view=results) fails during YAML expansion because removed variable groups are still referenced. Earlier build [3009991](https://dev.azure.com/dnceng/internal/_build/results?buildId=3009991&view=results) also fails with a 401 restoring from the DevDiv Engineering feed.

This change:

- removes retired PAT-backed variable groups and service connections
- acquires DevDiv drop and insertion tokens through WIF
- migrates Engineering, internal tooling, azure-public, and CoreXT feeds to WIF
- publishes CoreXT packages with ambient `NuGetAuthenticate` credentials
- selects the servicing pool through Arcade's pool-provider template
- updates immediate asset publishing and post-build parameters for the current Arcade templates
- updates PR validation to use the same WIF authentication paths

The superseded #84487 implementation is intentionally omitted in favor of the corrected #84490 approach.

## Validation

- Azure DevOps server-side preview expanded the official pipeline successfully
- Parsed all three changed YAML files
- Confirmed retired variable groups, PAT variables, and legacy feed connections are absent
- Confirmed the PR validation changes match the current `main` WIF configuration
[Test Run](https://dev.azure.com/dnceng/internal/_build/results?buildId=3048983&view=results)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84902)