### PR TITLE
Move insertion PR tagger pipeline

### DIFF
--- a/.github/memory/FILE_MAP.md
+++ b/.github/memory/FILE_MAP.md
@@ -33,6 +33,6 @@ This file is a **top-level map only**. For per-area directory detail, read the m
 
 | Path | Status | Purpose |
 |------|--------|---------|
-| `eng/` | Config / Generated | Arcade build engineering. `eng/common/` is DARC-synced — do not hand-edit. `eng/generate-compiler-code.cs` regenerates compiler code. |
+| `eng/` | Config / Generated | Arcade build engineering. Pipeline definitions and templates live in `eng/pipelines/`; `eng/common/` is DARC-synced and must not be hand-edited. `eng/generate-compiler-code.cs` regenerates compiler code. |
 | `docs/` | Active | Contributor & design docs. New docs use kebab-case filenames in the right subdirectory. |
 | Root | Config | Entry points & solution filters: `build.sh`/`Build.cmd`, `test.sh`/`Test.cmd`, `Roslyn.slnx`, `Compilers.slnf`, `Ide.slnf`, `Razor.slnf`, `global.json`, `Directory.*.props/targets`, `Directory.Packages.props`. |

--- a/eng/pipelines/insertion-pr-tagger.yml
+++ b/eng/pipelines/insertion-pr-tagger.yml
@@ -70,6 +70,7 @@ extends:
                 "--github-token", $Env:GitHubToken
                 "--devdiv-azdo-token", $azdoToken
                 "--dnceng-azdo-token", $azdoToken
+                "--ci"
               )
 
               & dnx @arguments

--- a/eng/pipelines/insertion-pr-tagger.yml
+++ b/eng/pipelines/insertion-pr-tagger.yml
@@ -1,0 +1,76 @@
+schedules:
+- cron: "0 */12 * * *"
+  displayName: Roslyn Tagger Tool
+  branches:
+    include:
+    - main
+  always: true
+
+variables:
+- group: roslyn-perf-bot
+
+# Make sure the pipeline doesn't build on commits.
+trigger: none
+
+resources:
+  repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    pool:
+      name: NetCore1ESPool-Svc-Internal
+      image: 1es-ubuntu-2204
+      os: linux
+    sdl:
+      sourceAnalysisPool:
+        name: NetCore1ESPool-Svc-Internal
+        image: 1es-windows-2022
+        os: windows
+    stages:
+    - stage: tagInsertedPullRequest
+      jobs:
+      - job: runPRTagger
+        steps:
+        - checkout: none
+        - task: UseDotNet@2
+          displayName: Install .NET 10 SDK
+          inputs:
+            packageType: sdk
+            version: 10.0.x
+        - task: AzureCLI@2
+          displayName: Run PR Tagger
+          inputs:
+            azureSubscription: 'Roslyn PRTagger: DevDiv'
+            scriptType: pscore
+            scriptLocation: inlineScript
+            inlineScript: |
+              $azdoToken = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv
+              if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($azdoToken)) {
+                Write-Error 'Failed to acquire Azure DevOps access token via WIF.'
+                exit 1
+              }
+
+              if ([string]::IsNullOrWhiteSpace($Env:GitHubToken)) {
+                Write-Error 'The GitHub token is not configured.'
+                exit 1
+              }
+
+              $arguments = @(
+                "Microsoft.RoslynTools"
+                "--prerelease"
+                "--add-source", "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json"
+                "--"
+                "pr-tagger"
+                "--github-token", $Env:GitHubToken
+                "--devdiv-azdo-token", $azdoToken
+                "--dnceng-azdo-token", $azdoToken
+              )
+
+              & dnx @arguments
+          env:
+            GitHubToken: $(roslyn-dotnet-bot-issue-w-pat)

--- a/eng/pipelines/insertion-pr-tagger.yml
+++ b/eng/pipelines/insertion-pr-tagger.yml
@@ -11,6 +11,7 @@ variables:
 
 # Make sure the pipeline doesn't build on commits.
 trigger: none
+pr: none
 
 resources:
   repositories:


### PR DESCRIPTION
This is the last of the roslyn-tools code that was still active. We can move our pipeline over to this yml once merged and archive dotnet/roslyn-tools repo.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84955)