### PR TITLE
[release/dev17.11] Backport official build authentication fixes

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -403,6 +403,7 @@ extends:
       - template: /eng/common/templates-official/job/publish-build-assets.yml@self
         parameters:
           publishUsingPipelines: true
+          publishAssetsImmediately: true
           dependsOn:
           - OfficialBuild
           pool:
@@ -437,6 +438,9 @@ extends:
       - template: /eng/common/templates-official/post-build/post-build.yml@self
         parameters:
           publishingInfraVersion: 3
+          publishAssetsImmediately: true
+          enableSigningValidation: false
+          enableNugetValidation: false
           # Symbol validation is not entirely reliable as of yet, so should be turned off until
           # https://github.com/dotnet/arcade/issues/2871 is resolved.
           enableSymbolValidation: false

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -59,18 +59,15 @@ variables:
     value: true
 
   # To retrieve OptProf data we need to authenticate to the VS drop storage.
-  # Get access token with $dn-bot-devdiv-drop-rw-code-rw and dn-bot-dnceng-build-rw-code-rw from DotNet-VSTS-Infra-Access
+  # DevDiv drop access token is acquired via WIF service connection (dnceng-devdiv-drop-rw-code-rw-wif)
   # Get $AccessToken-dotnet-build-bot-public-repo from DotNet-Versions-Publish
   - group: DotNet-Versions-Publish
-  - group: DotNet-VSTS-Infra-Access
   - group: DotNet-DevDiv-Insertion-Workflow-Variables
   - group: AzureDevOps-Artifact-Feeds-Pats
   - name: _DevDivDropAccessToken
-    value: $(dn-bot-devdiv-drop-rw-code-rw)
+    value: ''
   - name: ArtifactServices.Drop.PAT
-    value: $(dn-bot-devdiv-drop-rw-code-rw)
-  - group: DotNet-Roslyn-Insertion-Variables
-  - group: AzureDevOps-Artifact-Feeds-Pats
+    value: ''
 
   - name: BuildConfiguration
     value: release
@@ -166,16 +163,6 @@ extends:
             accessToken: $(_DevDivDropAccessToken)
             dropRetentionDays: 90
 
-          # Publish insertion packages to CoreXT store.
-          - output: nuget
-            displayName: 'Publish CoreXT Packages'
-            condition: succeeded()
-            packageParentPath: '$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)\DevDivPackages'
-            packagesToPush: '$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)\DevDivPackages\**\*.nupkg'
-            allowPackageConflicts: true
-            nuGetFeedType: external
-            publishFeedCredentials: 'DevDiv - VS package feed'
-
           # Publish an artifact that the RoslynInsertionTool is able to find by its name.
           - output: pipelineArtifact
             displayName: 'Publish Artifact VSSetup'
@@ -233,6 +220,22 @@ extends:
         - powershell: Write-Host "##vso[task.setvariable variable=VisualStudio.DropName]Products/$(System.TeamProject)/$(Build.Repository.Name)/$(SourceBranchName)/$(Build.BuildNumber)"
           displayName: Setting VisualStudio.DropName variable
 
+        - task: AzureCLI@2
+          displayName: Get DevDiv Drop Access Token
+          inputs:
+            azureSubscription: 'dnceng-devdiv-drop-rw-code-rw-wif'
+            scriptType: pscore
+            scriptLocation: inlineScript
+            inlineScript: |
+              $token = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv
+              if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($token)) {
+                throw "Failed to acquire a DevDiv drop access token."
+              }
+
+              Write-Host "##vso[task.setvariable variable=_DevDivDropAccessToken;issecret=true]$token"
+              Write-Host "##vso[task.setvariable variable=ArtifactServices.Drop.PAT;issecret=true]$token"
+          condition: succeeded()
+
         - task: NodeTool@0
           inputs:
             versionSpec: '16.x'
