### PR TITLE
Ensure queue shutdown doesn't cause double shutdown

### DIFF
--- a/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework.UnitTests/RequestExecutionQueueTests.cs
+++ b/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework.UnitTests/RequestExecutionQueueTests.cs
@@ -28,7 +28,7 @@ public sealed class RequestExecutionQueueTests
         protected override ILspServices ConstructLspServices() => RequestExecutionQueueTests.GetLspServices();
     }
 
-    private static RequestExecutionQueue<TestRequestContext> GetRequestExecutionQueue(
+    private static TestRequestExecutionQueue GetRequestExecutionQueue(
         bool cancelInProgressWorkUponMutatingRequest,
         params (RequestHandlerMetadata metadata, IMethodHandler handler)[] handlers)
     {
@@ -155,16 +155,36 @@ public sealed class RequestExecutionQueueTests
         Assert.True(task2.IsCompleted);
     }
 
+    [Fact]
+    public async Task Queue_CompletionDoesNotShutdownServer()
+    {
+        var requestExecutionQueue = GetRequestExecutionQueue(false, (TestMethodHandler.Metadata, TestMethodHandler.Instance));
+        var lspServices = GetLspServices();
+
+        await requestExecutionQueue.ExecuteAsync(JsonSerializer.SerializeToElement(new MockRequest(1)), TestMethodHandler.Name, lspServices, CancellationToken.None);
+
+        requestExecutionQueue.Complete();
+        await requestExecutionQueue.GetTestAccessor().WaitForProcessingToStopAsync();
+
+        Assert.False(requestExecutionQueue.LanguageServer.GetTestAccessor().HasShutdownStarted());
+    }
+
     private sealed class TestRequestExecutionQueue : RequestExecutionQueue<TestRequestContext>
     {
         private readonly bool _cancelInProgressWorkUponMutatingRequest;
 
-        public TestRequestExecutionQueue(AbstractLanguageServer<TestRequestContext> languageServer, AbstractHandlerProvider handlerProvider, bool cancelInProgressWorkUponMutatingRequest)
+        public TestRequestExecutionQueue(MockServer languageServer, AbstractHandlerProvider handlerProvider, bool cancelInProgressWorkUponMutatingRequest)
             : base(languageServer, handlerProvider)
         {
             _cancelInProgressWorkUponMutatingRequest = cancelInProgressWorkUponMutatingRequest;
+            LanguageServer = languageServer;
         }
 
+        public MockServer LanguageServer { get; }
+
         protected override bool CancelInProgressWorkUponMutatingRequest => _cancelInProgressWorkUponMutatingRequest;
+
+        public void Complete()
+            => _queue.Complete();
     }
 }

--- a/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/RequestExecutionQueue.cs
+++ b/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/RequestExecutionQueue.cs
@@ -213,9 +213,9 @@ internal class RequestExecutionQueue<TRequestContext> : IRequestExecutionQueue<T
                 {
                     queueItem = await _queue.DequeueAsync(_cancelSource.Token).ConfigureAwait(false);
                 }
-                catch (OperationCanceledException ex) when (ex.CancellationToken == _cancelSource.Token)
+                catch (OperationCanceledException) when (_cancelSource.IsCancellationRequested || _queue.IsCompleted)
                 {
-                    // The queue's cancellation token was invoked which means we are shutting down the queue.
+                    // The queue was cancelled or completed which means we are shutting down the queue.
                     // Exit out of the loop so we stop processing new items.
                     return;
                 }


### PR DESCRIPTION
When the LSP server shutsdown, it completes the queue.  For items already in the queue, calling `Dequeue` on them would throw an `OperationCanceledExcpetion`.  We tried to handle this exception with `when (ex.CancellationToken == _cancelSource.Token)`, but the `OperationCanceledException`'s token is not always the `_cancelSource.Token` (the queue impl doesn't propagate it on `AsyncQueue.Complete`). 

This would cause the queue to attempt another shutdown (unexpected exception in the queue processing loop).  The server does generally handle this (shutdown is idempotent on the server) - but it could cause clients to get a `ConnectionLostException` if the queue triggers `Exit` before the client sends the `Exit` notification. 

The fix is to catch OperationCanceledException when the queue is shutting down.

Resolves some of the failures described in https://github.com/dotnet/roslyn/issues/84828
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84949)