### PR TITLE
Reduce the set of feeds we are consuming when validating packages

### DIFF
--- a/src/Tools/BuildBoss/CompilerNuGetCheckerUtil.cs
+++ b/src/Tools/BuildBoss/CompilerNuGetCheckerUtil.cs
@@ -13,7 +13,6 @@ using System.Linq;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using System.Security.Cryptography;
-using System.Text.RegularExpressions;
 using Newtonsoft.Json.Linq;
 
 namespace BuildBoss
@@ -97,20 +96,17 @@ namespace BuildBoss
             var publishDataPackages = publishDataRoot["packages"] as JObject;
 
             // Check all shipping packages have an entry in PublishData.json
-            var regex = new Regex(@"^(.*?)\.\d.*\.nupkg$");
             var packagesDirectory = Path.Combine(ArtifactsDirectory, "packages", Configuration, "Shipping");
             foreach (var packageFullPath in Directory.EnumerateFiles(packagesDirectory, "*.nupkg"))
             {
                 var packageFileName = Path.GetFileName(packageFullPath);
-                var match = regex.Match(packageFileName);
-                if (!match.Success)
+                if (!SharedUtil.TryGetNuGetPackageId(packageFullPath, out var packageId))
                 {
                     allGood = false;
                     textWriter.WriteLine($"Unexpected package file name '{packageFileName}'");
                 }
                 else
                 {
-                    var packageId = match.Groups[1].Value;
                     if (!publishDataPackages.ContainsKey(packageId))
                     {
                         allGood = false;

--- a/src/Tools/BuildBoss/PackageInstallCheckerUtil.cs
+++ b/src/Tools/BuildBoss/PackageInstallCheckerUtil.cs
@@ -139,15 +139,10 @@ namespace BuildBoss
         private static bool RunDotnetAndReport(TextWriter textWriter, string description, string arguments, string workingDirectory)
         {
             var result = ProcessUtil.Run("dotnet", arguments, workingDirectory);
-            if (result.Succeeded)
-            {
-                return true;
-            }
-
-            textWriter.WriteLine($"{description}: 'dotnet {arguments}' failed with exit code {result.ExitCode}");
+            textWriter.WriteLine($"{description}: 'dotnet {arguments}' exited with code {result.ExitCode}");
             textWriter.WriteLine(result.Output);
 
-            return false;
+            return result.Succeeded;
         }
 
         /// <summary>

--- a/src/Tools/BuildBoss/PackageInstallCheckerUtil.cs
+++ b/src/Tools/BuildBoss/PackageInstallCheckerUtil.cs
@@ -55,13 +55,11 @@ namespace BuildBoss
 }"),
         };
 
-        internal string RepositoryDirectory { get; }
         internal string ArtifactsDirectory { get; }
         internal string Configuration { get; }
 
-        internal PackageInstallChecker(string repositoryDirectory, string artifactsDirectory, string configuration)
+        internal PackageInstallChecker(string artifactsDirectory, string configuration)
         {
-            RepositoryDirectory = repositoryDirectory;
             ArtifactsDirectory = artifactsDirectory;
             Configuration = configuration;
         }
@@ -182,24 +180,12 @@ namespace BuildBoss
         }
 
         /// <summary>
-        /// Builds a NuGet.config exposing the just built packages alongside the repository's own feeds.
-        /// The local feed supplies our packages and their Roslyn dependencies; the repository feeds
-        /// supply third party dependencies such as Microsoft.Build.Framework.
+        /// Builds a NuGet.config exposing the just built packages alongside the nuget.org mirror.
+        /// The local feed supplies our packages and their Roslyn dependencies; the mirror supplies
+        /// third party dependencies such as Microsoft.Build.Framework.
         /// </summary>