@@ -242,10 +245,35 @@ extends:
           inputs:
             versionSpec: '4.9.2'
 
-        # Authenticate with service connections to be able to publish packages to external nuget feeds.
+        # Authenticate to azure-public/vs-impl feed via WIF service connection
         - task: NuGetAuthenticate@1
           inputs:
-            nuGetServiceConnections: azure-public/vs-impl, azure-public/vssdk, devdiv/engineering, devdiv/dotnet-core-internal-tooling
+            azureDevOpsServiceConnection: dnceng-azure-public-vs-impl-push
+            feedUrl: https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json
+
+        # Authenticate to azure-public/vssdk feed via WIF service connection
+        - task: NuGetAuthenticate@1
+          inputs:
+            azureDevOpsServiceConnection: dnceng-azure-public-vs-impl-push
+            feedUrl: https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json
+
+        # Authenticate to DevDiv engineering feed via WIF service connection
+        - task: NuGetAuthenticate@1
+          inputs:
+            azureDevOpsServiceConnection: devdiv-engineering-feed-r-wif
+            feedUrl: https://devdiv.pkgs.visualstudio.com/_packaging/Engineering/nuget/v3/index.json
+
+        # Authenticate to DevDiv dotnet-core-internal-tooling feed via WIF service connection
+        - task: NuGetAuthenticate@1
+          inputs:
+            azureDevOpsServiceConnection: dnceng-devdiv-dotnet-core-internal-tooling-feed-rw-wif
+            feedUrl: https://pkgs.dev.azure.com/devdiv/_packaging/dotnet-core-internal-tooling/nuget/v3/index.json
+
+        # Authenticate to DevDiv VS (CoreXT) feed via WIF service connection
+        - task: NuGetAuthenticate@1
+          inputs:
+            azureDevOpsServiceConnection: dnceng-devdiv-vs-feed-push
+            feedUrl: https://pkgs.dev.azure.com/devdiv/_packaging/VS/nuget/v3/index.json
 
         # Needed for SBOM tool
         - task: UseDotNet@2
@@ -320,8 +348,37 @@ extends:
             arguments: '-configuration $(BuildConfiguration) -branchName "$(SourceBranchName)"'
           condition: succeeded()
 
+        # Publish insertion packages to CoreXT store using credentials from NuGetAuthenticate.
+        - task: PowerShell@2
+          displayName: Publish CoreXT Packages
+          condition: succeeded()
+          inputs:
+            targetType: inline
+            script: |
+              $feedUrl = "https://pkgs.dev.azure.com/devdiv/_packaging/VS/nuget/v3/index.json"
+              $packagePath = "$(Build.SourcesDirectory)\artifacts\VSSetup\$(BuildConfiguration)\DevDivPackages"
+              if (-not (Test-Path -LiteralPath $packagePath -PathType Container)) {
+                throw "CoreXT package directory does not exist: $packagePath"
+              }
+
+              $packages = @(Get-ChildItem -LiteralPath $packagePath -Recurse -Filter "*.nupkg" -File -ErrorAction Stop)
+              if ($packages.Count -eq 0) {
+                throw "No CoreXT packages were found under: $packagePath"
+              }
+
+              Write-Host "Found $($packages.Count) packages to push"
+              foreach ($package in $packages) {
+                Write-Host "Pushing $($package.Name)..."
+                & dotnet nuget push $package.FullName --source $feedUrl --api-key AzureDevOps --skip-duplicate
+                if ($LASTEXITCODE -ne 0) {
+                  throw "Failed to push $($package.Name)"
+                }
+              }
+
+              Write-Host "Successfully pushed $($packages.Count) packages"
+
         # Publish OptProf configuration files to the artifact service
