### PR TITLE
Update helix job monitor version

### DIFF
--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -9,7 +9,7 @@
       "rollForward": false
     },
     "microsoft.dotnet.helix.jobmonitor": {
-      "version": "11.0.0-beta.26412.4",
+      "version": "11.0.0-beta.26414.2",
       "commands": [
         "dotnet-helix-job-monitor"
       ]


### PR DESCRIPTION
To match the one in Version.Details.props. Also should bring in a fix of a bug where tests aren't re-run after re-triggering the Helix Job Monitor leg.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84940)