-        private string GenerateNuGetConfig(string packagesDirectory, string globalPackagesDirectory)
+        private static string GenerateNuGetConfig(string packagesDirectory, string globalPackagesDirectory)
         {
-            var sources = new List<XElement>
-            {
-                new XElement("add", new XAttribute("key", "package-install-validation-local"), new XAttribute("value", packagesDirectory))
-            };
-
-            var repositoryConfigPath = Path.Combine(RepositoryDirectory, "NuGet.config");
-            var repositoryConfig = XDocument.Load(repositoryConfigPath);
-            foreach (var element in repositoryConfig.Root.Element("packageSources").Elements("add"))
-            {
-                sources.Add(new XElement(element));
-            }
-
             var document = new XDocument(
                 new XElement("configuration",
                     // A dedicated packages folder, wiped with the scratch directory, keeps this honest.
@@ -209,11 +195,42 @@ namespace BuildBoss
                         new XElement("add", new XAttribute("key", "globalPackagesFolder"), new XAttribute("value", globalPackagesDirectory))),
                     new XElement("packageSources",
                         new XElement("clear"),
-                        sources),
+                        new XElement("add", new XAttribute("key", "package-install-validation-local"), new XAttribute("value", packagesDirectory)),
+                        new XElement("add",
+                            new XAttribute("key", "dotnet-public"),
+                            new XAttribute("value", "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json"))),
+                    new XElement("packageSourceMapping",
+                        new XElement("packageSource",
+                            new XAttribute("key", "package-install-validation-local"),
+                            GetLocalPackageMappings(packagesDirectory)),
+                        new XElement("packageSource",
+                            new XAttribute("key", "dotnet-public"),
+                            new XElement("package", new XAttribute("pattern", "*")))),
                     new XElement("disabledPackageSources",
                         new XElement("clear"))));
 
             return document.ToString();
+        }
+
+        private static IEnumerable<XElement> GetLocalPackageMappings(string packagesDirectory)
+        {
+            foreach (var packagePath in Directory.EnumerateFiles(packagesDirectory, "*.nupkg"))
+            {
+                var packageFileName = Path.GetFileName(packagePath);
+                if (!SharedUtil.TryGetNuGetPackageId(packagePath, out var packageId))
+                {
+                    throw new Exception($"Unexpected package file name '{packageFileName}'");
+                }
+
+                // The product packages intentionally depend on an older published analyzer package,
+                // not the analyzer package produced by the current build.
+                if (packageId == "Microsoft.CodeAnalysis.Analyzers")
+                {
+                    continue;
+                }
+
+                yield return new XElement("package", new XAttribute("pattern", packageId));
+            }
         }
 
         private static string GenerateProjectFile(string targetFramework) =>

--- a/src/Tools/BuildBoss/Program.cs
+++ b/src/Tools/BuildBoss/Program.cs
@@ -101,22 +101,32 @@ namespace BuildBoss
         private static bool Go(string repositoryDirectory, string configuration, string primarySolution, List<string> solutionFileNames, bool checkPackageInstall)
         {
             var allGood = true;
-            foreach (var solutionFileName in solutionFileNames)
+            var artifactsDirectory = Path.Combine(repositoryDirectory, "artifacts");
+            var logDirectory = Path.Combine(artifactsDirectory, "log", configuration, "BuildBoss");
+            if (Directory.Exists(logDirectory))
             {
-                allGood &= ProcessSolution(Path.Combine(repositoryDirectory, solutionFileName), isPrimarySolution: solutionFileName == primarySolution);
+                Directory.Delete(logDirectory, recursive: true);
             }
 
-            var artifactsDirectory = Path.Combine(repositoryDirectory, "artifacts");
+            Directory.CreateDirectory(logDirectory);
 
-            allGood &= ProcessGeneratedFiles(repositoryDirectory);
-            allGood &= ProcessTargets(repositoryDirectory);
-            allGood &= ProcessPackages(repositoryDirectory, artifactsDirectory, configuration);
-            allGood &= ProcessStructuredLog(artifactsDirectory, configuration);
-            allGood &= ProcessOptProf(repositoryDirectory, artifactsDirectory, configuration);
+            foreach (var solutionFileName in solutionFileNames)
+            {
+                allGood &= ProcessSolution(
+                    Path.Combine(repositoryDirectory, solutionFileName),
+                    solutionFileName == primarySolution,
+                    Path.Combine(logDirectory, $"Solution-{Path.GetFileName(solutionFileName)}.log"));
+            }
+
+            allGood &= ProcessGeneratedFiles(repositoryDirectory, Path.Combine(logDirectory, "GeneratedFiles.log"));
+            allGood &= ProcessTargets(repositoryDirectory, Path.Combine(logDirectory, "Targets.log"));
+            allGood &= ProcessPackages(repositoryDirectory, artifactsDirectory, configuration, Path.Combine(logDirectory, "PackageContents.log"));
+            allGood &= ProcessStructuredLog(artifactsDirectory, configuration, Path.Combine(logDirectory, "StructuredLog.log"));
+            allGood &= ProcessOptProf(repositoryDirectory, artifactsDirectory, configuration, Path.Combine(logDirectory, "OptProf.log"));
 
             if (checkPackageInstall)
             {
-                allGood &= ProcessPackageInstall(artifactsDirectory, configuration);
+                allGood &= ProcessPackageInstall(artifactsDirectory, configuration, Path.Combine(logDirectory, "PackageInstall.log"));
             }
 
             if (!allGood)
@@ -127,11 +137,21 @@ namespace BuildBoss
             return allGood;
         }
 