-        # This uses the ArtifactServices.Drop.PAT build variable which is required to enable cross account access using PAT (dnceng -> devdiv)
+        # ArtifactServices.Drop.PAT is set via WIF service connection for cross account access (dnceng -> devdiv)
         - task: 1ES.PublishArtifactsDrop@1
           inputs:
             dropServiceURI: 'https://devdiv.artifacts.visualstudio.com'

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -345,7 +345,7 @@ extends:
           displayName: Publish Assets
           inputs:
             filePath: 'eng\publish-assets.ps1'
-            arguments: '-configuration $(BuildConfiguration) -branchName "$(SourceBranchName)"'
+            arguments: '-configuration $(BuildConfiguration)'
           condition: succeeded()
 
         # Publish insertion packages to CoreXT store using credentials from NuGetAuthenticate.

--- a/azure-pipelines-pr-validation.yml
+++ b/azure-pipelines-pr-validation.yml
@@ -33,7 +33,6 @@ variables:
   - name: _DotNetValidationArtifactsCategory
     value: .NETCoreValidation
   - group: DotNet-Roslyn-SDLValidation-Params
-  - group: DotNet-Roslyn-Insertion-Variables
   - name: Codeql.Enabled
     value: false
   - name: Codeql.SkipTaskAutoInjection
@@ -267,7 +266,7 @@ extends:
           displayName: Publish Assets
           inputs:
             filePath: 'eng\publish-assets.ps1'
-            arguments: '-configuration $(BuildConfiguration) -branchName "$(SourceBranchName)" -prValidation'
+            arguments: '-configuration $(BuildConfiguration) -prValidation'
           condition: succeeded()
 
         - task: PublishTestResults@2

--- a/eng/build-utils.ps1
+++ b/eng/build-utils.ps1
@@ -34,14 +34,14 @@ function GetPublishData() {
   return $global:_PublishData = ConvertFrom-Json $content
 }
 
