### PR TITLE
Bound ProcessHost test client waits

### DIFF
--- a/.github/memory/testing/ide.md
+++ b/.github/memory/testing/ide.md
@@ -35,3 +35,7 @@ public class MyTests
   test source code.
 - Keep tests focused — avoid unnecessary intermediary assertions; use `.Single()`
   rather than asserting a count then indexing.
+- ProcessHost test-client waits use `TestHelpers.HangMitigatingTimeout` so
+  missing project-initialization or shutdown events fail with process-state
+  diagnostics instead of hanging the test leg. Timeout cleanup may terminate
+  processes owned by that client, but must never terminate a shared daemon.

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.ProcessHost.UnitTests/Lifecycle/SingleServerLifecycleTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.ProcessHost.UnitTests/Lifecycle/SingleServerLifecycleTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using Roslyn.Test.Utilities;
 using StreamJsonRpc;
 using StreamJsonRpc.Protocol;
@@ -67,6 +68,38 @@ public sealed class SingleServerLifecycleTests(ITestOutputHelper testOutputHelpe
         Assert.False(serverProcess.HasExited);
 
         await client.ShutdownAndExitAsync();
+    }
+
+    [Theory, CombinatorialData]
+    public async Task ProjectInitializationWaitTimesOut(bool useNamedPipe)
+    {
+        await using var client = await StartAsync(useNamedPipe);
+        var serverProcess = await client.GetServerProcessAsync();
+
+        var exception = await Assert.ThrowsAsync<TimeoutException>(async ()
+            => await client.WaitForProjectInitializationAsync(TimeSpan.Zero));
+
+        Assert.Contains("waiting for project initialization to complete", exception.Message);
+        Assert.Contains($"Thin client process {client.ThinClientProcess.Id} has not exited", exception.Message);
+        Assert.Contains($"Server process {serverProcess.Id} has not exited", exception.Message);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task ShutdownWaitTimesOutAndTerminatesOwnedProcesses(bool useNamedPipe)
+    {
+        await using var client = await StartAsync(useNamedPipe);
+        using var thinClientProcess = Process.GetProcessById(client.ThinClientProcess.Id);
+        using var serverProcess = Process.GetProcessById((await client.GetServerProcessAsync()).Id);
+
+        var exception = await Assert.ThrowsAsync<TimeoutException>(async ()
+            => await client.DisposeAsync(TimeSpan.Zero));
+
+        Assert.Contains("shutting down the test language server", exception.Message);
+        Assert.Contains($"Thin client process {thinClientProcess.Id} has not exited", exception.Message);
+        Assert.Contains($"Server process {serverProcess.Id} has not exited", exception.Message);
+
+        await thinClientProcess.WaitForExitAsync().WaitAsync(TestHelpers.HangMitigatingTimeout);
+        await serverProcess.WaitForExitAsync().WaitAsync(TestHelpers.HangMitigatingTimeout);
     }
 
     [Theory, CombinatorialData]

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.ProcessHost.UnitTests/Utilities/AbstractLanguageServerClientTests.DaemonLspClient.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.ProcessHost.UnitTests/Utilities/AbstractLanguageServerClientTests.DaemonLspClient.cs
@@ -128,6 +128,9 @@ public partial class AbstractLanguageServerClientTests
             CloseEditorTransport();
             await ThinClientProcess.WaitForExitAsync();
         }
+
+        protected override void TerminateOwnedProcesses(Process? serverProcess)
+            => KillIfRunning(ThinClientProcess);
     }
 
     internal sealed class DaemonStdioLspClient : DaemonLspClient

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.ProcessHost.UnitTests/Utilities/AbstractLanguageServerClientTests.TestLspClient.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.ProcessHost.UnitTests/Utilities/AbstractLanguageServerClientTests.TestLspClient.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.LanguageServer.UnitTests;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.Extensions.Logging;
 using Roslyn.LanguageServer.Protocol;
+using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using StreamJsonRpc;
 using LSP = Roslyn.LanguageServer.Protocol;
@@ -392,9 +393,21 @@ public partial class AbstractLanguageServerClientTests
 
         public IList<LSP.Location> GetLocations(string locationName) => _locations[locationName];
 
-        public async Task WaitForProjectInitializationAsync()
+        public async Task WaitForProjectInitializationAsync(TimeSpan? timeout = null)
         {
-            await _projectInitializationCompletedSource.Task;
+            var effectiveTimeout = timeout ?? TestHelpers.HangMitigatingTimeout;
+
+            try
+            {
+                await _projectInitializationCompletedSource.Task.WaitAsync(effectiveTimeout);
+            }
+            catch (TimeoutException exception)
+            {
+                throw new TimeoutException(
+                    $"Timed out after {effectiveTimeout} waiting for project initialization to complete. {GetProcessStatus()}",
+                    exception);
+            }
+
             ProjectInitializationCompleted = true;
         }
 