-        private static bool CheckCore(ICheckerUtil util, string title)
+        private static bool CheckCore(ICheckerUtil util, string title, string logFilePath)
         {
             Console.Write($"Processing {title} ... ");
             var textWriter = new StringWriter();
-            if (util.Check(textWriter))
+            var succeeded = util.Check(textWriter);
+            var output = textWriter.ToString();
+
+            using (var logWriter = new StreamWriter(logFilePath, append: false, SharedUtil.Encoding))
+            {
+                logWriter.WriteLine($"Check: {title}");
+                logWriter.WriteLine($"Result: {(succeeded ? "passed" : "FAILED")}");
+                logWriter.Write(output);
+            }
+
+            if (succeeded)
             {
                 Console.WriteLine("passed");
                 return true;
@@ -139,53 +159,53 @@ namespace BuildBoss
             else
             {
                 Console.WriteLine("FAILED");
-                Console.WriteLine(textWriter.ToString());
+                Console.WriteLine(output);
                 return false;
             }
         }
 
-        private static bool ProcessSolution(string solutionFilePath, bool isPrimarySolution)
+        private static bool ProcessSolution(string solutionFilePath, bool isPrimarySolution, string logFilePath)
         {
             var util = new SolutionCheckerUtil(solutionFilePath, isPrimarySolution);
-            return CheckCore(util, $"Solution {solutionFilePath}");
+            return CheckCore(util, $"Solution {solutionFilePath}", logFilePath);
         }
 
-        private static bool ProcessGeneratedFiles(string repositoryDirectory)
+        private static bool ProcessGeneratedFiles(string repositoryDirectory, string logFilePath)
         {
             var checker = new GeneratedFilesCheckerUtil(repositoryDirectory);
-            return CheckCore(checker, $"Generated files {repositoryDirectory}");
+            return CheckCore(checker, $"Generated files {repositoryDirectory}", logFilePath);
         }
 
-        private static bool ProcessTargets(string repositoryDirectory)
+        private static bool ProcessTargets(string repositoryDirectory, string logFilePath)
         {
             var targetsDirectory = Path.Combine(repositoryDirectory, @"eng\targets");
             var checker = new TargetsCheckerUtil(targetsDirectory);
-            return CheckCore(checker, $"Targets {targetsDirectory}");
+            return CheckCore(checker, $"Targets {targetsDirectory}", logFilePath);
         }
 
-        private static bool ProcessStructuredLog(string artifactsDirectory, string configuration)
+        private static bool ProcessStructuredLog(string artifactsDirectory, string configuration, string checkLogFilePath)
         {
-            var logFilePath = Path.Combine(artifactsDirectory, $@"log\{configuration}\Build.binlog");
-            var util = new StructuredLoggerCheckerUtil(logFilePath);
-            return CheckCore(util, $"Structured log {logFilePath}");
+            var binaryLogFilePath = Path.Combine(artifactsDirectory, $@"log\{configuration}\Build.binlog");
+            var util = new StructuredLoggerCheckerUtil(binaryLogFilePath);
+            return CheckCore(util, $"Structured log {binaryLogFilePath}", checkLogFilePath);
         }
 
-        private static bool ProcessPackages(string repositoryDirectory, string artifactsDirectory, string configuration)
+        private static bool ProcessPackages(string repositoryDirectory, string artifactsDirectory, string configuration, string logFilePath)
         {
             var util = new PackageContentsChecker(repositoryDirectory, artifactsDirectory, configuration);
-            return CheckCore(util, $"NuPkg and VSIX files");
+            return CheckCore(util, $"NuPkg and VSIX files", logFilePath);
         }
 
-        private static bool ProcessOptProf(string repositoryDirectory, string artifactsDirectory, string configuration)
+        private static bool ProcessOptProf(string repositoryDirectory, string artifactsDirectory, string configuration, string logFilePath)
         {
             var util = new OptProfCheckerUtil(repositoryDirectory, artifactsDirectory, configuration);
-            return CheckCore(util, $"OptProf inputs");
+            return CheckCore(util, $"OptProf inputs", logFilePath);
         }
 
-        private static bool ProcessPackageInstall(string artifactsDirectory, string configuration)
+        private static bool ProcessPackageInstall(string artifactsDirectory, string configuration, string logFilePath)
         {
             var util = new PackageInstallChecker(artifactsDirectory, configuration);
-            return CheckCore(util, "NuGet package install");
+            return CheckCore(util, "NuGet package install", logFilePath);
         }
     }
 }