-function GetBranchPublishData([string]$branchName) {
+function GetBranchPublishData() {
   $data = GetPublishData
 
-  if (Get-Member -InputObject $data.branches -Name $branchName) {
-    return $data.branches.$branchName
-  } else {
-    return $null
+  if ($data.branchInfo -eq $null) {
+    throw "No branchInfo entry found in PublishData.json"
   }
+
+  return $data.branchInfo
 }
 
 function GetFeedPublishData() {
@@ -49,13 +49,14 @@ function GetFeedPublishData() {
   return $data.feeds
 }
 
-function GetPackagesPublishData([string]$packageFeeds) {
+function GetPackagesPublishData() {
   $data = GetPublishData
-  if (Get-Member -InputObject $data.packages -Name $packageFeeds) {
-    return $data.packages.$packageFeeds
-  } else {
-    return $null
+
+  if ($data.packages -eq $null) {
+    throw "No packages entry found in PublishData.json"
   }
+
+  return $data.packages
 }
 
 function GetReleasePublishData([string]$releaseName) {

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -302,15 +302,7 @@ function GetIbcSourceBranchName() {
   }
 
   function calculate {
-    $fallback = "main"
-
-    $branchData = GetBranchPublishData $officialSourceBranchName
-    if ($branchData -eq $null) {
-      Write-LogIssue -Type "warning" -Message "Branch $officialSourceBranchName is not listed in PublishData.json. Using IBC data from '$fallback'."
-      Write-Host "Override by setting IbcDrop build variable." -ForegroundColor Yellow
-      return $fallback
-    }
-
+    $branchData = GetBranchPublishData
     return $branchData.vsBranch
   }
 

--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -5,7 +5,6 @@
     "vs": "https://pkgs.dev.azure.com/DevDiv/_packaging/VS/nuget/v3/index.json"
   },
   "packages": {
-    "default": {
       "Microsoft.CodeAnalysis": "arcade",
       "Microsoft.CodeAnalysis.Common": "vssdk",
       "Microsoft.CodeAnalysis.Compilers": "arcade",
@@ -90,7 +89,6 @@
       "Microsoft.VisualStudio.LanguageServices.Razor.RemoteClient": "vs-impl",
       "Microsoft.CommonLanguageServerProtocol.Framework": "vs-impl",
       "Microsoft.CommonLanguageServerProtocol.Framework.Binary": "vs-impl"
-    }
   },
   "branchInfo": {
     "nugetKind": [

--- a/eng/publish-assets.ps1
+++ b/eng/publish-assets.ps1
@@ -10,8 +10,6 @@
 Param(
   # Standard options
   [string]$configuration = "",
-  [string]$branchName = "",
-  [string]$releaseName = "",
   [switch]$test,
   [switch]$prValidation,
 
@@ -38,27 +36,9 @@ function Publish-Nuget($publishData, [string]$packageDir) {
     # Retrieve the feed name to source mapping.
     $feedData = GetFeedPublishData
     
-    # Let packageFeeds default to the default set of feeds
-    $packageFeeds = "default"
-    if ($publishData.PSobject.Properties.Name -contains "packageFeeds") {
-      $packageFeeds = $publishData.packageFeeds
-    }
-
-    # If the configured packageFeeds is arcade, then skip publishing here.  Arcade will handle publishing packages to their feeds.
-    if ($packageFeeds.equals("arcade") -and -not $prValidation) {
-      Write-Host "    Skipping publishing for all packages as they will be published by arcade"
-      continue
-    }
-
-    # Let packageFeeds default to the default set of feeds
-    $packageFeeds = "default"
-    if ($publishData.PSobject.Properties.Name -contains "packageFeeds") {
-      $packageFeeds = $publishData.packageFeeds
-    }
-
     # Each branch stores the name of the package to feed map it should use.
     # Retrieve the correct map for this particular branch.
-    $packagesData = GetPackagesPublishData $packageFeeds
+    $packagesData = GetPackagesPublishData
 
     foreach ($package in Get-ChildItem *.nupkg) {
       Write-Host ""
@@ -67,6 +47,11 @@ function Publish-Nuget($publishData, [string]$packageDir) {
       Write-Host "Publishing $nupkg"
       if (-not (Test-Path $nupkg)) {
         throw "$nupkg does not exist"
+      }
+
+      if ($nupkg.EndsWith(".symbols.nupkg")) {
+        Write-Host "Skipping symbol package $nupkg"
+        continue
       }
 
       $nupkgWithoutVersion = $nupkg -replace '(\.\d+){3}-.*.nupkg', ''
@@ -112,19 +97,17 @@ function Publish-Nuget($publishData, [string]$packageDir) {
 }
 
 # Do basic verification on the values provided in the publish configuration
-function Test-Entry($publishData, [switch]$isBranch) {
-  if ($isBranch) {
-    foreach ($nugetKind in $publishData.nugetKind) {
-      if ($nugetKind -ne "PerBuildPreRelease" -and $nugetKind -ne "Shipping" -and $nugetKind -ne "NonShipping") {
-                    throw "Branches are only allowed to publish Shipping, NonShipping, or PerBuildPreRelease"
-      }
+function Test-Entry($publishData) {
+  foreach ($nugetKind in $publishData.nugetKind) {
+    if ($nugetKind -ne "PerBuildPreRelease" -and $nugetKind -ne "Shipping" -and $nugetKind -ne "NonShipping") {
+                  throw "Branches are only allowed to publish Shipping, NonShipping, or PerBuildPreRelease"
     }
   }
 }
 
 # Publish a given entry: branch or release.
-function Publish-Entry($publishData, [switch]$isBranch) {
-  Test-Entry $publishData -isBranch:$isBranch
+function Publish-Entry($publishData) {
+  Test-Entry $publishData
 
   # First publish the NuGet packages to the specified feeds
   foreach ($nugetKind in $publishData.nugetKind) {
@@ -144,33 +127,9 @@ try {
 
   $dotnet = Ensure-DotnetSdk
 
-  if ($branchName -ne "" -and $releaseName -ne "") {
-    Write-Host "Can only specify -branchName or -releaseName, not both"
-    exit 1
-  }
+  $data = GetBranchPublishData
 
-  if ($branchName -ne "") {
-    $data = GetBranchPublishData $branchName
-    if ($data -eq $null) {
-      Write-Host "Branch $branchName not listed for publishing."
-      exit 0
-    }
-
-    Publish-Entry $data -isBranch:$true
-  }
-  elseif ($releaseName -ne "") {
-    $data = GetReleasePublishData $releaseName
-    if ($data -eq $null) {
-      Write-Host "Release $releaseName not listed for publishing."
-      exit 1
-    }
-
-    Publish-Entry $data -isBranch:$false
-  }
-  else {
-    Write-Host "Need to specify -branchName or -releaseName"
-    exit 1
-  }
+  Publish-Entry $data
 }
 catch {
   Write-Host $_

--- a/src/Tools/BuildBoss/CompilerNuGetCheckerUtil.cs
+++ b/src/Tools/BuildBoss/CompilerNuGetCheckerUtil.cs
@@ -95,7 +95,7 @@ namespace BuildBoss
             // Load PublishData.json
             var publishDataPath = Path.Combine(RepositoryDirectory, "eng", "config", "PublishData.json");
             var publishDataRoot = JObject.Parse(File.ReadAllText(publishDataPath));
-            var publishDataPackages = publishDataRoot["packages"]["default"] as JObject;
+            var publishDataPackages = publishDataRoot["packages"] as JObject;
 
             // Check all shipping packages have an entry in PublishData.json
             var regex = new Regex(@"^(.*?)\.\d.*\.nupkg$");

--- a/src/Tools/BuildBoss/CompilerNuGetCheckerUtil.cs
+++ b/src/Tools/BuildBoss/CompilerNuGetCheckerUtil.cs
@@ -96,6 +96,11 @@ namespace BuildBoss
             var publishDataPath = Path.Combine(RepositoryDirectory, "eng", "config", "PublishData.json");
             var publishDataRoot = JObject.Parse(File.ReadAllText(publishDataPath));
             var publishDataPackages = publishDataRoot["packages"] as JObject;
+            if (publishDataPackages is null)
+            {
+                textWriter.WriteLine("PublishData.json does not contain a valid packages object.");
+                return false;
+            }
 
             // Check all shipping packages have an entry in PublishData.json
             var regex = new Regex(@"^(.*?)\.\d.*\.nupkg$");


### PR DESCRIPTION
## Summary

Backport the official pipeline authentication changes from `main`:

- remove the retired `DotNet-VSTS-Infra-Access` and `DotNet-Roslyn-Insertion-Variables` variable groups
- acquire the DevDiv drop token through the WIF service connection
- migrate the azure-public, DevDiv Engineering, and dotnet-core-internal-tooling feeds to WIF authentication
- authenticate and publish CoreXT packages with `NuGetAuthenticate` and `dotnet nuget push`
- fail explicitly when token acquisition or CoreXT package discovery/publishing fails
- align publishing scripts, configuration, and BuildBoss with the branch-local publish-data schema
- publish BAR assets immediately and disable the obsolete signing/NuGet validation jobs, matching `main` and avoiding their retired PAT-backed authentication path

## Context

[Build 3046247](https://dev.azure.com/dnceng/internal/_build/results?buildId=3046247&view=results) fails during YAML validation because a referenced variable group no longer exists or is unauthorized. Builds 3031677 and 3039094 fail the same way. The last build that reached execution, 3010023, failed restoring internal tools with a 401 from the DevDiv Engineering feed.

This selectively carries the final behavior from #83726, #83918, #84382, #84414, #84457, and #84490 without bringing unrelated pipeline changes from `main`.

[Test Run](https://dev.azure.com/dnceng/internal/_build/results?buildId=3049441&view=results)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84903)