@@ -412,24 +425,73 @@ public partial class AbstractLanguageServerClientTests
             return LspWorkspaceContent.NormalizePath(relativePath);
         }
 
-        public async ValueTask DisposeAsync()
+        public ValueTask DisposeAsync()
+            => DisposeAsync(TestHelpers.HangMitigatingTimeout);
+
+        internal async ValueTask DisposeAsync(TimeSpan timeout)
         {
             // Ensure only one thing disposes; while we disconnect the process will go away, which will call us to do this again
             if (Interlocked.CompareExchange(ref _disposed, value: 1, comparand: 0) != 0)
                 return;
 
             var logger = _loggerFactory.CreateLogger("Shutdown");
+            Process? serverProcess = null;
 
-            var serverProcess = await GetServerProcessAsync();
-
-            await ShutdownAndWaitForExitAsync(serverProcess);
-
-            _clientRpc.Dispose();
-            _thinClientProcess.Dispose();
-            serverProcess.Dispose();
-            DisposeTransport();
+            try
+            {
+                serverProcess = await GetServerProcessAsync().WaitAsync(timeout);
+                await ShutdownAndWaitForExitAsync(serverProcess).WaitAsync(timeout);
+            }
+            catch (TimeoutException exception)
+            {
+                var processStatus = GetProcessStatus(serverProcess);
+                TerminateOwnedProcesses(serverProcess);
+                throw new TimeoutException($"Timed out after {timeout} shutting down the test language server. {processStatus}", exception);
+            }
+            finally
+            {
+                _clientRpc.Dispose();
+                _thinClientProcess.Dispose();
+                serverProcess?.Dispose();
+                DisposeTransport();
+            }
 
             logger.LogTrace("Process shut down.");
+        }
+
+        protected virtual void TerminateOwnedProcesses(Process? serverProcess)
+        {
+            KillIfRunning(_thinClientProcess);
+
+            if (serverProcess is not null)
+                KillIfRunning(serverProcess);
+        }
+
+        private string GetProcessStatus(Process? serverProcess = null)
+        {
+            var serverStatus = serverProcess is not null
+                ? GetProcessStatus("Server", serverProcess)
+                : _serverProcessTask.IsCompletedSuccessfully
+                    ? GetProcessStatus("Server", _serverProcessTask.Result)
+                    : "Server process is not available.";
+
+            return $"{GetProcessStatus("Thin client", _thinClientProcess)} {serverStatus}";
+        }
+
+        private static string GetProcessStatus(string processName, Process process)
+            => $"{processName} process {process.Id} has{(process.HasExited ? string.Empty : " not")} exited.";
+
+        protected void KillIfRunning(Process process)
+        {
+            try
+            {
+                if (!process.HasExited)
+                    process.Kill(entireProcessTree: true);
+            }
+            catch (InvalidOperationException exception)
+            {
+                _loggerFactory.CreateLogger("Shutdown").LogTrace(exception, "Process {ProcessId} exited before it could be terminated.", process.Id);
+            }
         }
 
         /// <summary>

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.ProcessHost.UnitTests/Utilities/AbstractLanguageServerClientTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.ProcessHost.UnitTests/Utilities/AbstractLanguageServerClientTests.cs
@@ -95,8 +95,23 @@ public abstract partial class AbstractLanguageServerClientTests(ITestOutputHelpe
                     throw new InvalidOperationException($"Unsupported load path extension: {PathUtilities.GetExtension(workspaceContent.LoadPath)}");
             }
 
-            await lspClient.WaitForProjectInitializationAsync();
-            lspClient.ProjectInitializationCompleted = true;
+            try
+            {
+                await lspClient.WaitForProjectInitializationAsync();
+            }
+            catch (TimeoutException initializationException)
+            {
+                try
+                {
+                    await lspClient.DisposeAsync();
+                }
+                catch (TimeoutException shutdownException)
+                {
+                    throw new AggregateException(initializationException, shutdownException);
+                }
+
+                throw;
+            }
         }
 
         return lspClient;


### PR DESCRIPTION
## Summary

- bound ProcessHost project-initialization and shutdown waits with `TestHelpers.HangMitigatingTimeout`
- include thin-client and server process state in timeout failures
- terminate only test-client-owned processes after shutdown timeouts, preserving shared daemons
- add lifecycle coverage for initialization and shutdown timeout behavior

This addresses the recurring `Test_Windows_CoreClr_Debug_Single_Machine` hang seen in rolling build 1560193, where `ReportsProgressForExplicitProjectOpen` waited until the 90-minute runner timeout and dump collection then collided with the 120-minute job cap.

## Validation

- `dotnet build src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.ProcessHost.UnitTests/Microsoft.CodeAnalysis.LanguageServer.ProcessHost.UnitTests.csproj --no-restore --nologo`
- focused timeout and `ReportsProgressForExplicitProjectOpen` tests: 5 passed
- `SingleServerLifecycleTests` and `AutoLoadProjectsTests`: 25 passed
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84974)