### PR TITLE
Install .NET 10 SDK for VS insertion

### DIFF
--- a/.github/memory/CONVENTIONS.md
+++ b/.github/memory/CONVENTIONS.md
@@ -62,7 +62,7 @@ var symbolInfo = semanticModel.GetSymbolInfo(expression, cancellationToken);
 
 ## Language / Framework Constraints
 
-- SDK pinned in `global.json` (currently .NET SDK `10.0.x`); VS toolset `17.14`.
+- SDK and VS toolset pinned in `global.json`.
 - Arcade-based build (`Microsoft.DotNet.Arcade.Sdk`); package versions centralized in `Directory.Packages.props`.
 
 ## Documentation Files

--- a/eng/pipelines/insert.yml
+++ b/eng/pipelines/insert.yml
@@ -55,6 +55,12 @@ parameters:
 steps:
   - checkout: none
 
+  - task: UseDotNet@2
+    displayName: 'Install .NET 10 SDK'
+    inputs:
+      packageType: sdk
+      version: 10.0.x
+
   - download: current
     artifact: PackageArtifacts
     displayName: 'Download package artifacts'


### PR DESCRIPTION
## Summary

- install the .NET 10 SDK before installing `Microsoft.RoslynTools` in the VS insertion stage
- avoid relying on the insertion pool's default .NET 9 SDK
- keep SDK and VS version documentation tied to `global.json` without duplicating version values

## Validation

- `git diff --check`
- confirmed failing PR-validation logs used SDK 9.0.317 to install a `net10.0` tool
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84967)