### PR TITLE
[17.14] Update SQLite to 3.53.4

### DIFF
--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -13,6 +13,7 @@ trigger:
     - release/dev17.8
     - release/dev17.10
     - release/dev17.12
+    - release/dev17.14
 
 # Branches that trigger builds on PR
 pr:
@@ -29,6 +30,7 @@ pr:
     - release/dev17.8
     - release/dev17.10
     - release/dev17.12
+    - release/dev17.14
   paths:
     exclude:
       - docs/*

--- a/eng/Directory.Packages.props
+++ b/eng/Directory.Packages.props
@@ -315,7 +315,7 @@
     <PackageVersion Include="Mono.Options" Version="6.6.0.161" />
     <PackageVersion Include="Roslyn.Diagnostics.Analyzers" Version="$(RoslynDiagnosticsNugetPackageVersion)" />
     <PackageVersion Include="SourceBrowser" Version="1.0.21" />
-    <PackageVersion Include="SourceGear.Sqlite3" Version="3.50.4.5" />
+    <PackageVersion Include="SourceGear.Sqlite3" Version="3.53.4" />
     <PackageVersion Include="RoslynTools.VSIXExpInstaller" Version="1.1.0-beta3.22474.1" />
     <PackageVersion Include="MicroBuildPluginsSwixBuild" Version="1.1.87" />
     <PackageVersion Include="vswhere" Version="$(vswhereVersion)" />


### PR DESCRIPTION
Related: #84963, #84964

Updates the native SQLite payloads used by this release to SourceGear.sqlite3 3.53.4. The 17.14 integration pipeline uses a moving Visual Studio image that no longer matches this servicing branch, so it is excluded using the existing servicing-branch policy.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84965)