### PR TITLE
[16.11] Update SQLite to 3.53.4

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -231,7 +231,7 @@
     <SystemThreadingTasksExtensionsVersion>4.5.4</SystemThreadingTasksExtensionsVersion>
     <SQLitePCLRawbundle_greenVersion>2.0.4</SQLitePCLRawbundle_greenVersion>
     <SQLitePCLRawlibe_sqlite3Version>$(SQLitePCLRawbundle_greenVersion)</SQLitePCLRawlibe_sqlite3Version>
-    <SourceGearSqlite3Version>3.50.4.5</SourceGearSqlite3Version>
+    <SourceGearSqlite3Version>3.53.4</SourceGearSqlite3Version>
     <UIAComWrapperVersion>1.1.0.14</UIAComWrapperVersion>
     <MicrosoftVSSDKBuildToolsVersion>16.8.3036</MicrosoftVSSDKBuildToolsVersion>
     <MicrosoftVSSDKVSDConfigToolVersion>16.0.2032702</MicrosoftVSSDKVSDConfigToolVersion>


### PR DESCRIPTION
Related: #84963, #84965

Updates the native SQLite payloads used by this release to SourceGear.sqlite3 3.53.4. This keeps the servicing branches on the latest public SourceGear SQLite package.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84964)