### PR TITLE
Centralize partial constructor detection

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1697,6 +1697,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             return false;
         }
 
+        private bool IsPartialConstructor(int peekIndex)
+        {
+            return this.PeekToken(peekIndex).ContextualKind == SyntaxKind.PartialKeyword &&
+                this.PeekToken(peekIndex + 1).Kind == SyntaxKind.IdentifierToken &&
+                this.PeekToken(peekIndex + 2).Kind == SyntaxKind.OpenParenToken &&
+                IsFeatureEnabled(MessageID.IDS_FeaturePartialEventsAndConstructors);
+        }
+
         private bool IsPartialMember()
         {
             Debug.Assert(this.CurrentToken.ContextualKind == SyntaxKind.PartialKeyword);
@@ -1710,10 +1718,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
             // Check for constructor:
             //   partial Identifier(
-            if (this.PeekToken(1).Kind == SyntaxKind.IdentifierToken &&
-                this.PeekToken(2).Kind == SyntaxKind.OpenParenToken)
+            if (this.IsPartialConstructor(peekIndex: 0))
             {
-                return IsFeatureEnabled(MessageID.IDS_FeaturePartialEventsAndConstructors);
+                return true;
             }
 
             // Check for method/property:

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1699,6 +1699,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
         private bool IsPartialConstructor(int peekIndex)
         {
+            return this.PeekToken(peekIndex).ContextualKind == SyntaxKind.PartialKeyword &&
+                this.IsPartialConstructorName(peekIndex + 1);
+        }
+
+        private bool IsPartialConstructorName(int peekIndex)
+        {
             return this.PeekToken(peekIndex).Kind == SyntaxKind.IdentifierToken &&
                 this.PeekToken(peekIndex + 1).Kind == SyntaxKind.OpenParenToken &&
                 IsFeatureEnabled(MessageID.IDS_FeaturePartialEventsAndConstructors);
@@ -1717,7 +1723,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
             // Check for constructor:
             //   partial Identifier(
-            if (this.IsPartialConstructor(peekIndex: 1))
+            if (this.IsPartialConstructor(peekIndex: 0))
             {
                 return true;
             }

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1699,9 +1699,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
         private bool IsPartialConstructor(int peekIndex)
         {
-            return this.PeekToken(peekIndex).ContextualKind == SyntaxKind.PartialKeyword &&
-                this.PeekToken(peekIndex + 1).Kind == SyntaxKind.IdentifierToken &&
-                this.PeekToken(peekIndex + 2).Kind == SyntaxKind.OpenParenToken &&
+            return this.PeekToken(peekIndex).Kind == SyntaxKind.IdentifierToken &&
+                this.PeekToken(peekIndex + 1).Kind == SyntaxKind.OpenParenToken &&
                 IsFeatureEnabled(MessageID.IDS_FeaturePartialEventsAndConstructors);
         }
 
@@ -1718,7 +1717,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
             // Check for constructor:
             //   partial Identifier(
-            if (this.IsPartialConstructor(peekIndex: 0))
+            if (this.IsPartialConstructor(peekIndex: 1))
             {
                 return true;
             }


### PR DESCRIPTION
## Summary
- centralize recognition of the `partial Identifier(` constructor shape
- keep the language-version check with the shared parser helper
- extract this cleanup from #83216 to make the partial-recovery changes easier to review

## Test plan
- `./eng/common/dotnet.sh build src/Compilers/CSharp/Test/Syntax/Microsoft.CodeAnalysis.CSharp.Syntax.UnitTests.csproj -f net10.0`
- `./eng/common/dotnet.sh test src/Compilers/CSharp/Test/Syntax/Microsoft.CodeAnalysis.CSharp.Syntax.UnitTests.csproj --no-build -f net10.0`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84929)