### PR TITLE
Fix Razor utilities ReadyToRun publishing

### DIFF
--- a/.github/memory/known-issues/razor.md
+++ b/.github/memory/known-issues/razor.md
@@ -63,3 +63,16 @@ BenchmarkDotNet parses the command line and configures exactly one Dry job. For
 Razor benchmarks that reference the Roslyn project graph, use
 `InProcessNoEmitToolchain` for that validation job so BenchmarkDotNet does not
 generate and build a second project graph.
+
+## ReadyToRun VSIX payloads must enter the publish graph before post-processing
+
+**Affected area:** `Microsoft.CodeAnalysis.Remote.Razor` payloads consumed by the
+CoreComponents VSIX projects
+**Description:** A project reference with `ReferenceOutputAssembly=false` does
+not automatically contribute its output to `ResolvedFileToPublish`. Synthesizing
+the referenced project's RID-specific `publish` path is also unreliable because
+the project may be built without being independently published.
+**Workaround:** Add compile-invisible payloads to `ResolvedFileToPublish` before
+`ComputeResolvedFilesToPublishList`. Set `PostprocessAssembly=true` on managed
+assemblies so ReadyToRun replaces them with the RID-specific output, and preserve
+`RecursiveDir` in satellite-resource `RelativePath` metadata.

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Microsoft.CodeAnalysis.Remote.Razor.csproj
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Microsoft.CodeAnalysis.Remote.Razor.csproj
@@ -101,8 +101,6 @@
       <_PublishedFiles Include="$(PublishDir)**\Microsoft.CodeAnalysis.Razor.*" />
       <_PublishedFiles Include="$(PublishDir)**\Microsoft.CodeAnalysis.Remote.Razor.*" Exclude="@(_ExcludedFiles)" />
       <_PublishedFiles Include="$(PublishDir)**\Microsoft.AspNetCore.*" />
-      <_PublishedFiles Include="$(ArtifactsDir)bin\Microsoft.AspNetCore.Razor.Utilities.Shared\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\Microsoft.AspNetCore.Razor.Utilities.Shared.dll" Condition="'$(PublishReadyToRun)' == 'true' and !Exists('$(PublishDir)Microsoft.AspNetCore.Razor.Utilities.Shared.dll')" />
-      <_PublishedFiles Include="$(ArtifactsDir)bin\Microsoft.AspNetCore.Razor.Utilities.Shared\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\**\Microsoft.AspNetCore.Razor.Utilities.Shared.resources.dll" Condition="'$(PublishReadyToRun)' == 'true' and !Exists('$(PublishDir)Microsoft.AspNetCore.Razor.Utilities.Shared.dll')" />
       <_PublishedFiles Include="$(ArtifactsDir)bin\Microsoft.CodeAnalysis.Razor.Compiler\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\Microsoft.CodeAnalysis.Razor.Compiler.dll" Condition="'$(PublishReadyToRun)' == 'true' and !Exists('$(PublishDir)Microsoft.CodeAnalysis.Razor.Compiler.dll')" />
       <_PublishedFiles Include="$(ArtifactsDir)bin\Microsoft.CodeAnalysis.Razor.Workspaces\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\Microsoft.CodeAnalysis.Razor.Workspaces.dll" Condition="'$(PublishReadyToRun)' == 'true' and !Exists('$(PublishDir)Microsoft.CodeAnalysis.Razor.Workspaces.dll')" />
       <_PublishedFiles Include="$(ArtifactsDir)bin\Microsoft.CodeAnalysis.Razor.Workspaces\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\**\Microsoft.CodeAnalysis.Razor.Workspaces.resources.dll" Condition="'$(PublishReadyToRun)' == 'true' and !Exists('$(PublishDir)Microsoft.CodeAnalysis.Razor.Workspaces.dll')" />
@@ -123,6 +121,22 @@
   <Target Name="PublishedProjectOutputGroup" DependsOnTargets="PublishProjectOutputGroup" Returns="@(_PublishedFiles)" />
 
   <Target Name="PublishVsixItems" DependsOnTargets="Publish;PublishedProjectOutputGroup" Returns="@(_PublishedFiles)" />
+
+  <Target Name="AddRazorUtilitiesToPublish"
+          BeforeTargets="ComputeResolvedFilesToPublishList"
+          Condition="'$(TargetFramework)' == 'net10.0' and '$(PublishReadyToRun)' == 'true' and '$(RuntimeIdentifier)' != ''">
+    <ItemGroup>
+      <ResolvedFileToPublish Remove="$(ArtifactsDir)bin\Microsoft.AspNetCore.Razor.Utilities.Shared\$(Configuration)\$(TargetFramework)\Microsoft.AspNetCore.Razor.Utilities.Shared.dll" />
+      <ResolvedFileToPublish Include="$(ArtifactsDir)bin\Microsoft.AspNetCore.Razor.Utilities.Shared\$(Configuration)\$(TargetFramework)\Microsoft.AspNetCore.Razor.Utilities.Shared.dll"
+                             RelativePath="Microsoft.AspNetCore.Razor.Utilities.Shared.dll"
+                             CopyToPublishDirectory="PreserveNewest"
+                             PostprocessAssembly="true" />
+      <_RazorUtilitiesResources Include="$(ArtifactsDir)bin\Microsoft.AspNetCore.Razor.Utilities.Shared\$(Configuration)\$(TargetFramework)\**\Microsoft.AspNetCore.Razor.Utilities.Shared.resources.dll" />
+      <ResolvedFileToPublish Include="@(_RazorUtilitiesResources)"
+                             RelativePath="%(RecursiveDir)%(Filename)%(Extension)"
+                             CopyToPublishDirectory="PreserveNewest" />
+    </ItemGroup>
+  </Target>
 
   <!-- Remote.Razor needs direct Roslyn compile-time references when Remote.ServiceHub is a project reference. -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
@@ -145,10 +159,6 @@
       <Private>true</Private>
     </ProjectReference>
     <ProjectReference Update="..\..\..\Compiler\Microsoft.CodeAnalysis.Razor.Compiler\src\Microsoft.CodeAnalysis.Razor.Compiler.csproj">
-      <Private>true</Private>
-    </ProjectReference>
-    <ProjectReference Update="$(SharedSourceRoot)\Microsoft.AspNetCore.Razor.Utilities.Shared\Microsoft.AspNetCore.Razor.Utilities.Shared.csproj">
-      <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
       <Private>true</Private>
     </ProjectReference>
     <ProjectReference Update="..\..\..\..\..\Workspaces\Remote\ServiceHub\Microsoft.CodeAnalysis.Remote.ServiceHub.csproj">


### PR DESCRIPTION
## Summary

- add the compile-invisible Razor utilities assembly and satellite resources directly to the Remote Razor publish graph
- opt the managed assembly into ReadyToRun post-processing so VSIX packaging consumes the actual RID-specific Remote Razor publish output
- remove fallback paths that assumed the utility project was independently published per RID

This follows up on #84954 and addresses the x64 and arm64 `VSSDK1025` failures in [PR Validation build 15030596](https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=15030596).

## Validation

- `./build.sh --restore --build --solution Razor.slnf --configuration Release --binaryLog --verbosity minimal`
- official ReadyToRun `PublishProjectOutputGroup` for `net10.0` / `osx-arm64`
- confirmed the utility assembly flows through `_ReadyToRunCompileList`, `RunReadyToRunCompiler`, and the Remote Razor publish directory with all satellite resources preserved
[Passing PR Validation Run](https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=15032932)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84973)