### PR TITLE
Fix rename conflict for source generated partial members

### DIFF
--- a/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
+++ b/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
@@ -2473,6 +2473,61 @@ class [|C|]
 
         <WpfTheory>
         <CombinatorialData, Trait(Traits.Feature, Traits.Features.Rename)>
+        <WorkItem("https://github.com/dotnet/roslyn/issues/84906")>
+        Public Async Function RenameTypeContainingSourceGeneratedPartialProperty(host As RenameTestHost) As Task
+            Using workspace = CreateWorkspaceWithWaiter(
+                    <Workspace>
+                        <Project Language="C#" CommonReferencesNet9="true" LanguageVersion="preview">
+                            <Document>
+                                using System.Text.RegularExpressions;
+
+                                partial class [|$$MyClass|]
+                                {
+                                    [GeneratedRegex(@"\w")]
+                                    private static partial Regex HelperRegex { get; }
+                                }
+                            </Document>
+                            <DocumentFromSourceGenerator>
+                                partial class MyClass
+                                {
+                                    private static partial global::System.Text.RegularExpressions.Regex HelperRegex =>
+                                        global::System.Text.RegularExpressions.Generated.HelperRegex_0.Instance;
+                                }
+
+                                namespace System.Text.RegularExpressions.Generated
+                                {
+                                    file sealed class HelperRegex_0 : Regex
+                                    {
+                                        internal static readonly HelperRegex_0 Instance = new();
+                                    }
+                                }
+                            </DocumentFromSourceGenerator>
+                        </Project>
+                    </Workspace>, host)
+
+                Dim session = StartSession(workspace)
+                Dim caretPosition = workspace.Documents.Single(Function(d) d.CursorPosition.HasValue).CursorPosition.Value
+
+                Using viewModel = New RenameFlyoutViewModel(
+                        session,
+                        New TextSpan(caretPosition, "MyClass".Length),
+                        registerOleComponent:=False,
+                        workspace.GetService(Of IGlobalOptionService)(),
+                        workspace.GetService(Of IThreadingContext)(),
+                        workspace.GetService(Of IAsynchronousOperationListenerProvider)(),
+                        smartRenameSessionFactory:=Nothing)
+
+                    session.ApplyReplacementText("NewClass", propagateEditImmediately:=True)
+                    Await WaitForRename(workspace)
+
+                    Assert.Equal(RenameFlyoutViewModel.Severity.None, viewModel.StatusSeverity)
+                    session.Cancel()
+                End Using
+            End Using
+        End Function
+
+        <WpfTheory>
+        <CombinatorialData, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Async Function RenameWithRazorGeneratedFile(host As RenameTestHost) As Task
             Dim generatedCode = "
 public class GeneratedClass

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.Session.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.Session.cs
@@ -559,7 +559,7 @@ internal static partial class ConflictResolver
                     var symbolIndex = 0;
                     foreach (var symbol in newReferencedSymbols)
                     {
-                        if (conflictAnnotation.RenameDeclarationLocationReferences[symbolIndex].SymbolLocationsCount != symbol.Locations.Length)
+                        if (conflictAnnotation.RenameDeclarationLocationReferences[symbolIndex].SymbolLocationsCount != GetRelevantSymbolLocations(solution, symbol).Length)
                         {
                             hasConflict = true;
                             break;

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolver.cs
@@ -347,7 +347,7 @@ internal static partial class ConflictResolver
         var symbolIndex = 0;
         foreach (var symbol in symbols)
         {
-            var locations = symbol.Locations;
+            var locations = GetRelevantSymbolLocations(solution, symbol);
             var overriddenFromMetadata = false;
 
             if (symbol.IsOverride)
@@ -402,17 +402,30 @@ internal static partial class ConflictResolver
     /// </summary>
     private static async ValueTask<Location?> GetSymbolLocationAsync(Solution solution, ISymbol symbol, CancellationToken cancellationToken)
     {
-        var locations = symbol.Locations;
+        var locations = GetRelevantSymbolLocations(solution, symbol);
 
         var originalsourcesymbol = await SymbolFinder.FindSourceDefinitionAsync(symbol, solution, cancellationToken).ConfigureAwait(false);
         if (originalsourcesymbol != null)
-            locations = originalsourcesymbol.Locations;
+            locations = GetRelevantSymbolLocations(solution, originalsourcesymbol);
 
         var orderedLocations = locations
             .OrderBy(l => l.IsInSource ? solution.GetDocumentId(l.SourceTree)!.Id : Guid.Empty)
             .ThenBy(l => l.IsInSource ? l.SourceSpan.Start : int.MaxValue);
 
         return orderedLocations.FirstOrDefault();
+    }
+
+    // Ordinary source-generated declarations are regenerated after rename and may be temporarily stale during
+    // conflict analysis. Razor-generated declarations remain relevant because rename can map and edit them.
+    private static ImmutableArray<Location> GetRelevantSymbolLocations(Solution solution, ISymbol symbol)
+    {
+        var locations = symbol.Locations;
+        var relevantLocations = locations.WhereAsArray(location =>
+            !location.IsInSource ||
+            solution.GetDocument(location.SourceTree) is not SourceGeneratedDocument sourceGeneratedDocument ||
+            sourceGeneratedDocument.IsRazorSourceGeneratedDocument());
+
+        return relevantLocations.IsEmpty ? locations : relevantLocations;
     }
 
     private static bool HeuristicMetadataNameEquivalenceCheck(


### PR DESCRIPTION
Fixes: #84906

Ignore stale generated locations when comparing mixed source/generated symbols during rename, while preserving generated-only and Razor locations
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84951)