### PR TITLE
Tolerate MSBuildWorkspace diagnostic warnings

### DIFF
--- a/src/Workspaces/MSBuild/Test/NetCoreTests.cs
+++ b/src/Workspaces/MSBuild/Test/NetCoreTests.cs
@@ -750,14 +750,10 @@ public sealed class NetCoreTests : MSBuildWorkspaceTestBase
         workspace.AssociateFileExtensionWithLanguage("cs", LanguageNames.CSharp);
         await workspace.OpenProjectAsync(sourceFilePath);
 
-        Assert.Collection(workspace.Diagnostics,
-            d =>
-            {
-                // [Failure] Msbuild failed when processing the file 'Program.cs' with message:
-                // The project file could not be loaded. Data at the root level is invalid. Line 1, position 1.
-                Assert.Equal(WorkspaceDiagnosticKind.Failure, d.Kind);
-                Assert.Contains("Program.cs", d.Message);
-            });
+        // [Failure] Msbuild failed when processing the file 'Program.cs' with message:
+        // The project file could not be loaded. Data at the root level is invalid. Line 1, position 1.
+        var diagnostic = Assert.Single(workspace.Diagnostics.Where(d => d.Kind == WorkspaceDiagnosticKind.Failure));
+        Assert.Contains("Program.cs", diagnostic.Message);
     }
 
     [ConditionalFact(typeof(DotNetSdkMSBuildInstalled))]

--- a/src/Workspaces/MSBuild/Test/NetCoreTests.cs
+++ b/src/Workspaces/MSBuild/Test/NetCoreTests.cs
@@ -752,7 +752,7 @@ public sealed class NetCoreTests : MSBuildWorkspaceTestBase
 
         // [Failure] Msbuild failed when processing the file 'Program.cs' with message:
         // The project file could not be loaded. Data at the root level is invalid. Line 1, position 1.
-        var diagnostic = Assert.Single(workspace.Diagnostics.Where(d => d.Kind == WorkspaceDiagnosticKind.Failure));
+        var diagnostic = Assert.Single(workspace.Diagnostics, d => d.Kind == WorkspaceDiagnosticKind.Failure);
         Assert.Contains("Program.cs", diagnostic.Message);
     }
 


### PR DESCRIPTION
## Summary

- tolerate environment-specific MSBuild workspace warnings in the file-based app test
- continue requiring exactly one failure diagnostic that mentions `Program.cs`

## Testing

- `dotnet test src\Workspaces\MSBuild\Test\Microsoft.CodeAnalysis.Workspaces.MSBuild.UnitTests.csproj --filter FullyQualifiedName~NetCoreTests.TestOpenProject_FileBasedApp_AssociateFileExtensionWithLanguage`

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84971)