### PR TITLE
[15.9] Update SQLite to 3.53.4

### DIFF
--- a/build/Targets/Packages.props
+++ b/build/Targets/Packages.props
@@ -237,7 +237,7 @@
     <SystemXmlXPathXDocumentVersion>4.3.0</SystemXmlXPathXDocumentVersion>
     <SQLitePCLRawbundle_greenVersion>1.1.2</SQLitePCLRawbundle_greenVersion>
     <SQLitePCLRawlibe_sqlite3Version>$(SQLitePCLRawbundle_greenVersion)</SQLitePCLRawlibe_sqlite3Version>
-    <SourceGearSqlite3Version>3.50.4.5</SourceGearSqlite3Version>
+    <SourceGearSqlite3Version>3.53.4</SourceGearSqlite3Version>
     <UIAComWrapperVersion>1.1.0.14</UIAComWrapperVersion>
     <MicrosoftVSSDKBuildToolsVersion>15.8.68-develop-g109a00ff</MicrosoftVSSDKBuildToolsVersion>
     <VSLangProjVersion>7.0.3300</VSLangProjVersion>


### PR DESCRIPTION
Related: #84964, #84965

Updates the native SQLite payloads used by this release to SourceGear.sqlite3 3.53.4. This keeps the servicing branches on the latest public SourceGear SQLite package.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84963)