--- a/src/Tools/BuildBoss/Program.cs
+++ b/src/Tools/BuildBoss/Program.cs
@@ -116,7 +116,7 @@ namespace BuildBoss
 
             if (checkPackageInstall)
             {
-                allGood &= ProcessPackageInstall(repositoryDirectory, artifactsDirectory, configuration);
+                allGood &= ProcessPackageInstall(artifactsDirectory, configuration);
             }
 
             if (!allGood)
@@ -182,9 +182,9 @@ namespace BuildBoss
             return CheckCore(util, $"OptProf inputs");
         }
 
-        private static bool ProcessPackageInstall(string repositoryDirectory, string artifactsDirectory, string configuration)
+        private static bool ProcessPackageInstall(string artifactsDirectory, string configuration)
         {
-            var util = new PackageInstallChecker(repositoryDirectory, artifactsDirectory, configuration);
+            var util = new PackageInstallChecker(artifactsDirectory, configuration);
             return CheckCore(util, "NuGet package install");
         }
     }

--- a/src/Tools/BuildBoss/README.md
+++ b/src/Tools/BuildBoss/README.md
@@ -10,6 +10,8 @@ This tool is run on every CI job against our important solution files: [Roslyn.s
 
 Violations reported are important to fix as they represent correctness issues in our build.  Many of the properties verified represent problems that otherwise won't be verified at check in time.
 
+Each check writes a log to `artifacts/log/<configuration>/BuildBoss`.  CI publishes these with the job logs.
+
 ## Options
 
 Most checks run unconditionally.  One check is opt in:

--- a/src/Tools/BuildBoss/SharedUtil.cs
+++ b/src/Tools/BuildBoss/SharedUtil.cs
@@ -26,6 +26,13 @@ namespace BuildBoss
         internal static bool IsTargetsFile(string path) => Path.GetExtension(path) == ".targets";
         internal static bool IsXslt(string path) => Path.GetExtension(path) == ".xslt";
 
+        internal static bool TryGetNuGetPackageId(string packageFilePath, out string packageId)
+        {
+            var match = Regex.Match(Path.GetFileName(packageFilePath), @"^(.*?)\.\d.*\.nupkg$");
+            packageId = match.Success ? match.Groups[1].Value : null;
+            return match.Success;
+        }
+
         /// <summary>
         /// Finds the single NuPkg in <paramref name="directory"/> whose file name begins with
         /// <paramref name="partialName"/> followed by a version.


### PR DESCRIPTION
The logic was previously copying nuget.config from our repository root, but this means we can accidentally pick up packages that won't get published to nuget.org. This restricts the feed list further, and adds packageSourceMappings to hopefully ensure we only restore from where we thought we were restoring from.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84948)