### PR TITLE
Restrict case-sensitive metadata cache test to Linux

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/HostWorkspace/SharedMetadataReferenceCacheTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/HostWorkspace/SharedMetadataReferenceCacheTests.cs
@@ -192,8 +192,8 @@ public sealed class SharedMetadataReferenceCacheTests : TestBase
         Assert.NotSame(assemblyReference.GetMetadataId(), moduleReference.GetMetadataId());
     }
 
-    [ConditionalFact(typeof(UnixLikeOnly))]
-    public void PathsDifferingOnlyByCase_DoNotShareReferenceOnUnix()
+    [ConditionalFact(typeof(LinuxOnly))]
+    public void PathsDifferingOnlyByCase_DoNotShareReferenceOnCaseSensitiveFileSystem()
     {
         var cache = new SharedMetadataReferenceCache();
         var directory = Temp.CreateDirectory();


### PR DESCRIPTION
## Summary

- run `PathsDifferingOnlyByCase_DoNotShareReferenceOnCaseSensitiveFileSystem` only on Linux
- avoid creating case-only duplicate filenames on default case-insensitive macOS filesystems
- rename the test to describe its filesystem requirement

This addresses the recurring macOS `IOException` in `roslyn-CI`, where creating `reference.dll` and `REFERENCE.dll` resolves to the same file.

## Validation

`dotnet test src\LanguageServer\Microsoft.CodeAnalysis.LanguageServer.UnitTests\Microsoft.CodeAnalysis.LanguageServer.UnitTests.csproj --filter "FullyQualifiedName~PathsDifferingOnlyByCase_DoNotShareReferenceOnCaseSensitiveFileSystem" --no-restore --nologo`

The test project built successfully and the test was skipped as expected on Windows.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84969)