### PR TITLE
[test-only-change] Record existing accessor parsing behavior

### DIFF
--- a/src/Compilers/CSharp/Test/Syntax/Parsing/AccessorDeclarationParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/AccessorDeclarationParsingTests.cs
@@ -139,62 +139,51 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
     [Fact]
     public void RefAccessorModifierBodyForms()
     {
-        const string source = "class C { int P { ref get { } ref get; ref get => 0; } }";
+        const string source = "int P { ref get { } ref get; ref get => 0; }";
 
-        UsingTree(source);
-        N(SyntaxKind.CompilationUnit);
+        UsingDeclaration(source);
+        N(SyntaxKind.PropertyDeclaration);
         {
-            N(SyntaxKind.ClassDeclaration);
+            N(SyntaxKind.PredefinedType);
             {
-                N(SyntaxKind.ClassKeyword);
-                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "P");
+            N(SyntaxKind.AccessorList);
+            {
                 N(SyntaxKind.OpenBraceToken);
-                N(SyntaxKind.PropertyDeclaration);
+                N(SyntaxKind.GetAccessorDeclaration);
                 {
-                    N(SyntaxKind.PredefinedType);
-                    {
-                        N(SyntaxKind.IntKeyword);
-                    }
-                    N(SyntaxKind.IdentifierToken, "P");
-                    N(SyntaxKind.AccessorList);
+                    N(SyntaxKind.RefKeyword);
+                    N(SyntaxKind.GetKeyword);
+                    N(SyntaxKind.Block);
                     {
                         N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.GetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.RefKeyword);
-                            N(SyntaxKind.GetKeyword);
-                            N(SyntaxKind.Block);
-                            {
-                                N(SyntaxKind.OpenBraceToken);
-                                N(SyntaxKind.CloseBraceToken);
-                            }
-                        }
-                        N(SyntaxKind.GetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.RefKeyword);
-                            N(SyntaxKind.GetKeyword);
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.GetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.RefKeyword);
-                            N(SyntaxKind.GetKeyword);
-                            N(SyntaxKind.ArrowExpressionClause);
-                            {
-                                N(SyntaxKind.EqualsGreaterThanToken);
-                                N(SyntaxKind.NumericLiteralExpression);
-                                {
-                                    N(SyntaxKind.NumericLiteralToken, "0");
-                                }
-                            }
-                            N(SyntaxKind.SemicolonToken);
-                        }
                         N(SyntaxKind.CloseBraceToken);
                     }
                 }
+                N(SyntaxKind.GetAccessorDeclaration);
+                {
+                    N(SyntaxKind.RefKeyword);
+                    N(SyntaxKind.GetKeyword);
+                    N(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.GetAccessorDeclaration);
+                {
+                    N(SyntaxKind.RefKeyword);
+                    N(SyntaxKind.GetKeyword);
+                    N(SyntaxKind.ArrowExpressionClause);
+                    {
+                        N(SyntaxKind.EqualsGreaterThanToken);
+                        N(SyntaxKind.NumericLiteralExpression);
+                        {
+                            N(SyntaxKind.NumericLiteralToken, "0");
+                        }
+                    }
+                    N(SyntaxKind.SemicolonToken);
+                }
                 N(SyntaxKind.CloseBraceToken);
             }
-            N(SyntaxKind.EndOfFileToken);
         }
         EOF();
     }
@@ -202,53 +191,43 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
     [Fact]
     public void ContextualKeywordWithoutAccessorNameBeforeBodyForms()
     {
-        const string source = "class C { int P { partial { } partial; } }";
+        const string source = "int P { partial { } partial; }";
 
-        UsingTree(
+        UsingDeclaration(
             source,
-            // (1,19): error CS1014: A get or set accessor expected
-            // class C { int P { partial { } partial; } }
-            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(1, 19),
-            // (1,31): error CS1014: A get or set accessor expected
-            // class C { int P { partial { } partial; } }
-            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(1, 31));
-        N(SyntaxKind.CompilationUnit);
+            options: null,
+            // (1,9): error CS1014: A get or set accessor expected
+            // int P { partial { } partial; }
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(1, 9),
+            // (1,21): error CS1014: A get or set accessor expected
+            // int P { partial { } partial; }
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(1, 21));
+        N(SyntaxKind.PropertyDeclaration);
         {
-            N(SyntaxKind.ClassDeclaration);
+            N(SyntaxKind.PredefinedType);
             {
-                N(SyntaxKind.ClassKeyword);
-                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "P");
+            N(SyntaxKind.AccessorList);
+            {
                 N(SyntaxKind.OpenBraceToken);
-                N(SyntaxKind.PropertyDeclaration);
+                N(SyntaxKind.UnknownAccessorDeclaration);
                 {
-                    N(SyntaxKind.PredefinedType);
-                    {
-                        N(SyntaxKind.IntKeyword);
-                    }
-                    N(SyntaxKind.IdentifierToken, "P");
-                    N(SyntaxKind.AccessorList);
+                    N(SyntaxKind.IdentifierToken, "partial");
+                    N(SyntaxKind.Block);
                     {
                         N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.UnknownAccessorDeclaration);
-                        {
-                            N(SyntaxKind.IdentifierToken, "partial");
-                            N(SyntaxKind.Block);
-                            {
-                                N(SyntaxKind.OpenBraceToken);
-                                N(SyntaxKind.CloseBraceToken);
-                            }
-                        }
-                        N(SyntaxKind.UnknownAccessorDeclaration);
-                        {
-                            N(SyntaxKind.IdentifierToken, "partial");
-                            N(SyntaxKind.SemicolonToken);
-                        }
                         N(SyntaxKind.CloseBraceToken);
                     }
                 }
+                N(SyntaxKind.UnknownAccessorDeclaration);
+                {
+                    N(SyntaxKind.IdentifierToken, "partial");
+                    N(SyntaxKind.SemicolonToken);
+                }
                 N(SyntaxKind.CloseBraceToken);
             }
-            N(SyntaxKind.EndOfFileToken);
         }
         EOF();
     }
@@ -256,65 +235,55 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
     [Fact]
     public void EscapedContextualAndArbitraryAccessorNames()
     {
-        const string source = "class C { int P { @partial; @async; @scoped; unknown; } }";
+        const string source = "int P { @partial; @async; @scoped; unknown; }";
 
-        UsingTree(
+        UsingDeclaration(
             source,
+            options: null,
+            // (1,9): error CS1014: A get or set accessor expected
+            // int P { @partial; @async; @scoped; unknown; }
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "@partial").WithLocation(1, 9),
             // (1,19): error CS1014: A get or set accessor expected
-            // class C { int P { @partial; @async; @scoped; unknown; } }
-            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "@partial").WithLocation(1, 19),
-            // (1,29): error CS1014: A get or set accessor expected
-            // class C { int P { @partial; @async; @scoped; unknown; } }
-            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "@async").WithLocation(1, 29),
-            // (1,37): error CS1014: A get or set accessor expected
-            // class C { int P { @partial; @async; @scoped; unknown; } }
-            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "@scoped").WithLocation(1, 37),
-            // (1,46): error CS1014: A get or set accessor expected
-            // class C { int P { @partial; @async; @scoped; unknown; } }
-            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "unknown").WithLocation(1, 46));
-        N(SyntaxKind.CompilationUnit);
+            // int P { @partial; @async; @scoped; unknown; }
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "@async").WithLocation(1, 19),
+            // (1,27): error CS1014: A get or set accessor expected
+            // int P { @partial; @async; @scoped; unknown; }
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "@scoped").WithLocation(1, 27),
+            // (1,36): error CS1014: A get or set accessor expected
+            // int P { @partial; @async; @scoped; unknown; }
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "unknown").WithLocation(1, 36));
+        N(SyntaxKind.PropertyDeclaration);
         {
-            N(SyntaxKind.ClassDeclaration);
+            N(SyntaxKind.PredefinedType);
             {
-                N(SyntaxKind.ClassKeyword);
-                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "P");
+            N(SyntaxKind.AccessorList);
+            {
                 N(SyntaxKind.OpenBraceToken);
-                N(SyntaxKind.PropertyDeclaration);
+                N(SyntaxKind.UnknownAccessorDeclaration);
                 {
-                    N(SyntaxKind.PredefinedType);
-                    {
-                        N(SyntaxKind.IntKeyword);
-                    }
-                    N(SyntaxKind.IdentifierToken, "P");
-                    N(SyntaxKind.AccessorList);
-                    {
-                        N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.UnknownAccessorDeclaration);
-                        {
-                            N(SyntaxKind.IdentifierToken, "@partial");
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.UnknownAccessorDeclaration);
-                        {
-                            N(SyntaxKind.IdentifierToken, "@async");
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.UnknownAccessorDeclaration);
-                        {
-                            N(SyntaxKind.IdentifierToken, "@scoped");
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.UnknownAccessorDeclaration);
-                        {
-                            N(SyntaxKind.IdentifierToken, "unknown");
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.CloseBraceToken);
-                    }
+                    N(SyntaxKind.IdentifierToken, "@partial");
+                    N(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.UnknownAccessorDeclaration);
+                {
+                    N(SyntaxKind.IdentifierToken, "@async");
+                    N(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.UnknownAccessorDeclaration);
+                {
+                    N(SyntaxKind.IdentifierToken, "@scoped");
+                    N(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.UnknownAccessorDeclaration);
+                {
+                    N(SyntaxKind.IdentifierToken, "unknown");
+                    N(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.CloseBraceToken);
             }
-            N(SyntaxKind.EndOfFileToken);
         }
         EOF();
     }
@@ -322,64 +291,54 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
     [Fact]
     public void ContextualKeywordBeforeNonAccessorTokens()
     {
-        const string source = "class C { int P { partial => 0; partial unknown; } }";
+        const string source = "int P { partial => 0; partial unknown; }";
 
-        UsingTree(
+        UsingDeclaration(
             source,
-            // (1,19): error CS1014: A get or set accessor expected
-            // class C { int P { partial => 0; partial unknown; } }
-            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(1, 19),
-            // (1,33): error CS1014: A get or set accessor expected
-            // class C { int P { partial => 0; partial unknown; } }
-            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(1, 33),
-            // (1,41): error CS1014: A get or set accessor expected
-            // class C { int P { partial => 0; partial unknown; } }
-            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "unknown").WithLocation(1, 41));
-        N(SyntaxKind.CompilationUnit);
+            options: null,
+            // (1,9): error CS1014: A get or set accessor expected
+            // int P { partial => 0; partial unknown; }
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(1, 9),
+            // (1,23): error CS1014: A get or set accessor expected
+            // int P { partial => 0; partial unknown; }
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(1, 23),
+            // (1,31): error CS1014: A get or set accessor expected
+            // int P { partial => 0; partial unknown; }
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "unknown").WithLocation(1, 31));
+        N(SyntaxKind.PropertyDeclaration);
         {
-            N(SyntaxKind.ClassDeclaration);
+            N(SyntaxKind.PredefinedType);
             {
-                N(SyntaxKind.ClassKeyword);
-                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "P");
+            N(SyntaxKind.AccessorList);
+            {
                 N(SyntaxKind.OpenBraceToken);
-                N(SyntaxKind.PropertyDeclaration);
+                N(SyntaxKind.UnknownAccessorDeclaration);
                 {
-                    N(SyntaxKind.PredefinedType);
+                    N(SyntaxKind.IdentifierToken, "partial");
+                    N(SyntaxKind.ArrowExpressionClause);
                     {
-                        N(SyntaxKind.IntKeyword);
+                        N(SyntaxKind.EqualsGreaterThanToken);
+                        N(SyntaxKind.NumericLiteralExpression);
+                        {
+                            N(SyntaxKind.NumericLiteralToken, "0");
+                        }
                     }
-                    N(SyntaxKind.IdentifierToken, "P");
-                    N(SyntaxKind.AccessorList);
-                    {
-                        N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.UnknownAccessorDeclaration);
-                        {
-                            N(SyntaxKind.IdentifierToken, "partial");
-                            N(SyntaxKind.ArrowExpressionClause);
-                            {
-                                N(SyntaxKind.EqualsGreaterThanToken);
-                                N(SyntaxKind.NumericLiteralExpression);
-                                {
-                                    N(SyntaxKind.NumericLiteralToken, "0");
-                                }
-                            }
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.UnknownAccessorDeclaration);
-                        {
-                            N(SyntaxKind.IdentifierToken, "partial");
-                        }
-                        N(SyntaxKind.UnknownAccessorDeclaration);
-                        {
-                            N(SyntaxKind.IdentifierToken, "unknown");
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.CloseBraceToken);
-                    }
+                    N(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.UnknownAccessorDeclaration);
+                {
+                    N(SyntaxKind.IdentifierToken, "partial");
+                }
+                N(SyntaxKind.UnknownAccessorDeclaration);
+                {
+                    N(SyntaxKind.IdentifierToken, "unknown");
+                    N(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.CloseBraceToken);
             }
-            N(SyntaxKind.EndOfFileToken);
         }
         EOF();
     }
@@ -475,117 +434,112 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
             }
             """;
 
-        UsingTree(source);
-        N(SyntaxKind.CompilationUnit);
+        UsingDeclaration("public int P { get; private set; }");
+        N(SyntaxKind.PropertyDeclaration);
         {
-            N(SyntaxKind.ClassDeclaration);
+            N(SyntaxKind.PublicKeyword);
+            N(SyntaxKind.PredefinedType);
             {
-                N(SyntaxKind.ClassKeyword);
-                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "P");
+            N(SyntaxKind.AccessorList);
+            {
                 N(SyntaxKind.OpenBraceToken);
-                N(SyntaxKind.PropertyDeclaration);
+                N(SyntaxKind.GetAccessorDeclaration);
                 {
-                    N(SyntaxKind.PublicKeyword);
-                    N(SyntaxKind.PredefinedType);
-                    {
-                        N(SyntaxKind.IntKeyword);
-                    }
-                    N(SyntaxKind.IdentifierToken, "P");
-                    N(SyntaxKind.AccessorList);
-                    {
-                        N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.GetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.GetKeyword);
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.SetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.PrivateKeyword);
-                            N(SyntaxKind.SetKeyword);
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.CloseBraceToken);
-                    }
+                    N(SyntaxKind.GetKeyword);
+                    N(SyntaxKind.SemicolonToken);
                 }
-                N(SyntaxKind.PropertyDeclaration);
+                N(SyntaxKind.SetAccessorDeclaration);
                 {
-                    N(SyntaxKind.PublicKeyword);
-                    N(SyntaxKind.PredefinedType);
-                    {
-                        N(SyntaxKind.IntKeyword);
-                    }
-                    N(SyntaxKind.IdentifierToken, "Q");
-                    N(SyntaxKind.AccessorList);
-                    {
-                        N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.GetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.GetKeyword);
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.InitAccessorDeclaration);
-                        {
-                            N(SyntaxKind.PrivateKeyword);
-                            N(SyntaxKind.InitKeyword);
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.CloseBraceToken);
-                    }
+                    N(SyntaxKind.PrivateKeyword);
+                    N(SyntaxKind.SetKeyword);
+                    N(SyntaxKind.SemicolonToken);
                 }
-                N(SyntaxKind.IndexerDeclaration);
+                N(SyntaxKind.CloseBraceToken);
+            }
+        }
+        EOF();
+
+        UsingDeclaration("public int Q { get; private init; }");
+        N(SyntaxKind.PropertyDeclaration);
+        {
+            N(SyntaxKind.PublicKeyword);
+            N(SyntaxKind.PredefinedType);
+            {
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "Q");
+            N(SyntaxKind.AccessorList);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.GetAccessorDeclaration);
                 {
-                    N(SyntaxKind.PublicKeyword);
+                    N(SyntaxKind.GetKeyword);
+                    N(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.InitAccessorDeclaration);
+                {
+                    N(SyntaxKind.PrivateKeyword);
+                    N(SyntaxKind.InitKeyword);
+                    N(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+        }
+        EOF();
+
+        UsingDeclaration("public int this[int i] { private get => 0; set { } }");
+        N(SyntaxKind.IndexerDeclaration);
+        {
+            N(SyntaxKind.PublicKeyword);
+            N(SyntaxKind.PredefinedType);
+            {
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.ThisKeyword);
+            N(SyntaxKind.BracketedParameterList);
+            {
+                N(SyntaxKind.OpenBracketToken);
+                N(SyntaxKind.Parameter);
+                {
                     N(SyntaxKind.PredefinedType);
                     {
                         N(SyntaxKind.IntKeyword);
                     }
-                    N(SyntaxKind.ThisKeyword);
-                    N(SyntaxKind.BracketedParameterList);
+                    N(SyntaxKind.IdentifierToken, "i");
+                }
+                N(SyntaxKind.CloseBracketToken);
+            }
+            N(SyntaxKind.AccessorList);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.GetAccessorDeclaration);
+                {
+                    N(SyntaxKind.PrivateKeyword);
+                    N(SyntaxKind.GetKeyword);
+                    N(SyntaxKind.ArrowExpressionClause);
                     {
-                        N(SyntaxKind.OpenBracketToken);
-                        N(SyntaxKind.Parameter);
+                        N(SyntaxKind.EqualsGreaterThanToken);
+                        N(SyntaxKind.NumericLiteralExpression);
                         {
-                            N(SyntaxKind.PredefinedType);
-                            {
-                                N(SyntaxKind.IntKeyword);
-                            }
-                            N(SyntaxKind.IdentifierToken, "i");
+                            N(SyntaxKind.NumericLiteralToken, "0");
                         }
-                        N(SyntaxKind.CloseBracketToken);
                     }
-                    N(SyntaxKind.AccessorList);
+                    N(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.SetAccessorDeclaration);
+                {
+                    N(SyntaxKind.SetKeyword);
+                    N(SyntaxKind.Block);
                     {
                         N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.GetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.PrivateKeyword);
-                            N(SyntaxKind.GetKeyword);
-                            N(SyntaxKind.ArrowExpressionClause);
-                            {
-                                N(SyntaxKind.EqualsGreaterThanToken);
-                                N(SyntaxKind.NumericLiteralExpression);
-                                {
-                                    N(SyntaxKind.NumericLiteralToken, "0");
-                                }
-                            }
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.SetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.SetKeyword);
-                            N(SyntaxKind.Block);
-                            {
-                                N(SyntaxKind.OpenBraceToken);
-                                N(SyntaxKind.CloseBraceToken);
-                            }
-                        }
                         N(SyntaxKind.CloseBraceToken);
                     }
                 }
                 N(SyntaxKind.CloseBraceToken);
             }
-            N(SyntaxKind.EndOfFileToken);
         }
         EOF();
 
@@ -603,98 +557,90 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
             }
             """;
 
-        UsingTree(source);
-        N(SyntaxKind.CompilationUnit);
+        UsingDeclaration("int P { ref get => 0; abstract ref set { } }");
+        N(SyntaxKind.PropertyDeclaration);
         {
-            N(SyntaxKind.ClassDeclaration);
+            N(SyntaxKind.PredefinedType);
             {
-                N(SyntaxKind.ClassKeyword);
-                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "P");
+            N(SyntaxKind.AccessorList);
+            {
                 N(SyntaxKind.OpenBraceToken);
-                N(SyntaxKind.PropertyDeclaration);
+                N(SyntaxKind.GetAccessorDeclaration);
                 {
-                    N(SyntaxKind.PredefinedType);
+                    N(SyntaxKind.RefKeyword);
+                    N(SyntaxKind.GetKeyword);
+                    N(SyntaxKind.ArrowExpressionClause);
                     {
-                        N(SyntaxKind.IntKeyword);
-                    }
-                    N(SyntaxKind.IdentifierToken, "P");
-                    N(SyntaxKind.AccessorList);
-                    {
-                        N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.GetAccessorDeclaration);
+                        N(SyntaxKind.EqualsGreaterThanToken);
+                        N(SyntaxKind.NumericLiteralExpression);
                         {
-                            N(SyntaxKind.RefKeyword);
-                            N(SyntaxKind.GetKeyword);
-                            N(SyntaxKind.ArrowExpressionClause);
-                            {
-                                N(SyntaxKind.EqualsGreaterThanToken);
-                                N(SyntaxKind.NumericLiteralExpression);
-                                {
-                                    N(SyntaxKind.NumericLiteralToken, "0");
-                                }
-                            }
-                            N(SyntaxKind.SemicolonToken);
+                            N(SyntaxKind.NumericLiteralToken, "0");
                         }
-                        N(SyntaxKind.SetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.AbstractKeyword);
-                            N(SyntaxKind.RefKeyword);
-                            N(SyntaxKind.SetKeyword);
-                            N(SyntaxKind.Block);
-                            {
-                                N(SyntaxKind.OpenBraceToken);
-                                N(SyntaxKind.CloseBraceToken);
-                            }
-                        }
-                        N(SyntaxKind.CloseBraceToken);
                     }
+                    N(SyntaxKind.SemicolonToken);
                 }
-                N(SyntaxKind.EventDeclaration);
+                N(SyntaxKind.SetAccessorDeclaration);
                 {
-                    N(SyntaxKind.EventKeyword);
-                    N(SyntaxKind.QualifiedName);
-                    {
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken, "System");
-                        }
-                        N(SyntaxKind.DotToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken, "Action");
-                        }
-                    }
-                    N(SyntaxKind.IdentifierToken, "E");
-                    N(SyntaxKind.AccessorList);
+                    N(SyntaxKind.AbstractKeyword);
+                    N(SyntaxKind.RefKeyword);
+                    N(SyntaxKind.SetKeyword);
+                    N(SyntaxKind.Block);
                     {
                         N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.AddAccessorDeclaration);
-                        {
-                            N(SyntaxKind.RefKeyword);
-                            N(SyntaxKind.AddKeyword);
-                            N(SyntaxKind.Block);
-                            {
-                                N(SyntaxKind.OpenBraceToken);
-                                N(SyntaxKind.CloseBraceToken);
-                            }
-                        }
-                        N(SyntaxKind.RemoveAccessorDeclaration);
-                        {
-                            N(SyntaxKind.AbstractKeyword);
-                            N(SyntaxKind.RefKeyword);
-                            N(SyntaxKind.RemoveKeyword);
-                            N(SyntaxKind.Block);
-                            {
-                                N(SyntaxKind.OpenBraceToken);
-                                N(SyntaxKind.CloseBraceToken);
-                            }
-                        }
                         N(SyntaxKind.CloseBraceToken);
                     }
                 }
                 N(SyntaxKind.CloseBraceToken);
             }
-            N(SyntaxKind.EndOfFileToken);
+        }
+        EOF();
+
+        UsingDeclaration("event System.Action E { ref add { } abstract ref remove { } }");
+        N(SyntaxKind.EventDeclaration);
+        {
+            N(SyntaxKind.EventKeyword);
+            N(SyntaxKind.QualifiedName);
+            {
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "System");
+                }
+                N(SyntaxKind.DotToken);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "Action");
+                }
+            }
+            N(SyntaxKind.IdentifierToken, "E");
+            N(SyntaxKind.AccessorList);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.AddAccessorDeclaration);
+                {
+                    N(SyntaxKind.RefKeyword);
+                    N(SyntaxKind.AddKeyword);
+                    N(SyntaxKind.Block);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.RemoveAccessorDeclaration);
+                {
+                    N(SyntaxKind.AbstractKeyword);
+                    N(SyntaxKind.RefKeyword);
+                    N(SyntaxKind.RemoveKeyword);
+                    N(SyntaxKind.Block);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
         }
         EOF();
 
@@ -894,40 +840,37 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
             }
             """;
 
-        UsingTree(
+        UsingDeclaration(
             source,
+            options: null,
             // (3,21): error CS8180: { or ; or => expected
             //     int P { ref get }
             Diagnostic(ErrorCode.ERR_SemiOrLBraceOrArrowExpected, "}").WithLocation(3, 21));
-        N(SyntaxKind.CompilationUnit);
+        N(SyntaxKind.ClassDeclaration);
         {
-            N(SyntaxKind.ClassDeclaration);
+            N(SyntaxKind.ClassKeyword);
+            N(SyntaxKind.IdentifierToken, "C");
+            N(SyntaxKind.OpenBraceToken);
+            N(SyntaxKind.PropertyDeclaration);
             {
-                N(SyntaxKind.ClassKeyword);
-                N(SyntaxKind.IdentifierToken, "C");
-                N(SyntaxKind.OpenBraceToken);
-                N(SyntaxKind.PropertyDeclaration);
+                N(SyntaxKind.PredefinedType);
                 {
-                    N(SyntaxKind.PredefinedType);
-                    {
-                        N(SyntaxKind.IntKeyword);
-                    }
-                    N(SyntaxKind.IdentifierToken, "P");
-                    N(SyntaxKind.AccessorList);
-                    {
-                        N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.GetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.RefKeyword);
-                            N(SyntaxKind.GetKeyword);
-                            M(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.CloseBraceToken);
-                    }
+                    N(SyntaxKind.IntKeyword);
                 }
-                N(SyntaxKind.CloseBraceToken);
+                N(SyntaxKind.IdentifierToken, "P");
+                N(SyntaxKind.AccessorList);
+                {
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.GetAccessorDeclaration);
+                    {
+                        N(SyntaxKind.RefKeyword);
+                        N(SyntaxKind.GetKeyword);
+                        M(SyntaxKind.SemicolonToken);
+                    }
+                    N(SyntaxKind.CloseBraceToken);
+                }
             }
-            N(SyntaxKind.EndOfFileToken);
+            N(SyntaxKind.CloseBraceToken);
         }
         EOF();
 
@@ -943,6 +886,7 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
     [Fact]
     public void ScopedRefModifiersRemainOnAccessor()
     {
+        const string declaration = "public int P { scoped ref get; set; }";
         const string source = """
             class C
             {
@@ -950,50 +894,40 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
             }
             """;
 
-        UsingTree(
-            source,
-            // (3,20): error CS1014: A get or set accessor expected
-            //     public int P { scoped ref get; set; }
-            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "scoped").WithLocation(3, 20));
-        N(SyntaxKind.CompilationUnit);
+        UsingDeclaration(
+            declaration,
+            options: null,
+            // (1,16): error CS1014: A get or set accessor expected
+            // public int P { scoped ref get; set; }
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "scoped").WithLocation(1, 16));
+        N(SyntaxKind.PropertyDeclaration);
         {
-            N(SyntaxKind.ClassDeclaration);
+            N(SyntaxKind.PublicKeyword);
+            N(SyntaxKind.PredefinedType);
             {
-                N(SyntaxKind.ClassKeyword);
-                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "P");
+            N(SyntaxKind.AccessorList);
+            {
                 N(SyntaxKind.OpenBraceToken);
-                N(SyntaxKind.PropertyDeclaration);
+                N(SyntaxKind.UnknownAccessorDeclaration);
                 {
-                    N(SyntaxKind.PublicKeyword);
-                    N(SyntaxKind.PredefinedType);
-                    {
-                        N(SyntaxKind.IntKeyword);
-                    }
-                    N(SyntaxKind.IdentifierToken, "P");
-                    N(SyntaxKind.AccessorList);
-                    {
-                        N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.UnknownAccessorDeclaration);
-                        {
-                            N(SyntaxKind.IdentifierToken, "scoped");
-                        }
-                        N(SyntaxKind.GetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.RefKeyword);
-                            N(SyntaxKind.GetKeyword);
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.SetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.SetKeyword);
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.CloseBraceToken);
-                    }
+                    N(SyntaxKind.IdentifierToken, "scoped");
+                }
+                N(SyntaxKind.GetAccessorDeclaration);
+                {
+                    N(SyntaxKind.RefKeyword);
+                    N(SyntaxKind.GetKeyword);
+                    N(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.SetAccessorDeclaration);
+                {
+                    N(SyntaxKind.SetKeyword);
+                    N(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.CloseBraceToken);
             }
-            N(SyntaxKind.EndOfFileToken);
         }
         EOF();
 
@@ -1018,138 +952,133 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
             }
             """;
 
-        UsingTree(
-            source,
-            TestOptions.RegularPreview,
-            // (5,13): error CS1014: A get or set accessor expected
-            //     int R { safe; get => 0; set { } }
-            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "safe").WithLocation(5, 13));
-        N(SyntaxKind.CompilationUnit);
+        UsingDeclaration("public int P { private safe get => 0; set { } }", TestOptions.RegularPreview);
+        N(SyntaxKind.PropertyDeclaration);
         {
-            N(SyntaxKind.ClassDeclaration);
+            N(SyntaxKind.PublicKeyword);
+            N(SyntaxKind.PredefinedType);
             {
-                N(SyntaxKind.ClassKeyword);
-                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "P");
+            N(SyntaxKind.AccessorList);
+            {
                 N(SyntaxKind.OpenBraceToken);
-                N(SyntaxKind.PropertyDeclaration);
+                N(SyntaxKind.GetAccessorDeclaration);
                 {
-                    N(SyntaxKind.PublicKeyword);
-                    N(SyntaxKind.PredefinedType);
+                    N(SyntaxKind.PrivateKeyword);
+                    N(SyntaxKind.SafeKeyword);
+                    N(SyntaxKind.GetKeyword);
+                    N(SyntaxKind.ArrowExpressionClause);
                     {
-                        N(SyntaxKind.IntKeyword);
-                    }
-                    N(SyntaxKind.IdentifierToken, "P");
-                    N(SyntaxKind.AccessorList);
-                    {
-                        N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.GetAccessorDeclaration);
+                        N(SyntaxKind.EqualsGreaterThanToken);
+                        N(SyntaxKind.NumericLiteralExpression);
                         {
-                            N(SyntaxKind.PrivateKeyword);
-                            N(SyntaxKind.SafeKeyword);
-                            N(SyntaxKind.GetKeyword);
-                            N(SyntaxKind.ArrowExpressionClause);
-                            {
-                                N(SyntaxKind.EqualsGreaterThanToken);
-                                N(SyntaxKind.NumericLiteralExpression);
-                                {
-                                    N(SyntaxKind.NumericLiteralToken, "0");
-                                }
-                            }
-                            N(SyntaxKind.SemicolonToken);
+                            N(SyntaxKind.NumericLiteralToken, "0");
                         }
-                        N(SyntaxKind.SetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.SetKeyword);
-                            N(SyntaxKind.Block);
-                            {
-                                N(SyntaxKind.OpenBraceToken);
-                                N(SyntaxKind.CloseBraceToken);
-                            }
-                        }
-                        N(SyntaxKind.CloseBraceToken);
                     }
+                    N(SyntaxKind.SemicolonToken);
                 }
-                N(SyntaxKind.PropertyDeclaration);
+                N(SyntaxKind.SetAccessorDeclaration);
                 {
-                    N(SyntaxKind.PublicKeyword);
-                    N(SyntaxKind.PredefinedType);
-                    {
-                        N(SyntaxKind.IntKeyword);
-                    }
-                    N(SyntaxKind.IdentifierToken, "Q");
-                    N(SyntaxKind.AccessorList);
+                    N(SyntaxKind.SetKeyword);
+                    N(SyntaxKind.Block);
                     {
                         N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.GetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.GetKeyword);
-                            N(SyntaxKind.ArrowExpressionClause);
-                            {
-                                N(SyntaxKind.EqualsGreaterThanToken);
-                                N(SyntaxKind.NumericLiteralExpression);
-                                {
-                                    N(SyntaxKind.NumericLiteralToken, "0");
-                                }
-                            }
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.SetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.SafeKeyword);
-                            N(SyntaxKind.PrivateKeyword);
-                            N(SyntaxKind.SetKeyword);
-                            N(SyntaxKind.Block);
-                            {
-                                N(SyntaxKind.OpenBraceToken);
-                                N(SyntaxKind.CloseBraceToken);
-                            }
-                        }
-                        N(SyntaxKind.CloseBraceToken);
-                    }
-                }
-                N(SyntaxKind.PropertyDeclaration);
-                {
-                    N(SyntaxKind.PredefinedType);
-                    {
-                        N(SyntaxKind.IntKeyword);
-                    }
-                    N(SyntaxKind.IdentifierToken, "R");
-                    N(SyntaxKind.AccessorList);
-                    {
-                        N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.UnknownAccessorDeclaration);
-                        {
-                            N(SyntaxKind.IdentifierToken, "safe");
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.GetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.GetKeyword);
-                            N(SyntaxKind.ArrowExpressionClause);
-                            {
-                                N(SyntaxKind.EqualsGreaterThanToken);
-                                N(SyntaxKind.NumericLiteralExpression);
-                                {
-                                    N(SyntaxKind.NumericLiteralToken, "0");
-                                }
-                            }
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.SetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.SetKeyword);
-                            N(SyntaxKind.Block);
-                            {
-                                N(SyntaxKind.OpenBraceToken);
-                                N(SyntaxKind.CloseBraceToken);
-                            }
-                        }
                         N(SyntaxKind.CloseBraceToken);
                     }
                 }
                 N(SyntaxKind.CloseBraceToken);
             }
-            N(SyntaxKind.EndOfFileToken);
+        }
+        EOF();
+
+        UsingDeclaration("public int Q { get => 0; safe private set { } }", TestOptions.RegularPreview);
+        N(SyntaxKind.PropertyDeclaration);
+        {
+            N(SyntaxKind.PublicKeyword);
+            N(SyntaxKind.PredefinedType);
+            {
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "Q");
+            N(SyntaxKind.AccessorList);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.GetAccessorDeclaration);
+                {
+                    N(SyntaxKind.GetKeyword);
+                    N(SyntaxKind.ArrowExpressionClause);
+                    {
+                        N(SyntaxKind.EqualsGreaterThanToken);
+                        N(SyntaxKind.NumericLiteralExpression);
+                        {
+                            N(SyntaxKind.NumericLiteralToken, "0");
+                        }
+                    }
+                    N(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.SetAccessorDeclaration);
+                {
+                    N(SyntaxKind.SafeKeyword);
+                    N(SyntaxKind.PrivateKeyword);
+                    N(SyntaxKind.SetKeyword);
+                    N(SyntaxKind.Block);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+        }
+        EOF();
+
+        UsingDeclaration(
+            "int R { safe; get => 0; set { } }",
+            TestOptions.RegularPreview,
+            // (1,9): error CS1014: A get or set accessor expected
+            // int R { safe; get => 0; set { } }
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "safe").WithLocation(1, 9));
+        N(SyntaxKind.PropertyDeclaration);
+        {
+            N(SyntaxKind.PredefinedType);
+            {
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "R");
+            N(SyntaxKind.AccessorList);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.UnknownAccessorDeclaration);
+                {
+                    N(SyntaxKind.IdentifierToken, "safe");
+                    N(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.GetAccessorDeclaration);
+                {
+                    N(SyntaxKind.GetKeyword);
+                    N(SyntaxKind.ArrowExpressionClause);
+                    {
+                        N(SyntaxKind.EqualsGreaterThanToken);
+                        N(SyntaxKind.NumericLiteralExpression);
+                        {
+                            N(SyntaxKind.NumericLiteralToken, "0");
+                        }
+                    }
+                    N(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.SetAccessorDeclaration);
+                {
+                    N(SyntaxKind.SetKeyword);
+                    N(SyntaxKind.Block);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
         }
         EOF();
 
@@ -1162,184 +1091,182 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
     [Fact]
     public void ContextualKeywordsAreRecoveredBeforeAccessors()
     {
-        const string source = """
-            class C
-            {
-                int P { scoped get; set; }
-                int Q { partial get; set; }
-                int R { async get; set; }
-                public int S { private async get; set; }
-                public int T { private partial get; set; }
-            }
-            """;
-
-        UsingTree(
-            source,
+        UsingDeclaration(
+            "int P { scoped get; set; }",
             TestOptions.RegularPreview,
-            // (3,13): error CS1014: A get or set accessor expected
-            //     int P { scoped get; set; }
-            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "scoped").WithLocation(3, 13),
-            // (4,13): error CS1014: A get or set accessor expected
-            //     int Q { partial get; set; }
-            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(4, 13),
-            // (5,13): error CS1014: A get or set accessor expected
-            //     int R { async get; set; }
-            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "async").WithLocation(5, 13),
-            // (6,28): error CS1014: A get or set accessor expected
-            //     public int S { private async get; set; }
-            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "async").WithLocation(6, 28),
-            // (7,28): error CS1014: A get or set accessor expected
-            //     public int T { private partial get; set; }
-            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(7, 28));
-        N(SyntaxKind.CompilationUnit);
+            // (1,9): error CS1014: A get or set accessor expected
+            // int P { scoped get; set; }
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "scoped").WithLocation(1, 9));
+        N(SyntaxKind.PropertyDeclaration);
         {
-            N(SyntaxKind.ClassDeclaration);
+            N(SyntaxKind.PredefinedType);
             {
-                N(SyntaxKind.ClassKeyword);
-                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "P");
+            N(SyntaxKind.AccessorList);
+            {
                 N(SyntaxKind.OpenBraceToken);
-                N(SyntaxKind.PropertyDeclaration);
+                N(SyntaxKind.UnknownAccessorDeclaration);
                 {
-                    N(SyntaxKind.PredefinedType);
-                    {
-                        N(SyntaxKind.IntKeyword);
-                    }
-                    N(SyntaxKind.IdentifierToken, "P");
-                    N(SyntaxKind.AccessorList);
-                    {
-                        N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.UnknownAccessorDeclaration);
-                        {
-                            N(SyntaxKind.IdentifierToken, "scoped");
-                        }
-                        N(SyntaxKind.GetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.GetKeyword);
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.SetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.SetKeyword);
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.CloseBraceToken);
-                    }
+                    N(SyntaxKind.IdentifierToken, "scoped");
                 }
-                N(SyntaxKind.PropertyDeclaration);
+                N(SyntaxKind.GetAccessorDeclaration);
                 {
-                    N(SyntaxKind.PredefinedType);
-                    {
-                        N(SyntaxKind.IntKeyword);
-                    }
-                    N(SyntaxKind.IdentifierToken, "Q");
-                    N(SyntaxKind.AccessorList);
-                    {
-                        N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.UnknownAccessorDeclaration);
-                        {
-                            N(SyntaxKind.IdentifierToken, "partial");
-                        }
-                        N(SyntaxKind.GetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.GetKeyword);
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.SetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.SetKeyword);
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.CloseBraceToken);
-                    }
+                    N(SyntaxKind.GetKeyword);
+                    N(SyntaxKind.SemicolonToken);
                 }
-                N(SyntaxKind.PropertyDeclaration);
+                N(SyntaxKind.SetAccessorDeclaration);
                 {
-                    N(SyntaxKind.PredefinedType);
-                    {
-                        N(SyntaxKind.IntKeyword);
-                    }
-                    N(SyntaxKind.IdentifierToken, "R");
-                    N(SyntaxKind.AccessorList);
-                    {
-                        N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.UnknownAccessorDeclaration);
-                        {
-                            N(SyntaxKind.IdentifierToken, "async");
-                        }
-                        N(SyntaxKind.GetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.GetKeyword);
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.SetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.SetKeyword);
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.CloseBraceToken);
-                    }
-                }
-                N(SyntaxKind.PropertyDeclaration);
-                {
-                    N(SyntaxKind.PublicKeyword);
-                    N(SyntaxKind.PredefinedType);
-                    {
-                        N(SyntaxKind.IntKeyword);
-                    }
-                    N(SyntaxKind.IdentifierToken, "S");
-                    N(SyntaxKind.AccessorList);
-                    {
-                        N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.UnknownAccessorDeclaration);
-                        {
-                            N(SyntaxKind.PrivateKeyword);
-                            N(SyntaxKind.IdentifierToken, "async");
-                        }
-                        N(SyntaxKind.GetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.GetKeyword);
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.SetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.SetKeyword);
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.CloseBraceToken);
-                    }
-                }
-                N(SyntaxKind.PropertyDeclaration);
-                {
-                    N(SyntaxKind.PublicKeyword);
-                    N(SyntaxKind.PredefinedType);
-                    {
-                        N(SyntaxKind.IntKeyword);
-                    }
-                    N(SyntaxKind.IdentifierToken, "T");
-                    N(SyntaxKind.AccessorList);
-                    {
-                        N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.UnknownAccessorDeclaration);
-                        {
-                            N(SyntaxKind.PrivateKeyword);
-                            N(SyntaxKind.IdentifierToken, "partial");
-                        }
-                        N(SyntaxKind.GetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.GetKeyword);
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.SetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.SetKeyword);
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.CloseBraceToken);
-                    }
+                    N(SyntaxKind.SetKeyword);
+                    N(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.CloseBraceToken);
             }
-            N(SyntaxKind.EndOfFileToken);
+        }
+        EOF();
+
+        UsingDeclaration(
+            "int Q { partial get; set; }",
+            TestOptions.RegularPreview,
+            // (1,9): error CS1014: A get or set accessor expected
+            // int Q { partial get; set; }
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(1, 9));
+        N(SyntaxKind.PropertyDeclaration);
+        {
+            N(SyntaxKind.PredefinedType);
+            {
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "Q");
+            N(SyntaxKind.AccessorList);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.UnknownAccessorDeclaration);
+                {
+                    N(SyntaxKind.IdentifierToken, "partial");
+                }
+                N(SyntaxKind.GetAccessorDeclaration);
+                {
+                    N(SyntaxKind.GetKeyword);
+                    N(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.SetAccessorDeclaration);
+                {
+                    N(SyntaxKind.SetKeyword);
+                    N(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+        }
+        EOF();
+
+        UsingDeclaration(
+            "int R { async get; set; }",
+            TestOptions.RegularPreview,
+            // (1,9): error CS1014: A get or set accessor expected
+            // int R { async get; set; }
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "async").WithLocation(1, 9));
+        N(SyntaxKind.PropertyDeclaration);
+        {
+            N(SyntaxKind.PredefinedType);
+            {
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "R");
+            N(SyntaxKind.AccessorList);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.UnknownAccessorDeclaration);
+                {
+                    N(SyntaxKind.IdentifierToken, "async");
+                }
+                N(SyntaxKind.GetAccessorDeclaration);
+                {
+                    N(SyntaxKind.GetKeyword);
+                    N(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.SetAccessorDeclaration);
+                {
+                    N(SyntaxKind.SetKeyword);
+                    N(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+        }
+        EOF();
+
+        UsingDeclaration(
+            "public int S { private async get; set; }",
+            TestOptions.RegularPreview,
+            // (1,24): error CS1014: A get or set accessor expected
+            // public int S { private async get; set; }
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "async").WithLocation(1, 24));
+        N(SyntaxKind.PropertyDeclaration);
+        {
+            N(SyntaxKind.PublicKeyword);
+            N(SyntaxKind.PredefinedType);
+            {
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "S");
+            N(SyntaxKind.AccessorList);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.UnknownAccessorDeclaration);
+                {
+                    N(SyntaxKind.PrivateKeyword);
+                    N(SyntaxKind.IdentifierToken, "async");
+                }
+                N(SyntaxKind.GetAccessorDeclaration);
+                {
+                    N(SyntaxKind.GetKeyword);
+                    N(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.SetAccessorDeclaration);
+                {
+                    N(SyntaxKind.SetKeyword);
+                    N(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+        }
+        EOF();
+
+        UsingDeclaration(
+            "public int T { private partial get; set; }",
+            TestOptions.RegularPreview,
+            // (1,24): error CS1014: A get or set accessor expected
+            // public int T { private partial get; set; }
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(1, 24));
+        N(SyntaxKind.PropertyDeclaration);
+        {
+            N(SyntaxKind.PublicKeyword);
+            N(SyntaxKind.PredefinedType);
+            {
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "T");
+            N(SyntaxKind.AccessorList);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.UnknownAccessorDeclaration);
+                {
+                    N(SyntaxKind.PrivateKeyword);
+                    N(SyntaxKind.IdentifierToken, "partial");
+                }
+                N(SyntaxKind.GetAccessorDeclaration);
+                {
+                    N(SyntaxKind.GetKeyword);
+                    N(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.SetAccessorDeclaration);
+                {
+                    N(SyntaxKind.SetKeyword);
+                    N(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
         }
         EOF();
     }
@@ -1356,93 +1283,88 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
             }
             """;
 
-        UsingTree(source, TestOptions.RegularPreview);
-        N(SyntaxKind.CompilationUnit);
+        UsingDeclaration("int P { required get; file set; }", TestOptions.RegularPreview);
+        N(SyntaxKind.PropertyDeclaration);
         {
-            N(SyntaxKind.ClassDeclaration);
+            N(SyntaxKind.PredefinedType);
             {
-                N(SyntaxKind.ClassKeyword);
-                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "P");
+            N(SyntaxKind.AccessorList);
+            {
                 N(SyntaxKind.OpenBraceToken);
-                N(SyntaxKind.PropertyDeclaration);
+                N(SyntaxKind.GetAccessorDeclaration);
                 {
-                    N(SyntaxKind.PredefinedType);
-                    {
-                        N(SyntaxKind.IntKeyword);
-                    }
-                    N(SyntaxKind.IdentifierToken, "P");
-                    N(SyntaxKind.AccessorList);
-                    {
-                        N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.GetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.RequiredKeyword);
-                            N(SyntaxKind.GetKeyword);
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.SetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.FileKeyword);
-                            N(SyntaxKind.SetKeyword);
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.CloseBraceToken);
-                    }
+                    N(SyntaxKind.RequiredKeyword);
+                    N(SyntaxKind.GetKeyword);
+                    N(SyntaxKind.SemicolonToken);
                 }
-                N(SyntaxKind.PropertyDeclaration);
+                N(SyntaxKind.SetAccessorDeclaration);
                 {
-                    N(SyntaxKind.PredefinedType);
-                    {
-                        N(SyntaxKind.IntKeyword);
-                    }
-                    N(SyntaxKind.IdentifierToken, "Q");
-                    N(SyntaxKind.AccessorList);
-                    {
-                        N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.GetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.ClosedKeyword);
-                            N(SyntaxKind.GetKeyword);
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.SetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.StaticKeyword);
-                            N(SyntaxKind.SetKeyword);
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.CloseBraceToken);
-                    }
-                }
-                N(SyntaxKind.PropertyDeclaration);
-                {
-                    N(SyntaxKind.PublicKeyword);
-                    N(SyntaxKind.PredefinedType);
-                    {
-                        N(SyntaxKind.IntKeyword);
-                    }
-                    N(SyntaxKind.IdentifierToken, "R");
-                    N(SyntaxKind.AccessorList);
-                    {
-                        N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.GetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.PrivateKeyword);
-                            N(SyntaxKind.PrivateKeyword);
-                            N(SyntaxKind.GetKeyword);
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.SetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.SetKeyword);
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.CloseBraceToken);
-                    }
+                    N(SyntaxKind.FileKeyword);
+                    N(SyntaxKind.SetKeyword);
+                    N(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.CloseBraceToken);
             }
-            N(SyntaxKind.EndOfFileToken);
+        }
+        EOF();
+
+        UsingDeclaration("int Q { closed get; static set; }", TestOptions.RegularPreview);
+        N(SyntaxKind.PropertyDeclaration);
+        {
+            N(SyntaxKind.PredefinedType);
+            {
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "Q");
+            N(SyntaxKind.AccessorList);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.GetAccessorDeclaration);
+                {
+                    N(SyntaxKind.ClosedKeyword);
+                    N(SyntaxKind.GetKeyword);
+                    N(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.SetAccessorDeclaration);
+                {
+                    N(SyntaxKind.StaticKeyword);
+                    N(SyntaxKind.SetKeyword);
+                    N(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+        }
+        EOF();
+
+        UsingDeclaration("public int R { private private get; set; }", TestOptions.RegularPreview);
+        N(SyntaxKind.PropertyDeclaration);
+        {
+            N(SyntaxKind.PublicKeyword);
+            N(SyntaxKind.PredefinedType);
+            {
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "R");
+            N(SyntaxKind.AccessorList);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.GetAccessorDeclaration);
+                {
+                    N(SyntaxKind.PrivateKeyword);
+                    N(SyntaxKind.PrivateKeyword);
+                    N(SyntaxKind.GetKeyword);
+                    N(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.SetAccessorDeclaration);
+                {
+                    N(SyntaxKind.SetKeyword);
+                    N(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
         }
         EOF();
 
@@ -1467,6 +1389,7 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
     [Fact]
     public void AttributeBeforeReadonlyAccessorModifier()
     {
+        const string declaration = "public int P { [System.Obsolete] readonly get => 0; set { } }";
         const string source = """
             struct S
             {
@@ -1474,74 +1397,63 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
             }
             """;
 
-        UsingTree(source);
-        N(SyntaxKind.CompilationUnit);
+        UsingDeclaration(declaration);
+        N(SyntaxKind.PropertyDeclaration);
         {
-            N(SyntaxKind.StructDeclaration);
+            N(SyntaxKind.PublicKeyword);
+            N(SyntaxKind.PredefinedType);
             {
-                N(SyntaxKind.StructKeyword);
-                N(SyntaxKind.IdentifierToken, "S");
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "P");
+            N(SyntaxKind.AccessorList);
+            {
                 N(SyntaxKind.OpenBraceToken);
-                N(SyntaxKind.PropertyDeclaration);
+                N(SyntaxKind.GetAccessorDeclaration);
                 {
-                    N(SyntaxKind.PublicKeyword);
-                    N(SyntaxKind.PredefinedType);
+                    N(SyntaxKind.AttributeList);
                     {
-                        N(SyntaxKind.IntKeyword);
+                        N(SyntaxKind.OpenBracketToken);
+                        N(SyntaxKind.Attribute);
+                        {
+                            N(SyntaxKind.QualifiedName);
+                            {
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "System");
+                                }
+                                N(SyntaxKind.DotToken);
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "Obsolete");
+                                }
+                            }
+                        }
+                        N(SyntaxKind.CloseBracketToken);
                     }
-                    N(SyntaxKind.IdentifierToken, "P");
-                    N(SyntaxKind.AccessorList);
+                    N(SyntaxKind.ReadOnlyKeyword);
+                    N(SyntaxKind.GetKeyword);
+                    N(SyntaxKind.ArrowExpressionClause);
+                    {
+                        N(SyntaxKind.EqualsGreaterThanToken);
+                        N(SyntaxKind.NumericLiteralExpression);
+                        {
+                            N(SyntaxKind.NumericLiteralToken, "0");
+                        }
+                    }
+                    N(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.SetAccessorDeclaration);
+                {
+                    N(SyntaxKind.SetKeyword);
+                    N(SyntaxKind.Block);
                     {
                         N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.GetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.AttributeList);
-                            {
-                                N(SyntaxKind.OpenBracketToken);
-                                N(SyntaxKind.Attribute);
-                                {
-                                    N(SyntaxKind.QualifiedName);
-                                    {
-                                        N(SyntaxKind.IdentifierName);
-                                        {
-                                            N(SyntaxKind.IdentifierToken, "System");
-                                        }
-                                        N(SyntaxKind.DotToken);
-                                        N(SyntaxKind.IdentifierName);
-                                        {
-                                            N(SyntaxKind.IdentifierToken, "Obsolete");
-                                        }
-                                    }
-                                }
-                                N(SyntaxKind.CloseBracketToken);
-                            }
-                            N(SyntaxKind.ReadOnlyKeyword);
-                            N(SyntaxKind.GetKeyword);
-                            N(SyntaxKind.ArrowExpressionClause);
-                            {
-                                N(SyntaxKind.EqualsGreaterThanToken);
-                                N(SyntaxKind.NumericLiteralExpression);
-                                {
-                                    N(SyntaxKind.NumericLiteralToken, "0");
-                                }
-                            }
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.SetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.SetKeyword);
-                            N(SyntaxKind.Block);
-                            {
-                                N(SyntaxKind.OpenBraceToken);
-                                N(SyntaxKind.CloseBraceToken);
-                            }
-                        }
                         N(SyntaxKind.CloseBraceToken);
                     }
                 }
                 N(SyntaxKind.CloseBraceToken);
             }
-            N(SyntaxKind.EndOfFileToken);
         }
         EOF();
 
@@ -1561,68 +1473,65 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
             }
             """;
 
-        UsingTree(
+        UsingDeclaration(
             source,
+            options: null,
             // (5,26): error CS1513: } expected
             //         get { return 0; }
             Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(5, 26));
-        N(SyntaxKind.CompilationUnit);
+        N(SyntaxKind.ClassDeclaration);
         {
-            N(SyntaxKind.ClassDeclaration);
+            N(SyntaxKind.ClassKeyword);
+            N(SyntaxKind.IdentifierToken, "C");
+            N(SyntaxKind.OpenBraceToken);
+            N(SyntaxKind.PropertyDeclaration);
             {
-                N(SyntaxKind.ClassKeyword);
-                N(SyntaxKind.IdentifierToken, "C");
-                N(SyntaxKind.OpenBraceToken);
-                N(SyntaxKind.PropertyDeclaration);
+                N(SyntaxKind.PredefinedType);
+                {
+                    N(SyntaxKind.IntKeyword);
+                }
+                N(SyntaxKind.IdentifierToken, "P");
+                N(SyntaxKind.AccessorList);
+                {
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.GetAccessorDeclaration);
+                    {
+                        N(SyntaxKind.GetKeyword);
+                        N(SyntaxKind.Block);
+                        {
+                            N(SyntaxKind.OpenBraceToken);
+                            N(SyntaxKind.ReturnStatement);
+                            {
+                                N(SyntaxKind.ReturnKeyword);
+                                N(SyntaxKind.NumericLiteralExpression);
+                                {
+                                    N(SyntaxKind.NumericLiteralToken, "0");
+                                }
+                                N(SyntaxKind.SemicolonToken);
+                            }
+                            N(SyntaxKind.CloseBraceToken);
+                        }
+                    }
+                    M(SyntaxKind.CloseBraceToken);
+                }
+            }
+            N(SyntaxKind.FieldDeclaration);
+            {
+                N(SyntaxKind.PrivateKeyword);
+                N(SyntaxKind.VariableDeclaration);
                 {
                     N(SyntaxKind.PredefinedType);
                     {
                         N(SyntaxKind.IntKeyword);
                     }
-                    N(SyntaxKind.IdentifierToken, "P");
-                    N(SyntaxKind.AccessorList);
+                    N(SyntaxKind.VariableDeclarator);
                     {
-                        N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.GetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.GetKeyword);
-                            N(SyntaxKind.Block);
-                            {
-                                N(SyntaxKind.OpenBraceToken);
-                                N(SyntaxKind.ReturnStatement);
-                                {
-                                    N(SyntaxKind.ReturnKeyword);
-                                    N(SyntaxKind.NumericLiteralExpression);
-                                    {
-                                        N(SyntaxKind.NumericLiteralToken, "0");
-                                    }
-                                    N(SyntaxKind.SemicolonToken);
-                                }
-                                N(SyntaxKind.CloseBraceToken);
-                            }
-                        }
-                        M(SyntaxKind.CloseBraceToken);
+                        N(SyntaxKind.IdentifierToken, "F");
                     }
                 }
-                N(SyntaxKind.FieldDeclaration);
-                {
-                    N(SyntaxKind.PrivateKeyword);
-                    N(SyntaxKind.VariableDeclaration);
-                    {
-                        N(SyntaxKind.PredefinedType);
-                        {
-                            N(SyntaxKind.IntKeyword);
-                        }
-                        N(SyntaxKind.VariableDeclarator);
-                        {
-                            N(SyntaxKind.IdentifierToken, "F");
-                        }
-                    }
-                    N(SyntaxKind.SemicolonToken);
-                }
-                N(SyntaxKind.CloseBraceToken);
+                N(SyntaxKind.SemicolonToken);
             }
-            N(SyntaxKind.EndOfFileToken);
+            N(SyntaxKind.CloseBraceToken);
         }
         EOF();
 
@@ -1638,6 +1547,7 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
     [Fact]
     public void AccessorModifierBeforeFeature()
     {
+        const string declaration = "public int P { get; private set; }";
         const string source = """
             class C
             {
@@ -1646,42 +1556,31 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
             """;
         var options = TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp1);
 
-        UsingTree(source, options);
-        N(SyntaxKind.CompilationUnit);
+        UsingDeclaration(declaration, options);
+        N(SyntaxKind.PropertyDeclaration);
         {
-            N(SyntaxKind.ClassDeclaration);
+            N(SyntaxKind.PublicKeyword);
+            N(SyntaxKind.PredefinedType);
             {
-                N(SyntaxKind.ClassKeyword);
-                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "P");
+            N(SyntaxKind.AccessorList);
+            {
                 N(SyntaxKind.OpenBraceToken);
-                N(SyntaxKind.PropertyDeclaration);
+                N(SyntaxKind.GetAccessorDeclaration);
                 {
-                    N(SyntaxKind.PublicKeyword);
-                    N(SyntaxKind.PredefinedType);
-                    {
-                        N(SyntaxKind.IntKeyword);
-                    }
-                    N(SyntaxKind.IdentifierToken, "P");
-                    N(SyntaxKind.AccessorList);
-                    {
-                        N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.GetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.GetKeyword);
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.SetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.PrivateKeyword);
-                            N(SyntaxKind.SetKeyword);
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.CloseBraceToken);
-                    }
+                    N(SyntaxKind.GetKeyword);
+                    N(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.SetAccessorDeclaration);
+                {
+                    N(SyntaxKind.PrivateKeyword);
+                    N(SyntaxKind.SetKeyword);
+                    N(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.CloseBraceToken);
             }
-            N(SyntaxKind.EndOfFileToken);
         }
         EOF();
 
@@ -1697,6 +1596,7 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
     [Fact]
     public void SafeAccessorModifierBeforeFeature()
     {
+        const string declaration = "public int P { private safe get => 0; set { } }";
         const string source = """
             class C
             {
@@ -1704,55 +1604,44 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
             }
             """;
 
-        UsingTree(source, TestOptions.Regular14);
-        N(SyntaxKind.CompilationUnit);
+        UsingDeclaration(declaration, TestOptions.Regular14);
+        N(SyntaxKind.PropertyDeclaration);
         {
-            N(SyntaxKind.ClassDeclaration);
+            N(SyntaxKind.PublicKeyword);
+            N(SyntaxKind.PredefinedType);
             {
-                N(SyntaxKind.ClassKeyword);
-                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "P");
+            N(SyntaxKind.AccessorList);
+            {
                 N(SyntaxKind.OpenBraceToken);
-                N(SyntaxKind.PropertyDeclaration);
+                N(SyntaxKind.GetAccessorDeclaration);
                 {
-                    N(SyntaxKind.PublicKeyword);
-                    N(SyntaxKind.PredefinedType);
+                    N(SyntaxKind.PrivateKeyword);
+                    N(SyntaxKind.SafeKeyword);
+                    N(SyntaxKind.GetKeyword);
+                    N(SyntaxKind.ArrowExpressionClause);
                     {
-                        N(SyntaxKind.IntKeyword);
+                        N(SyntaxKind.EqualsGreaterThanToken);
+                        N(SyntaxKind.NumericLiteralExpression);
+                        {
+                            N(SyntaxKind.NumericLiteralToken, "0");
+                        }
                     }
-                    N(SyntaxKind.IdentifierToken, "P");
-                    N(SyntaxKind.AccessorList);
+                    N(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.SetAccessorDeclaration);
+                {
+                    N(SyntaxKind.SetKeyword);
+                    N(SyntaxKind.Block);
                     {
                         N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.GetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.PrivateKeyword);
-                            N(SyntaxKind.SafeKeyword);
-                            N(SyntaxKind.GetKeyword);
-                            N(SyntaxKind.ArrowExpressionClause);
-                            {
-                                N(SyntaxKind.EqualsGreaterThanToken);
-                                N(SyntaxKind.NumericLiteralExpression);
-                                {
-                                    N(SyntaxKind.NumericLiteralToken, "0");
-                                }
-                            }
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.SetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.SetKeyword);
-                            N(SyntaxKind.Block);
-                            {
-                                N(SyntaxKind.OpenBraceToken);
-                                N(SyntaxKind.CloseBraceToken);
-                            }
-                        }
                         N(SyntaxKind.CloseBraceToken);
                     }
                 }
                 N(SyntaxKind.CloseBraceToken);
             }
-            N(SyntaxKind.EndOfFileToken);
         }
         EOF();
 
@@ -1765,75 +1654,59 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
     [Fact]
     public void OlderLanguageVersionDoesNotRecognizeNewAccessorModifiers()
     {
-        const string source = """
-            class C
-            {
-                int P { required get; file set; closed init; }
-            }
-            """;
+        const string source = "int P { required get; file set; closed init; }";
 
-        UsingTree(
+        UsingDeclaration(
             source,
             TestOptions.Regular10,
-            // (3,13): error CS1014: A get or set accessor expected
-            //     int P { required get; file set; closed init; }
-            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "required").WithLocation(3, 13),
-            // (3,27): error CS1014: A get or set accessor expected
-            //     int P { required get; file set; closed init; }
-            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "file").WithLocation(3, 27),
-            // (3,37): error CS1014: A get or set accessor expected
-            //     int P { required get; file set; closed init; }
-            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "closed").WithLocation(3, 37));
-        N(SyntaxKind.CompilationUnit);
+            // (1,9): error CS1014: A get or set accessor expected
+            // int P { required get; file set; closed init; }
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "required").WithLocation(1, 9),
+            // (1,23): error CS1014: A get or set accessor expected
+            // int P { required get; file set; closed init; }
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "file").WithLocation(1, 23),
+            // (1,33): error CS1014: A get or set accessor expected
+            // int P { required get; file set; closed init; }
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "closed").WithLocation(1, 33));
+        N(SyntaxKind.PropertyDeclaration);
         {
-            N(SyntaxKind.ClassDeclaration);
+            N(SyntaxKind.PredefinedType);
             {
-                N(SyntaxKind.ClassKeyword);
-                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "P");
+            N(SyntaxKind.AccessorList);
+            {
                 N(SyntaxKind.OpenBraceToken);
-                N(SyntaxKind.PropertyDeclaration);
+                N(SyntaxKind.UnknownAccessorDeclaration);
                 {
-                    N(SyntaxKind.PredefinedType);
-                    {
-                        N(SyntaxKind.IntKeyword);
-                    }
-                    N(SyntaxKind.IdentifierToken, "P");
-                    N(SyntaxKind.AccessorList);
-                    {
-                        N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.UnknownAccessorDeclaration);
-                        {
-                            N(SyntaxKind.IdentifierToken, "required");
-                        }
-                        N(SyntaxKind.GetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.GetKeyword);
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.UnknownAccessorDeclaration);
-                        {
-                            N(SyntaxKind.IdentifierToken, "file");
-                        }
-                        N(SyntaxKind.SetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.SetKeyword);
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.UnknownAccessorDeclaration);
-                        {
-                            N(SyntaxKind.IdentifierToken, "closed");
-                        }
-                        N(SyntaxKind.InitAccessorDeclaration);
-                        {
-                            N(SyntaxKind.InitKeyword);
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.CloseBraceToken);
-                    }
+                    N(SyntaxKind.IdentifierToken, "required");
+                }
+                N(SyntaxKind.GetAccessorDeclaration);
+                {
+                    N(SyntaxKind.GetKeyword);
+                    N(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.UnknownAccessorDeclaration);
+                {
+                    N(SyntaxKind.IdentifierToken, "file");
+                }
+                N(SyntaxKind.SetAccessorDeclaration);
+                {
+                    N(SyntaxKind.SetKeyword);
+                    N(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.UnknownAccessorDeclaration);
+                {
+                    N(SyntaxKind.IdentifierToken, "closed");
+                }
+                N(SyntaxKind.InitAccessorDeclaration);
+                {
+                    N(SyntaxKind.InitKeyword);
+                    N(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.CloseBraceToken);
             }
-            N(SyntaxKind.EndOfFileToken);
         }
         EOF();
     }
@@ -1841,45 +1714,30 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
     [Fact]
     public void PartialAccessorModifierBeforeCloseBrace()
     {
-        const string source = """
-            class C
-            {
-                int P { partial }
-            }
-            """;
+        const string source = "int P { partial }";
 
-        UsingTree(
+        UsingDeclaration(
             source,
-            // (3,13): error CS1014: A get or set accessor expected
-            //     int P { partial }
-            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(3, 13));
-        N(SyntaxKind.CompilationUnit);
+            options: null,
+            // (1,9): error CS1014: A get or set accessor expected
+            // int P { partial }
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(1, 9));
+        N(SyntaxKind.PropertyDeclaration);
         {
-            N(SyntaxKind.ClassDeclaration);
+            N(SyntaxKind.PredefinedType);
             {
-                N(SyntaxKind.ClassKeyword);
-                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "P");
+            N(SyntaxKind.AccessorList);
+            {
                 N(SyntaxKind.OpenBraceToken);
-                N(SyntaxKind.PropertyDeclaration);
+                N(SyntaxKind.UnknownAccessorDeclaration);
                 {
-                    N(SyntaxKind.PredefinedType);
-                    {
-                        N(SyntaxKind.IntKeyword);
-                    }
-                    N(SyntaxKind.IdentifierToken, "P");
-                    N(SyntaxKind.AccessorList);
-                    {
-                        N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.UnknownAccessorDeclaration);
-                        {
-                            N(SyntaxKind.IdentifierToken, "partial");
-                        }
-                        N(SyntaxKind.CloseBraceToken);
-                    }
+                    N(SyntaxKind.IdentifierToken, "partial");
                 }
                 N(SyntaxKind.CloseBraceToken);
             }
-            N(SyntaxKind.EndOfFileToken);
         }
         EOF();
     }
@@ -1889,8 +1747,9 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
     {
         const string source = "class C { int P { partial";
 
-        UsingTree(
+        UsingDeclaration(
             source,
+            options: null,
             // (1,19): error CS1014: A get or set accessor expected
             // class C { int P { partial
             Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(1, 19),
@@ -1900,33 +1759,29 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
             // (1,26): error CS1513: } expected
             // class C { int P { partial
             Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(1, 26));
-        N(SyntaxKind.CompilationUnit);
+        N(SyntaxKind.ClassDeclaration);
         {
-            N(SyntaxKind.ClassDeclaration);
+            N(SyntaxKind.ClassKeyword);
+            N(SyntaxKind.IdentifierToken, "C");
+            N(SyntaxKind.OpenBraceToken);
+            N(SyntaxKind.PropertyDeclaration);
             {
-                N(SyntaxKind.ClassKeyword);
-                N(SyntaxKind.IdentifierToken, "C");
-                N(SyntaxKind.OpenBraceToken);
-                N(SyntaxKind.PropertyDeclaration);
+                N(SyntaxKind.PredefinedType);
                 {
-                    N(SyntaxKind.PredefinedType);
-                    {
-                        N(SyntaxKind.IntKeyword);
-                    }
-                    N(SyntaxKind.IdentifierToken, "P");
-                    N(SyntaxKind.AccessorList);
-                    {
-                        N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.UnknownAccessorDeclaration);
-                        {
-                            N(SyntaxKind.IdentifierToken, "partial");
-                        }
-                        M(SyntaxKind.CloseBraceToken);
-                    }
+                    N(SyntaxKind.IntKeyword);
                 }
-                M(SyntaxKind.CloseBraceToken);
+                N(SyntaxKind.IdentifierToken, "P");
+                N(SyntaxKind.AccessorList);
+                {
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.UnknownAccessorDeclaration);
+                    {
+                        N(SyntaxKind.IdentifierToken, "partial");
+                    }
+                    M(SyntaxKind.CloseBraceToken);
+                }
             }
-            N(SyntaxKind.EndOfFileToken);
+            M(SyntaxKind.CloseBraceToken);
         }
         EOF();
     }
@@ -1934,65 +1789,50 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
     [Fact]
     public void AttributeAndPartialAccessorModifierBeforeCloseBrace()
     {
-        const string source = """
-            class C
-            {
-                int P { [System.Obsolete] partial }
-            }
-            """;
+        const string source = "int P { [System.Obsolete] partial }";
 
-        UsingTree(
+        UsingDeclaration(
             source,
-            // (3,31): error CS1014: A get or set accessor expected
-            //     int P { [System.Obsolete] partial }
-            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(3, 31));
-        N(SyntaxKind.CompilationUnit);
+            options: null,
+            // (1,27): error CS1014: A get or set accessor expected
+            // int P { [System.Obsolete] partial }
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(1, 27));
+        N(SyntaxKind.PropertyDeclaration);
         {
-            N(SyntaxKind.ClassDeclaration);
+            N(SyntaxKind.PredefinedType);
             {
-                N(SyntaxKind.ClassKeyword);
-                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "P");
+            N(SyntaxKind.AccessorList);
+            {
                 N(SyntaxKind.OpenBraceToken);
-                N(SyntaxKind.PropertyDeclaration);
+                N(SyntaxKind.UnknownAccessorDeclaration);
                 {
-                    N(SyntaxKind.PredefinedType);
+                    N(SyntaxKind.AttributeList);
                     {
-                        N(SyntaxKind.IntKeyword);
-                    }
-                    N(SyntaxKind.IdentifierToken, "P");
-                    N(SyntaxKind.AccessorList);
-                    {
-                        N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.UnknownAccessorDeclaration);
+                        N(SyntaxKind.OpenBracketToken);
+                        N(SyntaxKind.Attribute);
                         {
-                            N(SyntaxKind.AttributeList);
+                            N(SyntaxKind.QualifiedName);
                             {
-                                N(SyntaxKind.OpenBracketToken);
-                                N(SyntaxKind.Attribute);
+                                N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.QualifiedName);
-                                    {
-                                        N(SyntaxKind.IdentifierName);
-                                        {
-                                            N(SyntaxKind.IdentifierToken, "System");
-                                        }
-                                        N(SyntaxKind.DotToken);
-                                        N(SyntaxKind.IdentifierName);
-                                        {
-                                            N(SyntaxKind.IdentifierToken, "Obsolete");
-                                        }
-                                    }
+                                    N(SyntaxKind.IdentifierToken, "System");
                                 }
-                                N(SyntaxKind.CloseBracketToken);
+                                N(SyntaxKind.DotToken);
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "Obsolete");
+                                }
                             }
-                            N(SyntaxKind.IdentifierToken, "partial");
                         }
-                        N(SyntaxKind.CloseBraceToken);
+                        N(SyntaxKind.CloseBracketToken);
                     }
+                    N(SyntaxKind.IdentifierToken, "partial");
                 }
                 N(SyntaxKind.CloseBraceToken);
             }
-            N(SyntaxKind.EndOfFileToken);
         }
         EOF();
     }
@@ -2010,62 +1850,59 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
             }
             """;
 
-        UsingTree(
+        UsingDeclaration(
             source,
+            options: null,
             // (6,13): error CS1014: A get or set accessor expected
             //     partial int F;
             Diagnostic(ErrorCode.ERR_GetOrSetExpected, "int").WithLocation(6, 13),
             // (6,13): error CS1513: } expected
             //     partial int F;
             Diagnostic(ErrorCode.ERR_RbraceExpected, "int").WithLocation(6, 13));
-        N(SyntaxKind.CompilationUnit);
+        N(SyntaxKind.ClassDeclaration);
         {
-            N(SyntaxKind.ClassDeclaration);
+            N(SyntaxKind.ClassKeyword);
+            N(SyntaxKind.IdentifierToken, "C");
+            N(SyntaxKind.OpenBraceToken);
+            N(SyntaxKind.PropertyDeclaration);
             {
-                N(SyntaxKind.ClassKeyword);
-                N(SyntaxKind.IdentifierToken, "C");
-                N(SyntaxKind.OpenBraceToken);
-                N(SyntaxKind.PropertyDeclaration);
+                N(SyntaxKind.PredefinedType);
+                {
+                    N(SyntaxKind.IntKeyword);
+                }
+                N(SyntaxKind.IdentifierToken, "P");
+                N(SyntaxKind.AccessorList);
+                {
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.GetAccessorDeclaration);
+                    {
+                        N(SyntaxKind.GetKeyword);
+                        N(SyntaxKind.SemicolonToken);
+                    }
+                    N(SyntaxKind.UnknownAccessorDeclaration);
+                    {
+                        N(SyntaxKind.PartialKeyword);
+                        M(SyntaxKind.IdentifierToken);
+                    }
+                    M(SyntaxKind.CloseBraceToken);
+                }
+            }
+            N(SyntaxKind.FieldDeclaration);
+            {
+                N(SyntaxKind.VariableDeclaration);
                 {
                     N(SyntaxKind.PredefinedType);
                     {
                         N(SyntaxKind.IntKeyword);
                     }
-                    N(SyntaxKind.IdentifierToken, "P");
-                    N(SyntaxKind.AccessorList);
+                    N(SyntaxKind.VariableDeclarator);
                     {
-                        N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.GetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.GetKeyword);
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.UnknownAccessorDeclaration);
-                        {
-                            N(SyntaxKind.PartialKeyword);
-                            M(SyntaxKind.IdentifierToken);
-                        }
-                        M(SyntaxKind.CloseBraceToken);
+                        N(SyntaxKind.IdentifierToken, "F");
                     }
                 }
-                N(SyntaxKind.FieldDeclaration);
-                {
-                    N(SyntaxKind.VariableDeclaration);
-                    {
-                        N(SyntaxKind.PredefinedType);
-                        {
-                            N(SyntaxKind.IntKeyword);
-                        }
-                        N(SyntaxKind.VariableDeclarator);
-                        {
-                            N(SyntaxKind.IdentifierToken, "F");
-                        }
-                    }
-                    N(SyntaxKind.SemicolonToken);
-                }
-                N(SyntaxKind.CloseBraceToken);
+                N(SyntaxKind.SemicolonToken);
             }
-            N(SyntaxKind.EndOfFileToken);
+            N(SyntaxKind.CloseBraceToken);
         }
         EOF();
     }
@@ -2073,70 +1910,55 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
     [Fact]
     public void AttributeBeforeScopedAccessorModifier()
     {
-        const string source = """
-            class C
-            {
-                int P { [System.Obsolete] scoped get; }
-            }
-            """;
+        const string source = "int P { [System.Obsolete] scoped get; }";
 
-        UsingTree(
+        UsingDeclaration(
             source,
-            // (3,31): error CS1014: A get or set accessor expected
-            //     int P { [System.Obsolete] scoped get; }
-            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "scoped").WithLocation(3, 31));
-        N(SyntaxKind.CompilationUnit);
+            options: null,
+            // (1,27): error CS1014: A get or set accessor expected
+            // int P { [System.Obsolete] scoped get; }
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "scoped").WithLocation(1, 27));
+        N(SyntaxKind.PropertyDeclaration);
         {
-            N(SyntaxKind.ClassDeclaration);
+            N(SyntaxKind.PredefinedType);
             {
-                N(SyntaxKind.ClassKeyword);
-                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "P");
+            N(SyntaxKind.AccessorList);
+            {
                 N(SyntaxKind.OpenBraceToken);
-                N(SyntaxKind.PropertyDeclaration);
+                N(SyntaxKind.UnknownAccessorDeclaration);
                 {
-                    N(SyntaxKind.PredefinedType);
+                    N(SyntaxKind.AttributeList);
                     {
-                        N(SyntaxKind.IntKeyword);
-                    }
-                    N(SyntaxKind.IdentifierToken, "P");
-                    N(SyntaxKind.AccessorList);
-                    {
-                        N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.UnknownAccessorDeclaration);
+                        N(SyntaxKind.OpenBracketToken);
+                        N(SyntaxKind.Attribute);
                         {
-                            N(SyntaxKind.AttributeList);
+                            N(SyntaxKind.QualifiedName);
                             {
-                                N(SyntaxKind.OpenBracketToken);
-                                N(SyntaxKind.Attribute);
+                                N(SyntaxKind.IdentifierName);
                                 {
-                                    N(SyntaxKind.QualifiedName);
-                                    {
-                                        N(SyntaxKind.IdentifierName);
-                                        {
-                                            N(SyntaxKind.IdentifierToken, "System");
-                                        }
-                                        N(SyntaxKind.DotToken);
-                                        N(SyntaxKind.IdentifierName);
-                                        {
-                                            N(SyntaxKind.IdentifierToken, "Obsolete");
-                                        }
-                                    }
+                                    N(SyntaxKind.IdentifierToken, "System");
                                 }
-                                N(SyntaxKind.CloseBracketToken);
+                                N(SyntaxKind.DotToken);
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "Obsolete");
+                                }
                             }
-                            N(SyntaxKind.IdentifierToken, "scoped");
                         }
-                        N(SyntaxKind.GetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.GetKeyword);
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.CloseBraceToken);
+                        N(SyntaxKind.CloseBracketToken);
                     }
+                    N(SyntaxKind.IdentifierToken, "scoped");
+                }
+                N(SyntaxKind.GetAccessorDeclaration);
+                {
+                    N(SyntaxKind.GetKeyword);
+                    N(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.CloseBraceToken);
             }
-            N(SyntaxKind.EndOfFileToken);
         }
         EOF();
     }
@@ -2144,144 +1966,135 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
     [Fact]
     public void ContextualModifiersOnOtherAccessorKinds()
     {
-        const string source = """
-            class C
-            {
-                int P { partial init; }
-                int this[int i] { scoped get; }
-                event System.Action E { partial add { } scoped remove { } }
-            }
-            """;
-
-        UsingTree(
-            source,
-            // (3,13): error CS1014: A get or set accessor expected
-            //     int P { partial init; }
-            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(3, 13),
-            // (4,23): error CS1014: A get or set accessor expected
-            //     int this[int i] { scoped get; }
-            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "scoped").WithLocation(4, 23),
-            // (5,29): error CS1055: An add or remove accessor expected
-            //     event System.Action E { partial add { } scoped remove { } }
-            Diagnostic(ErrorCode.ERR_AddOrRemoveExpected, "partial").WithLocation(5, 29),
-            // (5,45): error CS1055: An add or remove accessor expected
-            //     event System.Action E { partial add { } scoped remove { } }
-            Diagnostic(ErrorCode.ERR_AddOrRemoveExpected, "scoped").WithLocation(5, 45));
-        N(SyntaxKind.CompilationUnit);
+        UsingDeclaration(
+            "int P { partial init; }",
+            options: null,
+            // (1,9): error CS1014: A get or set accessor expected
+            // int P { partial init; }
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(1, 9));
+        N(SyntaxKind.PropertyDeclaration);
         {
-            N(SyntaxKind.ClassDeclaration);
+            N(SyntaxKind.PredefinedType);
             {
-                N(SyntaxKind.ClassKeyword);
-                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "P");
+            N(SyntaxKind.AccessorList);
+            {
                 N(SyntaxKind.OpenBraceToken);
-                N(SyntaxKind.PropertyDeclaration);
+                N(SyntaxKind.UnknownAccessorDeclaration);
+                {
+                    N(SyntaxKind.IdentifierToken, "partial");
+                }
+                N(SyntaxKind.InitAccessorDeclaration);
+                {
+                    N(SyntaxKind.InitKeyword);
+                    N(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+        }
+        EOF();
+
+        UsingDeclaration(
+            "int this[int i] { scoped get; }",
+            options: null,
+            // (1,19): error CS1014: A get or set accessor expected
+            // int this[int i] { scoped get; }
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "scoped").WithLocation(1, 19));
+        N(SyntaxKind.IndexerDeclaration);
+        {
+            N(SyntaxKind.PredefinedType);
+            {
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.ThisKeyword);
+            N(SyntaxKind.BracketedParameterList);
+            {
+                N(SyntaxKind.OpenBracketToken);
+                N(SyntaxKind.Parameter);
                 {
                     N(SyntaxKind.PredefinedType);
                     {
                         N(SyntaxKind.IntKeyword);
                     }
-                    N(SyntaxKind.IdentifierToken, "P");
-                    N(SyntaxKind.AccessorList);
+                    N(SyntaxKind.IdentifierToken, "i");
+                }
+                N(SyntaxKind.CloseBracketToken);
+            }
+            N(SyntaxKind.AccessorList);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.UnknownAccessorDeclaration);
+                {
+                    N(SyntaxKind.IdentifierToken, "scoped");
+                }
+                N(SyntaxKind.GetAccessorDeclaration);
+                {
+                    N(SyntaxKind.GetKeyword);
+                    N(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+        }
+        EOF();
+
+        UsingDeclaration(
+            "event System.Action E { partial add { } scoped remove { } }",
+            options: null,
+            // (1,25): error CS1055: An add or remove accessor expected
+            // event System.Action E { partial add { } scoped remove { } }
+            Diagnostic(ErrorCode.ERR_AddOrRemoveExpected, "partial").WithLocation(1, 25),
+            // (1,41): error CS1055: An add or remove accessor expected
+            // event System.Action E { partial add { } scoped remove { } }
+            Diagnostic(ErrorCode.ERR_AddOrRemoveExpected, "scoped").WithLocation(1, 41));
+        N(SyntaxKind.EventDeclaration);
+        {
+            N(SyntaxKind.EventKeyword);
+            N(SyntaxKind.QualifiedName);
+            {
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "System");
+                }
+                N(SyntaxKind.DotToken);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "Action");
+                }
+            }
+            N(SyntaxKind.IdentifierToken, "E");
+            N(SyntaxKind.AccessorList);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.UnknownAccessorDeclaration);
+                {
+                    N(SyntaxKind.IdentifierToken, "partial");
+                }
+                N(SyntaxKind.AddAccessorDeclaration);
+                {
+                    N(SyntaxKind.AddKeyword);
+                    N(SyntaxKind.Block);
                     {
                         N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.UnknownAccessorDeclaration);
-                        {
-                            N(SyntaxKind.IdentifierToken, "partial");
-                        }
-                        N(SyntaxKind.InitAccessorDeclaration);
-                        {
-                            N(SyntaxKind.InitKeyword);
-                            N(SyntaxKind.SemicolonToken);
-                        }
                         N(SyntaxKind.CloseBraceToken);
                     }
                 }
-                N(SyntaxKind.IndexerDeclaration);
+                N(SyntaxKind.UnknownAccessorDeclaration);
                 {
-                    N(SyntaxKind.PredefinedType);
-                    {
-                        N(SyntaxKind.IntKeyword);
-                    }
-                    N(SyntaxKind.ThisKeyword);
-                    N(SyntaxKind.BracketedParameterList);
-                    {
-                        N(SyntaxKind.OpenBracketToken);
-                        N(SyntaxKind.Parameter);
-                        {
-                            N(SyntaxKind.PredefinedType);
-                            {
-                                N(SyntaxKind.IntKeyword);
-                            }
-                            N(SyntaxKind.IdentifierToken, "i");
-                        }
-                        N(SyntaxKind.CloseBracketToken);
-                    }
-                    N(SyntaxKind.AccessorList);
-                    {
-                        N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.UnknownAccessorDeclaration);
-                        {
-                            N(SyntaxKind.IdentifierToken, "scoped");
-                        }
-                        N(SyntaxKind.GetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.GetKeyword);
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.CloseBraceToken);
-                    }
+                    N(SyntaxKind.IdentifierToken, "scoped");
                 }
-                N(SyntaxKind.EventDeclaration);
+                N(SyntaxKind.RemoveAccessorDeclaration);
                 {
-                    N(SyntaxKind.EventKeyword);
-                    N(SyntaxKind.QualifiedName);
-                    {
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken, "System");
-                        }
-                        N(SyntaxKind.DotToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken, "Action");
-                        }
-                    }
-                    N(SyntaxKind.IdentifierToken, "E");
-                    N(SyntaxKind.AccessorList);
+                    N(SyntaxKind.RemoveKeyword);
+                    N(SyntaxKind.Block);
                     {
                         N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.UnknownAccessorDeclaration);
-                        {
-                            N(SyntaxKind.IdentifierToken, "partial");
-                        }
-                        N(SyntaxKind.AddAccessorDeclaration);
-                        {
-                            N(SyntaxKind.AddKeyword);
-                            N(SyntaxKind.Block);
-                            {
-                                N(SyntaxKind.OpenBraceToken);
-                                N(SyntaxKind.CloseBraceToken);
-                            }
-                        }
-                        N(SyntaxKind.UnknownAccessorDeclaration);
-                        {
-                            N(SyntaxKind.IdentifierToken, "scoped");
-                        }
-                        N(SyntaxKind.RemoveAccessorDeclaration);
-                        {
-                            N(SyntaxKind.RemoveKeyword);
-                            N(SyntaxKind.Block);
-                            {
-                                N(SyntaxKind.OpenBraceToken);
-                                N(SyntaxKind.CloseBraceToken);
-                            }
-                        }
                         N(SyntaxKind.CloseBraceToken);
                     }
                 }
                 N(SyntaxKind.CloseBraceToken);
             }
-            N(SyntaxKind.EndOfFileToken);
         }
         EOF();
     }
@@ -2300,8 +2113,9 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
             }
             """;
 
-        UsingTree(
+        UsingDeclaration(
             source,
+            options: null,
             // (3,22): error CS8180: { or ; or => expected
             //     int P1 { ref get A; }
             Diagnostic(ErrorCode.ERR_SemiOrLBraceOrArrowExpected, "A").WithLocation(3, 22),
@@ -2332,152 +2146,148 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
             // (7,22): error CS1014: A get or set accessor expected
             //     int P5 { ref get A; set; }
             Diagnostic(ErrorCode.ERR_GetOrSetExpected, "A").WithLocation(7, 22));
-        N(SyntaxKind.CompilationUnit);
+        N(SyntaxKind.ClassDeclaration);
         {
-            N(SyntaxKind.ClassDeclaration);
+            N(SyntaxKind.ClassKeyword);
+            N(SyntaxKind.IdentifierToken, "C");
+            N(SyntaxKind.OpenBraceToken);
+            N(SyntaxKind.PropertyDeclaration);
             {
-                N(SyntaxKind.ClassKeyword);
-                N(SyntaxKind.IdentifierToken, "C");
-                N(SyntaxKind.OpenBraceToken);
-                N(SyntaxKind.PropertyDeclaration);
+                N(SyntaxKind.PredefinedType);
                 {
-                    N(SyntaxKind.PredefinedType);
-                    {
-                        N(SyntaxKind.IntKeyword);
-                    }
-                    N(SyntaxKind.IdentifierToken, "P1");
-                    N(SyntaxKind.AccessorList);
-                    {
-                        N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.GetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.RefKeyword);
-                            N(SyntaxKind.GetKeyword);
-                            M(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.UnknownAccessorDeclaration);
-                        {
-                            N(SyntaxKind.IdentifierToken, "A");
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.CloseBraceToken);
-                    }
+                    N(SyntaxKind.IntKeyword);
                 }
-                N(SyntaxKind.PropertyDeclaration);
+                N(SyntaxKind.IdentifierToken, "P1");
+                N(SyntaxKind.AccessorList);
                 {
-                    N(SyntaxKind.PredefinedType);
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.GetAccessorDeclaration);
                     {
-                        N(SyntaxKind.IntKeyword);
+                        N(SyntaxKind.RefKeyword);
+                        N(SyntaxKind.GetKeyword);
+                        M(SyntaxKind.SemicolonToken);
                     }
-                    N(SyntaxKind.IdentifierToken, "P2");
-                    N(SyntaxKind.AccessorList);
+                    N(SyntaxKind.UnknownAccessorDeclaration);
                     {
-                        N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.GetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.RefKeyword);
-                            N(SyntaxKind.GetKeyword);
-                            M(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.UnknownAccessorDeclaration);
-                        {
-                            N(SyntaxKind.IdentifierToken, "A");
-                            N(SyntaxKind.Block);
-                            {
-                                N(SyntaxKind.OpenBraceToken);
-                                N(SyntaxKind.CloseBraceToken);
-                            }
-                        }
-                        N(SyntaxKind.CloseBraceToken);
+                        N(SyntaxKind.IdentifierToken, "A");
+                        N(SyntaxKind.SemicolonToken);
                     }
+                    N(SyntaxKind.CloseBraceToken);
                 }
-                N(SyntaxKind.PropertyDeclaration);
-                {
-                    N(SyntaxKind.PredefinedType);
-                    {
-                        N(SyntaxKind.IntKeyword);
-                    }
-                    N(SyntaxKind.IdentifierToken, "P3");
-                    N(SyntaxKind.AccessorList);
-                    {
-                        N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.GetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.RefKeyword);
-                            N(SyntaxKind.GetKeyword);
-                            M(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.UnknownAccessorDeclaration);
-                        {
-                            N(SyntaxKind.IdentifierToken, "A");
-                            N(SyntaxKind.ArrowExpressionClause);
-                            {
-                                N(SyntaxKind.EqualsGreaterThanToken);
-                                N(SyntaxKind.NumericLiteralExpression);
-                                {
-                                    N(SyntaxKind.NumericLiteralToken, "0");
-                                }
-                            }
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.CloseBraceToken);
-                    }
-                }
-                N(SyntaxKind.PropertyDeclaration);
-                {
-                    N(SyntaxKind.PredefinedType);
-                    {
-                        N(SyntaxKind.IntKeyword);
-                    }
-                    N(SyntaxKind.IdentifierToken, "P4");
-                    N(SyntaxKind.AccessorList);
-                    {
-                        N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.GetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.RefKeyword);
-                            N(SyntaxKind.GetKeyword);
-                            M(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.UnknownAccessorDeclaration);
-                        {
-                            N(SyntaxKind.IdentifierToken, "A");
-                        }
-                        N(SyntaxKind.CloseBraceToken);
-                    }
-                }
-                N(SyntaxKind.PropertyDeclaration);
-                {
-                    N(SyntaxKind.PredefinedType);
-                    {
-                        N(SyntaxKind.IntKeyword);
-                    }
-                    N(SyntaxKind.IdentifierToken, "P5");
-                    N(SyntaxKind.AccessorList);
-                    {
-                        N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.GetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.RefKeyword);
-                            N(SyntaxKind.GetKeyword);
-                            M(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.UnknownAccessorDeclaration);
-                        {
-                            N(SyntaxKind.IdentifierToken, "A");
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.SetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.SetKeyword);
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.CloseBraceToken);
-                    }
-                }
-                N(SyntaxKind.CloseBraceToken);
             }
-            N(SyntaxKind.EndOfFileToken);
+            N(SyntaxKind.PropertyDeclaration);
+            {
+                N(SyntaxKind.PredefinedType);
+                {
+                    N(SyntaxKind.IntKeyword);
+                }
+                N(SyntaxKind.IdentifierToken, "P2");
+                N(SyntaxKind.AccessorList);
+                {
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.GetAccessorDeclaration);
+                    {
+                        N(SyntaxKind.RefKeyword);
+                        N(SyntaxKind.GetKeyword);
+                        M(SyntaxKind.SemicolonToken);
+                    }
+                    N(SyntaxKind.UnknownAccessorDeclaration);
+                    {
+                        N(SyntaxKind.IdentifierToken, "A");
+                        N(SyntaxKind.Block);
+                        {
+                            N(SyntaxKind.OpenBraceToken);
+                            N(SyntaxKind.CloseBraceToken);
+                        }
+                    }
+                    N(SyntaxKind.CloseBraceToken);
+                }
+            }
+            N(SyntaxKind.PropertyDeclaration);
+            {
+                N(SyntaxKind.PredefinedType);
+                {
+                    N(SyntaxKind.IntKeyword);
+                }
+                N(SyntaxKind.IdentifierToken, "P3");
+                N(SyntaxKind.AccessorList);
+                {
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.GetAccessorDeclaration);
+                    {
+                        N(SyntaxKind.RefKeyword);
+                        N(SyntaxKind.GetKeyword);
+                        M(SyntaxKind.SemicolonToken);
+                    }
+                    N(SyntaxKind.UnknownAccessorDeclaration);
+                    {
+                        N(SyntaxKind.IdentifierToken, "A");
+                        N(SyntaxKind.ArrowExpressionClause);
+                        {
+                            N(SyntaxKind.EqualsGreaterThanToken);
+                            N(SyntaxKind.NumericLiteralExpression);
+                            {
+                                N(SyntaxKind.NumericLiteralToken, "0");
+                            }
+                        }
+                        N(SyntaxKind.SemicolonToken);
+                    }
+                    N(SyntaxKind.CloseBraceToken);
+                }
+            }
+            N(SyntaxKind.PropertyDeclaration);
+            {
+                N(SyntaxKind.PredefinedType);
+                {
+                    N(SyntaxKind.IntKeyword);
+                }
+                N(SyntaxKind.IdentifierToken, "P4");
+                N(SyntaxKind.AccessorList);
+                {
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.GetAccessorDeclaration);
+                    {
+                        N(SyntaxKind.RefKeyword);
+                        N(SyntaxKind.GetKeyword);
+                        M(SyntaxKind.SemicolonToken);
+                    }
+                    N(SyntaxKind.UnknownAccessorDeclaration);
+                    {
+                        N(SyntaxKind.IdentifierToken, "A");
+                    }
+                    N(SyntaxKind.CloseBraceToken);
+                }
+            }
+            N(SyntaxKind.PropertyDeclaration);
+            {
+                N(SyntaxKind.PredefinedType);
+                {
+                    N(SyntaxKind.IntKeyword);
+                }
+                N(SyntaxKind.IdentifierToken, "P5");
+                N(SyntaxKind.AccessorList);
+                {
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.GetAccessorDeclaration);
+                    {
+                        N(SyntaxKind.RefKeyword);
+                        N(SyntaxKind.GetKeyword);
+                        M(SyntaxKind.SemicolonToken);
+                    }
+                    N(SyntaxKind.UnknownAccessorDeclaration);
+                    {
+                        N(SyntaxKind.IdentifierToken, "A");
+                        N(SyntaxKind.SemicolonToken);
+                    }
+                    N(SyntaxKind.SetAccessorDeclaration);
+                    {
+                        N(SyntaxKind.SetKeyword);
+                        N(SyntaxKind.SemicolonToken);
+                    }
+                    N(SyntaxKind.CloseBraceToken);
+                }
+            }
+            N(SyntaxKind.CloseBraceToken);
         }
         EOF();
     }
@@ -2722,49 +2532,39 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
     [Fact]
     public void TrailingContextualModifierInEventAccessorList()
     {
-        const string source = "class C { event System.Action E { scoped } }";
+        const string source = "event System.Action E { scoped }";
 
-        UsingTree(
+        UsingDeclaration(
             source,
-            // (1,35): error CS1055: An add or remove accessor expected
-            // class C { event System.Action E { scoped } }
-            Diagnostic(ErrorCode.ERR_AddOrRemoveExpected, "scoped").WithLocation(1, 35));
-        N(SyntaxKind.CompilationUnit);
+            options: null,
+            // (1,25): error CS1055: An add or remove accessor expected
+            // event System.Action E { scoped }
+            Diagnostic(ErrorCode.ERR_AddOrRemoveExpected, "scoped").WithLocation(1, 25));
+        N(SyntaxKind.EventDeclaration);
         {
-            N(SyntaxKind.ClassDeclaration);
+            N(SyntaxKind.EventKeyword);
+            N(SyntaxKind.QualifiedName);
             {
-                N(SyntaxKind.ClassKeyword);
-                N(SyntaxKind.IdentifierToken, "C");
-                N(SyntaxKind.OpenBraceToken);
-                N(SyntaxKind.EventDeclaration);
+                N(SyntaxKind.IdentifierName);
                 {
-                    N(SyntaxKind.EventKeyword);
-                    N(SyntaxKind.QualifiedName);
-                    {
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken, "System");
-                        }
-                        N(SyntaxKind.DotToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken, "Action");
-                        }
-                    }
-                    N(SyntaxKind.IdentifierToken, "E");
-                    N(SyntaxKind.AccessorList);
-                    {
-                        N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.UnknownAccessorDeclaration);
-                        {
-                            N(SyntaxKind.IdentifierToken, "scoped");
-                        }
-                        N(SyntaxKind.CloseBraceToken);
-                    }
+                    N(SyntaxKind.IdentifierToken, "System");
+                }
+                N(SyntaxKind.DotToken);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "Action");
+                }
+            }
+            N(SyntaxKind.IdentifierToken, "E");
+            N(SyntaxKind.AccessorList);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.UnknownAccessorDeclaration);
+                {
+                    N(SyntaxKind.IdentifierToken, "scoped");
                 }
                 N(SyntaxKind.CloseBraceToken);
             }
-            N(SyntaxKind.EndOfFileToken);
         }
         EOF();
     }
@@ -2774,55 +2574,52 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
     {
         const string source = "class C { int P { ref get 0; } }";
 
-        UsingTree(
+        UsingDeclaration(
             source,
+            options: null,
             // (1,27): error CS8180: { or ; or => expected
             // class C { int P { ref get 0; } }
             Diagnostic(ErrorCode.ERR_SemiOrLBraceOrArrowExpected, "0").WithLocation(1, 27),
             // (1,33): error CS1513: } expected
             // class C { int P { ref get 0; } }
             Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(1, 33));
-        N(SyntaxKind.CompilationUnit);
+        N(SyntaxKind.ClassDeclaration);
         {
-            N(SyntaxKind.ClassDeclaration);
+            N(SyntaxKind.ClassKeyword);
+            N(SyntaxKind.IdentifierToken, "C");
+            N(SyntaxKind.OpenBraceToken);
+            N(SyntaxKind.PropertyDeclaration);
             {
-                N(SyntaxKind.ClassKeyword);
-                N(SyntaxKind.IdentifierToken, "C");
-                N(SyntaxKind.OpenBraceToken);
-                N(SyntaxKind.PropertyDeclaration);
+                N(SyntaxKind.PredefinedType);
                 {
-                    N(SyntaxKind.PredefinedType);
-                    {
-                        N(SyntaxKind.IntKeyword);
-                    }
-                    N(SyntaxKind.IdentifierToken, "P");
-                    N(SyntaxKind.AccessorList);
-                    {
-                        N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.GetAccessorDeclaration);
-                        {
-                            N(SyntaxKind.RefKeyword);
-                            N(SyntaxKind.GetKeyword);
-                            N(SyntaxKind.Block);
-                            {
-                                M(SyntaxKind.OpenBraceToken);
-                                N(SyntaxKind.ExpressionStatement);
-                                {
-                                    N(SyntaxKind.NumericLiteralExpression);
-                                    {
-                                        N(SyntaxKind.NumericLiteralToken, "0");
-                                    }
-                                    N(SyntaxKind.SemicolonToken);
-                                }
-                                N(SyntaxKind.CloseBraceToken);
-                            }
-                        }
-                        N(SyntaxKind.CloseBraceToken);
-                    }
+                    N(SyntaxKind.IntKeyword);
                 }
-                M(SyntaxKind.CloseBraceToken);
+                N(SyntaxKind.IdentifierToken, "P");
+                N(SyntaxKind.AccessorList);
+                {
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.GetAccessorDeclaration);
+                    {
+                        N(SyntaxKind.RefKeyword);
+                        N(SyntaxKind.GetKeyword);
+                        N(SyntaxKind.Block);
+                        {
+                            M(SyntaxKind.OpenBraceToken);
+                            N(SyntaxKind.ExpressionStatement);
+                            {
+                                N(SyntaxKind.NumericLiteralExpression);
+                                {
+                                    N(SyntaxKind.NumericLiteralToken, "0");
+                                }
+                                N(SyntaxKind.SemicolonToken);
+                            }
+                            N(SyntaxKind.CloseBraceToken);
+                        }
+                    }
+                    N(SyntaxKind.CloseBraceToken);
+                }
             }
-            N(SyntaxKind.EndOfFileToken);
+            M(SyntaxKind.CloseBraceToken);
         }
         EOF();
     }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/AccessorDeclarationParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/AccessorDeclarationParsingTests.cs
@@ -10,7 +10,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests;
 
-public sealed class AccessorModifierParsingTests(ITestOutputHelper output) : ParsingTests(output)
+public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : ParsingTests(output)
 {
     [Fact]
     public void ContextualAndKeywordAccessorModifierOrderings()

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/AccessorDeclarationParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/AccessorDeclarationParsingTests.cs
@@ -26,10 +26,20 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
 
         UsingTree(
             source,
+            // (3,13): error CS1014: A get or set accessor expected
+            //     int P { partial ref get; }
             Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(3, 13),
+            // (4,13): error CS1014: A get or set accessor expected
+            //     int Q { async partial get; }
             Diagnostic(ErrorCode.ERR_GetOrSetExpected, "async").WithLocation(4, 13),
+            // (4,19): error CS1014: A get or set accessor expected
+            //     int Q { async partial get; }
             Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(4, 19),
+            // (5,13): error CS1513: } expected
+            //     int R { ref scoped get; }
             Diagnostic(ErrorCode.ERR_RbraceExpected, "ref").WithLocation(5, 13),
+            // (6,1): error CS1022: Type or namespace definition, or end-of-file expected
+            // }
             Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(6, 1));
         N(SyntaxKind.CompilationUnit);
         {
@@ -196,7 +206,11 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
 
         UsingTree(
             source,
+            // (1,19): error CS1014: A get or set accessor expected
+            // class C { int P { partial { } partial; } }
             Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(1, 19),
+            // (1,31): error CS1014: A get or set accessor expected
+            // class C { int P { partial { } partial; } }
             Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(1, 31));
         N(SyntaxKind.CompilationUnit);
         {
@@ -246,9 +260,17 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
 
         UsingTree(
             source,
+            // (1,19): error CS1014: A get or set accessor expected
+            // class C { int P { @partial; @async; @scoped; unknown; } }
             Diagnostic(ErrorCode.ERR_GetOrSetExpected, "@partial").WithLocation(1, 19),
+            // (1,29): error CS1014: A get or set accessor expected
+            // class C { int P { @partial; @async; @scoped; unknown; } }
             Diagnostic(ErrorCode.ERR_GetOrSetExpected, "@async").WithLocation(1, 29),
+            // (1,37): error CS1014: A get or set accessor expected
+            // class C { int P { @partial; @async; @scoped; unknown; } }
             Diagnostic(ErrorCode.ERR_GetOrSetExpected, "@scoped").WithLocation(1, 37),
+            // (1,46): error CS1014: A get or set accessor expected
+            // class C { int P { @partial; @async; @scoped; unknown; } }
             Diagnostic(ErrorCode.ERR_GetOrSetExpected, "unknown").WithLocation(1, 46));
         N(SyntaxKind.CompilationUnit);
         {
@@ -304,8 +326,14 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
 
         UsingTree(
             source,
+            // (1,19): error CS1014: A get or set accessor expected
+            // class C { int P { partial => 0; partial unknown; } }
             Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(1, 19),
+            // (1,33): error CS1014: A get or set accessor expected
+            // class C { int P { partial => 0; partial unknown; } }
             Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(1, 33),
+            // (1,41): error CS1014: A get or set accessor expected
+            // class C { int P { partial => 0; partial unknown; } }
             Diagnostic(ErrorCode.ERR_GetOrSetExpected, "unknown").WithLocation(1, 41));
         N(SyntaxKind.CompilationUnit);
         {
@@ -363,8 +391,14 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
 
         UsingTree(
             source,
+            // (1,19): error CS1513: } expected
+            // class C { int P { private [System.Obsolete] get; } }
             Diagnostic(ErrorCode.ERR_RbraceExpected, "private").WithLocation(1, 19),
+            // (1,27): error CS1031: Type expected
+            // class C { int P { private [System.Obsolete] get; } }
             Diagnostic(ErrorCode.ERR_TypeExpected, "[").WithLocation(1, 27),
+            // (1,52): error CS1022: Type or namespace definition, or end-of-file expected
+            // class C { int P { private [System.Obsolete] get; } }
             Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(1, 52));
         N(SyntaxKind.CompilationUnit);
         {
@@ -665,10 +699,20 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
         EOF();
 
         CreateCompilation(source).VerifyDiagnostics(
+            // (3,17): error CS0106: The modifier 'ref' is not valid for this item
+            //     int P { ref get => 0; abstract ref set { } }
             Diagnostic(ErrorCode.ERR_BadMemberFlag, "get").WithArguments("ref").WithLocation(3, 17),
+            // (3,40): error CS0106: The modifier 'abstract' is not valid for this item
+            //     int P { ref get => 0; abstract ref set { } }
             Diagnostic(ErrorCode.ERR_BadMemberFlag, "set").WithArguments("abstract").WithLocation(3, 40),
+            // (3,40): error CS0106: The modifier 'ref' is not valid for this item
+            //     int P { ref get => 0; abstract ref set { } }
             Diagnostic(ErrorCode.ERR_BadMemberFlag, "set").WithArguments("ref").WithLocation(3, 40),
+            // (4,29): error CS1609: Modifiers cannot be placed on event accessor declarations
+            //     event System.Action E { ref add { } abstract ref remove { } }
             Diagnostic(ErrorCode.ERR_NoModifiersOnAccessor, "ref").WithLocation(4, 29),
+            // (4,41): error CS1609: Modifiers cannot be placed on event accessor declarations
+            //     event System.Action E { ref add { } abstract ref remove { } }
             Diagnostic(ErrorCode.ERR_NoModifiersOnAccessor, "abstract").WithLocation(4, 41));
     }
 
@@ -852,6 +896,8 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
 
         UsingTree(
             source,
+            // (3,21): error CS8180: { or ; or => expected
+            //     int P { ref get }
             Diagnostic(ErrorCode.ERR_SemiOrLBraceOrArrowExpected, "}").WithLocation(3, 21));
         N(SyntaxKind.CompilationUnit);
         {
@@ -886,7 +932,11 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
         EOF();
 
         CreateCompilation(source).VerifyDiagnostics(
+            // (3,17): error CS0106: The modifier 'ref' is not valid for this item
+            //     int P { ref get }
             Diagnostic(ErrorCode.ERR_BadMemberFlag, "get").WithArguments("ref").WithLocation(3, 17),
+            // (3,21): error CS8180: { or ; or => expected
+            //     int P { ref get }
             Diagnostic(ErrorCode.ERR_SemiOrLBraceOrArrowExpected, "}").WithLocation(3, 21));
     }
 
@@ -902,6 +952,8 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
 
         UsingTree(
             source,
+            // (3,20): error CS1014: A get or set accessor expected
+            //     public int P { scoped ref get; set; }
             Diagnostic(ErrorCode.ERR_GetOrSetExpected, "scoped").WithLocation(3, 20));
         N(SyntaxKind.CompilationUnit);
         {
@@ -946,7 +998,11 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
         EOF();
 
         CreateCompilation(source).VerifyDiagnostics(
+            // (3,20): error CS1014: A get or set accessor expected
+            //     public int P { scoped ref get; set; }
             Diagnostic(ErrorCode.ERR_GetOrSetExpected, "scoped").WithLocation(3, 20),
+            // (3,31): error CS0106: The modifier 'ref' is not valid for this item
+            //     public int P { scoped ref get; set; }
             Diagnostic(ErrorCode.ERR_BadMemberFlag, "get").WithArguments("ref").WithLocation(3, 31));
     }
 
@@ -965,6 +1021,8 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
         UsingTree(
             source,
             TestOptions.RegularPreview,
+            // (5,13): error CS1014: A get or set accessor expected
+            //     int R { safe; get => 0; set { } }
             Diagnostic(ErrorCode.ERR_GetOrSetExpected, "safe").WithLocation(5, 13));
         N(SyntaxKind.CompilationUnit);
         {
@@ -1096,6 +1154,8 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
         EOF();
 
         CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (5,13): error CS1014: A get or set accessor expected
+            //     int R { safe; get => 0; set { } }
             Diagnostic(ErrorCode.ERR_GetOrSetExpected, "safe").WithLocation(5, 13));
     }
 
@@ -1116,10 +1176,20 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
         UsingTree(
             source,
             TestOptions.RegularPreview,
+            // (3,13): error CS1014: A get or set accessor expected
+            //     int P { scoped get; set; }
             Diagnostic(ErrorCode.ERR_GetOrSetExpected, "scoped").WithLocation(3, 13),
+            // (4,13): error CS1014: A get or set accessor expected
+            //     int Q { partial get; set; }
             Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(4, 13),
+            // (5,13): error CS1014: A get or set accessor expected
+            //     int R { async get; set; }
             Diagnostic(ErrorCode.ERR_GetOrSetExpected, "async").WithLocation(5, 13),
+            // (6,28): error CS1014: A get or set accessor expected
+            //     public int S { private async get; set; }
             Diagnostic(ErrorCode.ERR_GetOrSetExpected, "async").WithLocation(6, 28),
+            // (7,28): error CS1014: A get or set accessor expected
+            //     public int T { private partial get; set; }
             Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(7, 28));
         N(SyntaxKind.CompilationUnit);
         {
@@ -1377,10 +1447,20 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
         EOF();
 
         CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (3,22): error CS0106: The modifier 'required' is not valid for this item
+            //     int P { required get; file set; }
             Diagnostic(ErrorCode.ERR_BadMemberFlag, "get").WithArguments("required").WithLocation(3, 22),
+            // (3,32): error CS0106: The modifier 'file' is not valid for this item
+            //     int P { required get; file set; }
             Diagnostic(ErrorCode.ERR_BadMemberFlag, "set").WithArguments("file").WithLocation(3, 32),
+            // (4,20): error CS0106: The modifier 'closed' is not valid for this item
+            //     int Q { closed get; static set; }
             Diagnostic(ErrorCode.ERR_BadMemberFlag, "get").WithArguments("closed").WithLocation(4, 20),
+            // (4,32): error CS0106: The modifier 'static' is not valid for this item
+            //     int Q { closed get; static set; }
             Diagnostic(ErrorCode.ERR_BadMemberFlag, "set").WithArguments("static").WithLocation(4, 32),
+            // (5,28): error CS1004: Duplicate 'private' modifier
+            //     public int R { private private get; set; }
             Diagnostic(ErrorCode.ERR_DuplicateModifier, "private").WithArguments("private").WithLocation(5, 28));
     }
 
@@ -1483,6 +1563,8 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
 
         UsingTree(
             source,
+            // (5,26): error CS1513: } expected
+            //         get { return 0; }
             Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(5, 26));
         N(SyntaxKind.CompilationUnit);
         {
@@ -1545,7 +1627,11 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
         EOF();
 
         CreateCompilation(source).VerifyDiagnostics(
+            // (5,26): error CS1513: } expected
+            //         get { return 0; }
             Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(5, 26),
+            // (6,17): warning CS0169: The field 'C.F' is never used
+            //     private int F;
             Diagnostic(ErrorCode.WRN_UnreferencedField, "F").WithArguments("C.F").WithLocation(6, 17));
     }
 
@@ -1600,7 +1686,11 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
         EOF();
 
         CreateCompilation(source, parseOptions: options).VerifyDiagnostics(
+            // (3,16): error CS8022: Feature 'automatically implemented properties' is not available in C# 1. Please use language version 3 or greater.
+            //     public int P { get; private set; }
             Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion1, "P").WithArguments("automatically implemented properties", "3").WithLocation(3, 16),
+            // (3,25): error CS8022: Feature 'access modifiers on properties' is not available in C# 1. Please use language version 2 or greater.
+            //     public int P { get; private set; }
             Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion1, "private").WithArguments("access modifiers on properties", "2").WithLocation(3, 25));
     }
 
@@ -1667,6 +1757,8 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
         EOF();
 
         CreateCompilation(source, parseOptions: TestOptions.Regular14).VerifyDiagnostics(
+            // (3,28): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            //     public int P { private safe get => 0; set { } }
             Diagnostic(ErrorCode.ERR_FeatureInPreview, "safe").WithArguments("updated memory safety rules").WithLocation(3, 28));
     }
 
@@ -1683,8 +1775,14 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
         UsingTree(
             source,
             TestOptions.Regular10,
+            // (3,13): error CS1014: A get or set accessor expected
+            //     int P { required get; file set; closed init; }
             Diagnostic(ErrorCode.ERR_GetOrSetExpected, "required").WithLocation(3, 13),
+            // (3,27): error CS1014: A get or set accessor expected
+            //     int P { required get; file set; closed init; }
             Diagnostic(ErrorCode.ERR_GetOrSetExpected, "file").WithLocation(3, 27),
+            // (3,37): error CS1014: A get or set accessor expected
+            //     int P { required get; file set; closed init; }
             Diagnostic(ErrorCode.ERR_GetOrSetExpected, "closed").WithLocation(3, 37));
         N(SyntaxKind.CompilationUnit);
         {
@@ -1752,6 +1850,8 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
 
         UsingTree(
             source,
+            // (3,13): error CS1014: A get or set accessor expected
+            //     int P { partial }
             Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(3, 13));
         N(SyntaxKind.CompilationUnit);
         {
@@ -1791,8 +1891,14 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
 
         UsingTree(
             source,
+            // (1,19): error CS1014: A get or set accessor expected
+            // class C { int P { partial
             Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(1, 19),
+            // (1,26): error CS1513: } expected
+            // class C { int P { partial
             Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(1, 26),
+            // (1,26): error CS1513: } expected
+            // class C { int P { partial
             Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(1, 26));
         N(SyntaxKind.CompilationUnit);
         {
@@ -1837,6 +1943,8 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
 
         UsingTree(
             source,
+            // (3,31): error CS1014: A get or set accessor expected
+            //     int P { [System.Obsolete] partial }
             Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(3, 31));
         N(SyntaxKind.CompilationUnit);
         {
@@ -1904,7 +2012,11 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
 
         UsingTree(
             source,
+            // (6,13): error CS1014: A get or set accessor expected
+            //     partial int F;
             Diagnostic(ErrorCode.ERR_GetOrSetExpected, "int").WithLocation(6, 13),
+            // (6,13): error CS1513: } expected
+            //     partial int F;
             Diagnostic(ErrorCode.ERR_RbraceExpected, "int").WithLocation(6, 13));
         N(SyntaxKind.CompilationUnit);
         {
@@ -1970,6 +2082,8 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
 
         UsingTree(
             source,
+            // (3,31): error CS1014: A get or set accessor expected
+            //     int P { [System.Obsolete] scoped get; }
             Diagnostic(ErrorCode.ERR_GetOrSetExpected, "scoped").WithLocation(3, 31));
         N(SyntaxKind.CompilationUnit);
         {
@@ -2041,9 +2155,17 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
 
         UsingTree(
             source,
+            // (3,13): error CS1014: A get or set accessor expected
+            //     int P { partial init; }
             Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(3, 13),
+            // (4,23): error CS1014: A get or set accessor expected
+            //     int this[int i] { scoped get; }
             Diagnostic(ErrorCode.ERR_GetOrSetExpected, "scoped").WithLocation(4, 23),
+            // (5,29): error CS1055: An add or remove accessor expected
+            //     event System.Action E { partial add { } scoped remove { } }
             Diagnostic(ErrorCode.ERR_AddOrRemoveExpected, "partial").WithLocation(5, 29),
+            // (5,45): error CS1055: An add or remove accessor expected
+            //     event System.Action E { partial add { } scoped remove { } }
             Diagnostic(ErrorCode.ERR_AddOrRemoveExpected, "scoped").WithLocation(5, 45));
         N(SyntaxKind.CompilationUnit);
         {
@@ -2180,15 +2302,35 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
 
         UsingTree(
             source,
+            // (3,22): error CS8180: { or ; or => expected
+            //     int P1 { ref get A; }
             Diagnostic(ErrorCode.ERR_SemiOrLBraceOrArrowExpected, "A").WithLocation(3, 22),
+            // (3,22): error CS1014: A get or set accessor expected
+            //     int P1 { ref get A; }
             Diagnostic(ErrorCode.ERR_GetOrSetExpected, "A").WithLocation(3, 22),
+            // (4,22): error CS8180: { or ; or => expected
+            //     int P2 { ref get A { } }
             Diagnostic(ErrorCode.ERR_SemiOrLBraceOrArrowExpected, "A").WithLocation(4, 22),
+            // (4,22): error CS1014: A get or set accessor expected
+            //     int P2 { ref get A { } }
             Diagnostic(ErrorCode.ERR_GetOrSetExpected, "A").WithLocation(4, 22),
+            // (5,22): error CS8180: { or ; or => expected
+            //     int P3 { ref get A => 0; }
             Diagnostic(ErrorCode.ERR_SemiOrLBraceOrArrowExpected, "A").WithLocation(5, 22),
+            // (5,22): error CS1014: A get or set accessor expected
+            //     int P3 { ref get A => 0; }
             Diagnostic(ErrorCode.ERR_GetOrSetExpected, "A").WithLocation(5, 22),
+            // (6,22): error CS8180: { or ; or => expected
+            //     int P4 { ref get A }
             Diagnostic(ErrorCode.ERR_SemiOrLBraceOrArrowExpected, "A").WithLocation(6, 22),
+            // (6,22): error CS1014: A get or set accessor expected
+            //     int P4 { ref get A }
             Diagnostic(ErrorCode.ERR_GetOrSetExpected, "A").WithLocation(6, 22),
+            // (7,22): error CS8180: { or ; or => expected
+            //     int P5 { ref get A; set; }
             Diagnostic(ErrorCode.ERR_SemiOrLBraceOrArrowExpected, "A").WithLocation(7, 22),
+            // (7,22): error CS1014: A get or set accessor expected
+            //     int P5 { ref get A; set; }
             Diagnostic(ErrorCode.ERR_GetOrSetExpected, "A").WithLocation(7, 22));
         N(SyntaxKind.CompilationUnit);
         {
@@ -2347,11 +2489,23 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
 
         UsingTree(
             source,
+            // (1,27): error CS8180: { or ; or => expected
+            // class C { int P { ref get A(); } }
             Diagnostic(ErrorCode.ERR_SemiOrLBraceOrArrowExpected, "A").WithLocation(1, 27),
+            // (1,27): error CS1014: A get or set accessor expected
+            // class C { int P { ref get A(); } }
             Diagnostic(ErrorCode.ERR_GetOrSetExpected, "A").WithLocation(1, 27),
+            // (1,28): error CS1513: } expected
+            // class C { int P { ref get A(); } }
             Diagnostic(ErrorCode.ERR_RbraceExpected, "(").WithLocation(1, 28),
+            // (1,29): error CS8124: Tuple must contain at least two elements.
+            // class C { int P { ref get A(); } }
             Diagnostic(ErrorCode.ERR_TupleTooFewElements, ")").WithLocation(1, 29),
+            // (1,30): error CS1519: Invalid token ';' in a member declaration
+            // class C { int P { ref get A(); } }
             Diagnostic(ErrorCode.ERR_InvalidMemberDecl, ";").WithArguments(";").WithLocation(1, 30),
+            // (1,34): error CS1022: Type or namespace definition, or end-of-file expected
+            // class C { int P { ref get A(); } }
             Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(1, 34));
         N(SyntaxKind.CompilationUnit);
         {
@@ -2420,7 +2574,11 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
 
         UsingTree(
             source,
+            // (1,19): error CS1513: } expected
+            // class C { int P { private int F; } }
             Diagnostic(ErrorCode.ERR_RbraceExpected, "private").WithLocation(1, 19),
+            // (1,36): error CS1022: Type or namespace definition, or end-of-file expected
+            // class C { int P { private int F; } }
             Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(1, 36));
         N(SyntaxKind.CompilationUnit);
         {
@@ -2472,13 +2630,29 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
 
         UsingTree(
             source,
+            // (1,20): error CS1513: } expected
+            // class C1 { int P { private { } } } class C2 { int P { private; } }
             Diagnostic(ErrorCode.ERR_RbraceExpected, "private").WithLocation(1, 20),
+            // (1,28): error CS1031: Type expected
+            // class C1 { int P { private { } } } class C2 { int P { private; } }
             Diagnostic(ErrorCode.ERR_TypeExpected, "{").WithLocation(1, 28),
+            // (1,28): error CS1001: Identifier expected
+            // class C1 { int P { private { } } } class C2 { int P { private; } }
             Diagnostic(ErrorCode.ERR_IdentifierExpected, "{").WithLocation(1, 28),
+            // (1,34): error CS1022: Type or namespace definition, or end-of-file expected
+            // class C1 { int P { private { } } } class C2 { int P { private; } }
             Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(1, 34),
+            // (1,55): error CS1513: } expected
+            // class C1 { int P { private { } } } class C2 { int P { private; } }
             Diagnostic(ErrorCode.ERR_RbraceExpected, "private").WithLocation(1, 55),
+            // (1,62): error CS1519: Invalid token ';' in a member declaration
+            // class C1 { int P { private { } } } class C2 { int P { private; } }
             Diagnostic(ErrorCode.ERR_InvalidMemberDecl, ";").WithArguments(";").WithLocation(1, 62),
+            // (1,62): error CS1519: Invalid token ';' in a member declaration
+            // class C1 { int P { private { } } } class C2 { int P { private; } }
             Diagnostic(ErrorCode.ERR_InvalidMemberDecl, ";").WithArguments(";").WithLocation(1, 62),
+            // (1,66): error CS1022: Type or namespace definition, or end-of-file expected
+            // class C1 { int P { private { } } } class C2 { int P { private; } }
             Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(1, 66));
         N(SyntaxKind.CompilationUnit);
         {
@@ -2552,6 +2726,8 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
 
         UsingTree(
             source,
+            // (1,35): error CS1055: An add or remove accessor expected
+            // class C { event System.Action E { scoped } }
             Diagnostic(ErrorCode.ERR_AddOrRemoveExpected, "scoped").WithLocation(1, 35));
         N(SyntaxKind.CompilationUnit);
         {
@@ -2600,7 +2776,11 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
 
         UsingTree(
             source,
+            // (1,27): error CS8180: { or ; or => expected
+            // class C { int P { ref get 0; } }
             Diagnostic(ErrorCode.ERR_SemiOrLBraceOrArrowExpected, "0").WithLocation(1, 27),
+            // (1,33): error CS1513: } expected
+            // class C { int P { ref get 0; } }
             Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(1, 33));
         N(SyntaxKind.CompilationUnit);
         {

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/AccessorModifierParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/AccessorModifierParsingTests.cs
@@ -13,6 +13,423 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests;
 public sealed class AccessorModifierParsingTests(ITestOutputHelper output) : ParsingTests(output)
 {
     [Fact]
+    public void ContextualAndKeywordAccessorModifierOrderings()
+    {
+        const string source = """
+            class C
+            {
+                int P { partial ref get; }
+                int Q { async partial get; }
+                int R { ref scoped get; }
+            }
+            """;
+
+        UsingTree(
+            source,
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(3, 13),
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "async").WithLocation(4, 13),
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(4, 19),
+            Diagnostic(ErrorCode.ERR_RbraceExpected, "ref").WithLocation(5, 13),
+            Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(6, 1));
+        N(SyntaxKind.CompilationUnit);
+        {
+            N(SyntaxKind.ClassDeclaration);
+            {
+                N(SyntaxKind.ClassKeyword);
+                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "P");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.UnknownAccessorDeclaration);
+                        {
+                            N(SyntaxKind.IdentifierToken, "partial");
+                        }
+                        N(SyntaxKind.GetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.RefKeyword);
+                            N(SyntaxKind.GetKeyword);
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "Q");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.UnknownAccessorDeclaration);
+                        {
+                            N(SyntaxKind.IdentifierToken, "async");
+                        }
+                        N(SyntaxKind.UnknownAccessorDeclaration);
+                        {
+                            N(SyntaxKind.IdentifierToken, "partial");
+                        }
+                        N(SyntaxKind.GetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.GetKeyword);
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "R");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        M(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.FieldDeclaration);
+                {
+                    N(SyntaxKind.VariableDeclaration);
+                    {
+                        N(SyntaxKind.RefType);
+                        {
+                            N(SyntaxKind.RefKeyword);
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "scoped");
+                            }
+                        }
+                        N(SyntaxKind.VariableDeclarator);
+                        {
+                            N(SyntaxKind.IdentifierToken, "get");
+                        }
+                    }
+                    N(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+            N(SyntaxKind.EndOfFileToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void RefAccessorModifierBodyForms()
+    {
+        const string source = "class C { int P { ref get { } ref get; ref get => 0; } }";
+
+        UsingTree(source);
+        N(SyntaxKind.CompilationUnit);
+        {
+            N(SyntaxKind.ClassDeclaration);
+            {
+                N(SyntaxKind.ClassKeyword);
+                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "P");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.GetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.RefKeyword);
+                            N(SyntaxKind.GetKeyword);
+                            N(SyntaxKind.Block);
+                            {
+                                N(SyntaxKind.OpenBraceToken);
+                                N(SyntaxKind.CloseBraceToken);
+                            }
+                        }
+                        N(SyntaxKind.GetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.RefKeyword);
+                            N(SyntaxKind.GetKeyword);
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.GetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.RefKeyword);
+                            N(SyntaxKind.GetKeyword);
+                            N(SyntaxKind.ArrowExpressionClause);
+                            {
+                                N(SyntaxKind.EqualsGreaterThanToken);
+                                N(SyntaxKind.NumericLiteralExpression);
+                                {
+                                    N(SyntaxKind.NumericLiteralToken, "0");
+                                }
+                            }
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+            N(SyntaxKind.EndOfFileToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void ContextualKeywordWithoutAccessorNameBeforeBodyForms()
+    {
+        const string source = "class C { int P { partial { } partial; } }";
+
+        UsingTree(
+            source,
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(1, 19),
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(1, 31));
+        N(SyntaxKind.CompilationUnit);
+        {
+            N(SyntaxKind.ClassDeclaration);
+            {
+                N(SyntaxKind.ClassKeyword);
+                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "P");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.UnknownAccessorDeclaration);
+                        {
+                            N(SyntaxKind.IdentifierToken, "partial");
+                            N(SyntaxKind.Block);
+                            {
+                                N(SyntaxKind.OpenBraceToken);
+                                N(SyntaxKind.CloseBraceToken);
+                            }
+                        }
+                        N(SyntaxKind.UnknownAccessorDeclaration);
+                        {
+                            N(SyntaxKind.IdentifierToken, "partial");
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+            N(SyntaxKind.EndOfFileToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void EscapedContextualAndArbitraryAccessorNames()
+    {
+        const string source = "class C { int P { @partial; @async; @scoped; unknown; } }";
+
+        UsingTree(
+            source,
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "@partial").WithLocation(1, 19),
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "@async").WithLocation(1, 29),
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "@scoped").WithLocation(1, 37),
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "unknown").WithLocation(1, 46));
+        N(SyntaxKind.CompilationUnit);
+        {
+            N(SyntaxKind.ClassDeclaration);
+            {
+                N(SyntaxKind.ClassKeyword);
+                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "P");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.UnknownAccessorDeclaration);
+                        {
+                            N(SyntaxKind.IdentifierToken, "@partial");
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.UnknownAccessorDeclaration);
+                        {
+                            N(SyntaxKind.IdentifierToken, "@async");
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.UnknownAccessorDeclaration);
+                        {
+                            N(SyntaxKind.IdentifierToken, "@scoped");
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.UnknownAccessorDeclaration);
+                        {
+                            N(SyntaxKind.IdentifierToken, "unknown");
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+            N(SyntaxKind.EndOfFileToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void ContextualKeywordBeforeNonAccessorTokens()
+    {
+        const string source = "class C { int P { partial => 0; partial unknown; } }";
+
+        UsingTree(
+            source,
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(1, 19),
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(1, 33),
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "unknown").WithLocation(1, 41));
+        N(SyntaxKind.CompilationUnit);
+        {
+            N(SyntaxKind.ClassDeclaration);
+            {
+                N(SyntaxKind.ClassKeyword);
+                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "P");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.UnknownAccessorDeclaration);
+                        {
+                            N(SyntaxKind.IdentifierToken, "partial");
+                            N(SyntaxKind.ArrowExpressionClause);
+                            {
+                                N(SyntaxKind.EqualsGreaterThanToken);
+                                N(SyntaxKind.NumericLiteralExpression);
+                                {
+                                    N(SyntaxKind.NumericLiteralToken, "0");
+                                }
+                            }
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.UnknownAccessorDeclaration);
+                        {
+                            N(SyntaxKind.IdentifierToken, "partial");
+                        }
+                        N(SyntaxKind.UnknownAccessorDeclaration);
+                        {
+                            N(SyntaxKind.IdentifierToken, "unknown");
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+            N(SyntaxKind.EndOfFileToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void AccessorModifierBeforeAttributeRecovery()
+    {
+        const string source = "class C { int P { private [System.Obsolete] get; } }";
+
+        UsingTree(
+            source,
+            Diagnostic(ErrorCode.ERR_RbraceExpected, "private").WithLocation(1, 19),
+            Diagnostic(ErrorCode.ERR_TypeExpected, "[").WithLocation(1, 27),
+            Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(1, 52));
+        N(SyntaxKind.CompilationUnit);
+        {
+            N(SyntaxKind.ClassDeclaration);
+            {
+                N(SyntaxKind.ClassKeyword);
+                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "P");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        M(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.FieldDeclaration);
+                {
+                    N(SyntaxKind.PrivateKeyword);
+                    N(SyntaxKind.VariableDeclaration);
+                    {
+                        N(SyntaxKind.ArrayType);
+                        {
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
+                            N(SyntaxKind.ArrayRankSpecifier);
+                            {
+                                N(SyntaxKind.OpenBracketToken);
+                                N(SyntaxKind.SimpleMemberAccessExpression);
+                                {
+                                    N(SyntaxKind.IdentifierName);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "System");
+                                    }
+                                    N(SyntaxKind.DotToken);
+                                    N(SyntaxKind.IdentifierName);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "Obsolete");
+                                    }
+                                }
+                                N(SyntaxKind.CloseBracketToken);
+                            }
+                        }
+                        N(SyntaxKind.VariableDeclarator);
+                        {
+                            N(SyntaxKind.IdentifierToken, "get");
+                        }
+                    }
+                    N(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+            N(SyntaxKind.EndOfFileToken);
+        }
+        EOF();
+    }
+
+    [Fact]
     public void ValidPropertyAndIndexerAccessors()
     {
         const string source = """
@@ -256,7 +673,7 @@ public sealed class AccessorModifierParsingTests(ITestOutputHelper output) : Par
     }
 
     [Fact]
-    public void RefReturningPropertyWithAccessorKeywordType()
+    public void RefReturningMembersWithAccessorKeywordType()
     {
         const string source = """
             #pragma warning disable CS8981
@@ -265,6 +682,10 @@ public sealed class AccessorModifierParsingTests(ITestOutputHelper output) : Par
             {
                 get _value;
                 ref get A => ref _value;
+                ref get B { }
+                ref get C;
+                ref get D() { }
+                ref get E() => ref _value;
             }
             """;
 
@@ -323,13 +744,100 @@ public sealed class AccessorModifierParsingTests(ITestOutputHelper output) : Par
                     }
                     N(SyntaxKind.SemicolonToken);
                 }
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.RefType);
+                    {
+                        N(SyntaxKind.RefKeyword);
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "get");
+                        }
+                    }
+                    N(SyntaxKind.IdentifierToken, "B");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.FieldDeclaration);
+                {
+                    N(SyntaxKind.VariableDeclaration);
+                    {
+                        N(SyntaxKind.RefType);
+                        {
+                            N(SyntaxKind.RefKeyword);
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "get");
+                            }
+                        }
+                        N(SyntaxKind.VariableDeclarator);
+                        {
+                            N(SyntaxKind.IdentifierToken, "C");
+                        }
+                    }
+                    N(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.MethodDeclaration);
+                {
+                    N(SyntaxKind.RefType);
+                    {
+                        N(SyntaxKind.RefKeyword);
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "get");
+                        }
+                    }
+                    N(SyntaxKind.IdentifierToken, "D");
+                    N(SyntaxKind.ParameterList);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                    N(SyntaxKind.Block);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.MethodDeclaration);
+                {
+                    N(SyntaxKind.RefType);
+                    {
+                        N(SyntaxKind.RefKeyword);
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "get");
+                        }
+                    }
+                    N(SyntaxKind.IdentifierToken, "E");
+                    N(SyntaxKind.ParameterList);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                    N(SyntaxKind.ArrowExpressionClause);
+                    {
+                        N(SyntaxKind.EqualsGreaterThanToken);
+                        N(SyntaxKind.RefExpression);
+                        {
+                            N(SyntaxKind.RefKeyword);
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "_value");
+                            }
+                        }
+                    }
+                    N(SyntaxKind.SemicolonToken);
+                }
                 N(SyntaxKind.CloseBraceToken);
             }
             N(SyntaxKind.EndOfFileToken);
         }
         EOF();
 
-        CreateCompilation(source).VerifyDiagnostics();
     }
 
     [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/AccessorModifierParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/AccessorModifierParsingTests.cs
@@ -2163,4 +2163,487 @@ public sealed class AccessorModifierParsingTests(ITestOutputHelper output) : Par
         }
         EOF();
     }
+
+    [Fact]
+    public void RefGetFollowedByUnknownAccessor()
+    {
+        const string source = """
+            class C
+            {
+                int P1 { ref get A; }
+                int P2 { ref get A { } }
+                int P3 { ref get A => 0; }
+                int P4 { ref get A }
+                int P5 { ref get A; set; }
+            }
+            """;
+
+        UsingTree(
+            source,
+            Diagnostic(ErrorCode.ERR_SemiOrLBraceOrArrowExpected, "A").WithLocation(3, 22),
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "A").WithLocation(3, 22),
+            Diagnostic(ErrorCode.ERR_SemiOrLBraceOrArrowExpected, "A").WithLocation(4, 22),
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "A").WithLocation(4, 22),
+            Diagnostic(ErrorCode.ERR_SemiOrLBraceOrArrowExpected, "A").WithLocation(5, 22),
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "A").WithLocation(5, 22),
+            Diagnostic(ErrorCode.ERR_SemiOrLBraceOrArrowExpected, "A").WithLocation(6, 22),
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "A").WithLocation(6, 22),
+            Diagnostic(ErrorCode.ERR_SemiOrLBraceOrArrowExpected, "A").WithLocation(7, 22),
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "A").WithLocation(7, 22));
+        N(SyntaxKind.CompilationUnit);
+        {
+            N(SyntaxKind.ClassDeclaration);
+            {
+                N(SyntaxKind.ClassKeyword);
+                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "P1");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.GetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.RefKeyword);
+                            N(SyntaxKind.GetKeyword);
+                            M(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.UnknownAccessorDeclaration);
+                        {
+                            N(SyntaxKind.IdentifierToken, "A");
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "P2");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.GetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.RefKeyword);
+                            N(SyntaxKind.GetKeyword);
+                            M(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.UnknownAccessorDeclaration);
+                        {
+                            N(SyntaxKind.IdentifierToken, "A");
+                            N(SyntaxKind.Block);
+                            {
+                                N(SyntaxKind.OpenBraceToken);
+                                N(SyntaxKind.CloseBraceToken);
+                            }
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "P3");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.GetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.RefKeyword);
+                            N(SyntaxKind.GetKeyword);
+                            M(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.UnknownAccessorDeclaration);
+                        {
+                            N(SyntaxKind.IdentifierToken, "A");
+                            N(SyntaxKind.ArrowExpressionClause);
+                            {
+                                N(SyntaxKind.EqualsGreaterThanToken);
+                                N(SyntaxKind.NumericLiteralExpression);
+                                {
+                                    N(SyntaxKind.NumericLiteralToken, "0");
+                                }
+                            }
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "P4");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.GetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.RefKeyword);
+                            N(SyntaxKind.GetKeyword);
+                            M(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.UnknownAccessorDeclaration);
+                        {
+                            N(SyntaxKind.IdentifierToken, "A");
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "P5");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.GetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.RefKeyword);
+                            N(SyntaxKind.GetKeyword);
+                            M(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.UnknownAccessorDeclaration);
+                        {
+                            N(SyntaxKind.IdentifierToken, "A");
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.SetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.SetKeyword);
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+            N(SyntaxKind.EndOfFileToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void RefGetFollowedByParenthesizedUnknownAccessor()
+    {
+        const string source = "class C { int P { ref get A(); } }";
+
+        UsingTree(
+            source,
+            Diagnostic(ErrorCode.ERR_SemiOrLBraceOrArrowExpected, "A").WithLocation(1, 27),
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "A").WithLocation(1, 27),
+            Diagnostic(ErrorCode.ERR_RbraceExpected, "(").WithLocation(1, 28),
+            Diagnostic(ErrorCode.ERR_TupleTooFewElements, ")").WithLocation(1, 29),
+            Diagnostic(ErrorCode.ERR_InvalidMemberDecl, ";").WithArguments(";").WithLocation(1, 30),
+            Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(1, 34));
+        N(SyntaxKind.CompilationUnit);
+        {
+            N(SyntaxKind.ClassDeclaration);
+            {
+                N(SyntaxKind.ClassKeyword);
+                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "P");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.GetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.RefKeyword);
+                            N(SyntaxKind.GetKeyword);
+                            M(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.UnknownAccessorDeclaration);
+                        {
+                            N(SyntaxKind.IdentifierToken, "A");
+                        }
+                        M(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.IncompleteMember);
+                {
+                    N(SyntaxKind.TupleType);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        M(SyntaxKind.TupleElement);
+                        {
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
+                        }
+                        M(SyntaxKind.CommaToken);
+                        M(SyntaxKind.TupleElement);
+                        {
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
+                        }
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+            N(SyntaxKind.EndOfFileToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void KeywordModifierBeforeFollowingMember()
+    {
+        const string source = "class C { int P { private int F; } }";
+
+        UsingTree(
+            source,
+            Diagnostic(ErrorCode.ERR_RbraceExpected, "private").WithLocation(1, 19),
+            Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(1, 36));
+        N(SyntaxKind.CompilationUnit);
+        {
+            N(SyntaxKind.ClassDeclaration);
+            {
+                N(SyntaxKind.ClassKeyword);
+                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "P");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        M(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.FieldDeclaration);
+                {
+                    N(SyntaxKind.PrivateKeyword);
+                    N(SyntaxKind.VariableDeclaration);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.IntKeyword);
+                        }
+                        N(SyntaxKind.VariableDeclarator);
+                        {
+                            N(SyntaxKind.IdentifierToken, "F");
+                        }
+                    }
+                    N(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+            N(SyntaxKind.EndOfFileToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void KeywordModifierWithMissingAccessorName()
+    {
+        const string source = "class C1 { int P { private { } } } class C2 { int P { private; } }";
+
+        UsingTree(
+            source,
+            Diagnostic(ErrorCode.ERR_RbraceExpected, "private").WithLocation(1, 20),
+            Diagnostic(ErrorCode.ERR_TypeExpected, "{").WithLocation(1, 28),
+            Diagnostic(ErrorCode.ERR_IdentifierExpected, "{").WithLocation(1, 28),
+            Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(1, 34),
+            Diagnostic(ErrorCode.ERR_RbraceExpected, "private").WithLocation(1, 55),
+            Diagnostic(ErrorCode.ERR_InvalidMemberDecl, ";").WithArguments(";").WithLocation(1, 62),
+            Diagnostic(ErrorCode.ERR_InvalidMemberDecl, ";").WithArguments(";").WithLocation(1, 62),
+            Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(1, 66));
+        N(SyntaxKind.CompilationUnit);
+        {
+            N(SyntaxKind.ClassDeclaration);
+            {
+                N(SyntaxKind.ClassKeyword);
+                N(SyntaxKind.IdentifierToken, "C1");
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "P");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        M(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PrivateKeyword);
+                    M(SyntaxKind.IdentifierName);
+                    {
+                        M(SyntaxKind.IdentifierToken);
+                    }
+                    M(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+            N(SyntaxKind.ClassDeclaration);
+            {
+                N(SyntaxKind.ClassKeyword);
+                N(SyntaxKind.IdentifierToken, "C2");
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "P");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        M(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.IncompleteMember);
+                {
+                    N(SyntaxKind.PrivateKeyword);
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+            N(SyntaxKind.EndOfFileToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void TrailingContextualModifierInEventAccessorList()
+    {
+        const string source = "class C { event System.Action E { scoped } }";
+
+        UsingTree(
+            source,
+            Diagnostic(ErrorCode.ERR_AddOrRemoveExpected, "scoped").WithLocation(1, 35));
+        N(SyntaxKind.CompilationUnit);
+        {
+            N(SyntaxKind.ClassDeclaration);
+            {
+                N(SyntaxKind.ClassKeyword);
+                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.EventDeclaration);
+                {
+                    N(SyntaxKind.EventKeyword);
+                    N(SyntaxKind.QualifiedName);
+                    {
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "System");
+                        }
+                        N(SyntaxKind.DotToken);
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "Action");
+                        }
+                    }
+                    N(SyntaxKind.IdentifierToken, "E");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.UnknownAccessorDeclaration);
+                        {
+                            N(SyntaxKind.IdentifierToken, "scoped");
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+            N(SyntaxKind.EndOfFileToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void ModifiedKnownAccessorWithForcedBody()
+    {
+        const string source = "class C { int P { ref get 0; } }";
+
+        UsingTree(
+            source,
+            Diagnostic(ErrorCode.ERR_SemiOrLBraceOrArrowExpected, "0").WithLocation(1, 27),
+            Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(1, 33));
+        N(SyntaxKind.CompilationUnit);
+        {
+            N(SyntaxKind.ClassDeclaration);
+            {
+                N(SyntaxKind.ClassKeyword);
+                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "P");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.GetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.RefKeyword);
+                            N(SyntaxKind.GetKeyword);
+                            N(SyntaxKind.Block);
+                            {
+                                M(SyntaxKind.OpenBraceToken);
+                                N(SyntaxKind.ExpressionStatement);
+                                {
+                                    N(SyntaxKind.NumericLiteralExpression);
+                                    {
+                                        N(SyntaxKind.NumericLiteralToken, "0");
+                                    }
+                                    N(SyntaxKind.SemicolonToken);
+                                }
+                                N(SyntaxKind.CloseBraceToken);
+                            }
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                M(SyntaxKind.CloseBraceToken);
+            }
+            N(SyntaxKind.EndOfFileToken);
+        }
+        EOF();
+    }
 }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/AccessorModifierParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/AccessorModifierParsingTests.cs
@@ -2,8 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Linq;
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -15,6 +16,22 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests;
 
 public sealed class AccessorModifierParsingTests(ITestOutputHelper output) : ParsingTests(output)
 {
+    private static readonly ImmutableArray<string> s_allModifiers =
+    [
+        "public", "internal", "protected", "private", "sealed", "abstract", "static", "virtual",
+        "extern", "new", "override", "readonly", "volatile", "unsafe", "partial", "async", "ref",
+        "required", "file", "closed", "safe", "scoped",
+    ];
+
+    private static readonly ImmutableArray<string> s_newlyParsedCSharp10Modifiers =
+        ["partial", "async", "required", "file", "closed", "scoped"];
+
+    private static readonly ImmutableArray<string> s_newlyParsedCSharp11And14Modifiers =
+        ["partial", "async", "closed", "scoped"];
+
+    private static readonly ImmutableArray<string> s_newlyParsedPreviewModifiers =
+        ["partial", "async", "scoped"];
+
     public static TheoryData<LanguageVersion, string, string, string> NewlyParsedAccessorModifiers
     {
         get
@@ -30,14 +47,14 @@ public sealed class AccessorModifierParsingTests(ITestOutputHelper output) : Par
                 ("event", "remove"),
             };
 
-            add(LanguageVersion.CSharp10, "partial", "async", "required", "file", "closed", "scoped");
-            add(LanguageVersion.CSharp11, "partial", "async", "closed", "scoped");
-            add(LanguageVersion.CSharp14, "partial", "async", "closed", "scoped");
-            add(LanguageVersion.Preview, "partial", "async", "scoped");
+            add(LanguageVersion.CSharp10, s_newlyParsedCSharp10Modifiers);
+            add(LanguageVersion.CSharp11, s_newlyParsedCSharp11And14Modifiers);
+            add(LanguageVersion.CSharp14, s_newlyParsedCSharp11And14Modifiers);
+            add(LanguageVersion.Preview, s_newlyParsedPreviewModifiers);
 
             return data;
 
-            void add(LanguageVersion languageVersion, params string[] modifiers)
+            void add(LanguageVersion languageVersion, ImmutableArray<string> modifiers)
             {
                 foreach (var modifier in modifiers)
                 {
@@ -55,26 +72,20 @@ public sealed class AccessorModifierParsingTests(ITestOutputHelper output) : Par
         get
         {
             var data = new TheoryData<LanguageVersion, string, string, string>();
-            var modifiers = new[]
-            {
-                "public", "internal", "protected", "private", "sealed", "abstract", "static", "virtual",
-                "extern", "new", "override", "readonly", "volatile", "unsafe", "partial", "async", "ref",
-                "required", "file", "closed", "safe", "scoped",
-            };
             var partialFollowers = new[] { "virtual", "extern", "override", "readonly", "volatile", "ref" };
 
-            add(LanguageVersion.CSharp10, "partial", "async", "required", "file", "closed", "scoped");
-            add(LanguageVersion.CSharp11, "partial", "async", "closed", "scoped");
-            add(LanguageVersion.CSharp14, "partial", "async", "closed", "scoped");
-            add(LanguageVersion.Preview, "partial", "async", "scoped");
+            add(LanguageVersion.CSharp10, s_newlyParsedCSharp10Modifiers);
+            add(LanguageVersion.CSharp11, s_newlyParsedCSharp11And14Modifiers);
+            add(LanguageVersion.CSharp14, s_newlyParsedCSharp11And14Modifiers);
+            add(LanguageVersion.Preview, s_newlyParsedPreviewModifiers);
 
             return data;
 
-            void add(LanguageVersion languageVersion, params string[] secondModifiers)
+            void add(LanguageVersion languageVersion, ImmutableArray<string> secondModifiers)
             {
                 var pairs = new HashSet<(string first, string second)>();
 
-                foreach (var first in modifiers)
+                foreach (var first in s_allModifiers)
                 {
                     foreach (var second in secondModifiers)
                     {
@@ -82,7 +93,7 @@ public sealed class AccessorModifierParsingTests(ITestOutputHelper output) : Par
                     }
                 }
 
-                foreach (var second in modifiers)
+                foreach (var second in s_allModifiers)
                 {
                     pairs.Add(("scoped", second));
                 }
@@ -221,15 +232,9 @@ public sealed class AccessorModifierParsingTests(ITestOutputHelper output) : Par
     [InlineData("event", "{ }")]
     public void NewlyParsedModifierWithMissingAccessorName(string declarationKind, string body)
     {
-        var modifiers = new[]
-        {
-            "public", "internal", "protected", "private", "sealed", "abstract", "static", "virtual",
-            "extern", "new", "override", "readonly", "volatile", "unsafe", "partial", "async", "ref",
-            "required", "file", "closed", "safe", "scoped",
-        };
         var options = TestOptions.Regular10;
 
-        foreach (var modifier in modifiers)
+        foreach (var modifier in s_allModifiers)
         {
             var source = declarationKind switch
             {
@@ -284,7 +289,7 @@ public sealed class AccessorModifierParsingTests(ITestOutputHelper output) : Par
     [InlineData("event")]
     public void NewlyParsedModifierBeforeCloseBrace(string declarationKind)
     {
-        foreach (var modifier in new[] { "partial", "async", "required", "file", "closed", "scoped" })
+        foreach (var modifier in s_newlyParsedCSharp10Modifiers)
         {
             var source = declarationKind switch
             {

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/AccessorModifierParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/AccessorModifierParsingTests.cs
@@ -2,11 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -16,366 +12,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests;
 
 public sealed class AccessorModifierParsingTests(ITestOutputHelper output) : ParsingTests(output)
 {
-    private static readonly ImmutableArray<string> s_allModifiers =
-    [
-        "public", "internal", "protected", "private", "sealed", "abstract", "static", "virtual",
-        "extern", "new", "override", "readonly", "volatile", "unsafe", "partial", "async", "ref",
-        "required", "file", "closed", "safe", "scoped",
-    ];
-
-    private static readonly ImmutableArray<string> s_newlyParsedCSharp10Modifiers =
-        ["partial", "async", "required", "file", "closed", "scoped"];
-
-    private static readonly ImmutableArray<string> s_newlyParsedCSharp11And14Modifiers =
-        ["partial", "async", "closed", "scoped"];
-
-    private static readonly ImmutableArray<string> s_newlyParsedPreviewModifiers =
-        ["partial", "async", "scoped"];
-
-    public static TheoryData<LanguageVersion, string, string, string> NewlyParsedAccessorModifiers
-    {
-        get
-        {
-            var data = new TheoryData<LanguageVersion, string, string, string>();
-            var accessorKinds = new[]
-            {
-                ("property", "get"),
-                ("property", "set"),
-                ("property", "init"),
-                ("indexer", "get"),
-                ("event", "add"),
-                ("event", "remove"),
-            };
-
-            add(LanguageVersion.CSharp10, s_newlyParsedCSharp10Modifiers);
-            add(LanguageVersion.CSharp11, s_newlyParsedCSharp11And14Modifiers);
-            add(LanguageVersion.CSharp14, s_newlyParsedCSharp11And14Modifiers);
-            add(LanguageVersion.Preview, s_newlyParsedPreviewModifiers);
-
-            return data;
-
-            void add(LanguageVersion languageVersion, ImmutableArray<string> modifiers)
-            {
-                foreach (var modifier in modifiers)
-                {
-                    foreach (var (declarationKind, accessorKind) in accessorKinds)
-                    {
-                        data.Add(languageVersion, modifier, declarationKind, accessorKind);
-                    }
-                }
-            }
-        }
-    }
-
-    public static TheoryData<LanguageVersion, string, string, string> NewlyParsedAccessorModifierOrderings
-    {
-        get
-        {
-            var data = new TheoryData<LanguageVersion, string, string, string>();
-            var partialFollowers = new[] { "virtual", "extern", "override", "readonly", "volatile", "ref" };
-
-            add(LanguageVersion.CSharp10, s_newlyParsedCSharp10Modifiers);
-            add(LanguageVersion.CSharp11, s_newlyParsedCSharp11And14Modifiers);
-            add(LanguageVersion.CSharp14, s_newlyParsedCSharp11And14Modifiers);
-            add(LanguageVersion.Preview, s_newlyParsedPreviewModifiers);
-
-            return data;
-
-            void add(LanguageVersion languageVersion, ImmutableArray<string> secondModifiers)
-            {
-                var pairs = new HashSet<(string first, string second)>();
-
-                foreach (var first in s_allModifiers)
-                {
-                    foreach (var second in secondModifiers)
-                    {
-                        pairs.Add((first, second));
-                    }
-                }
-
-                foreach (var second in s_allModifiers)
-                {
-                    pairs.Add(("scoped", second));
-                }
-
-                foreach (var second in partialFollowers)
-                {
-                    pairs.Add(("partial", second));
-                }
-
-                foreach (var (first, second) in pairs)
-                {
-                    data.Add(languageVersion, first, second, "property");
-                    data.Add(languageVersion, first, second, "event");
-                }
-            }
-        }
-    }
-
-    [Theory]
-    [MemberData(nameof(NewlyParsedAccessorModifiers))]
-    public void NewlyParsedAccessorModifier(
-        LanguageVersion languageVersion,
-        string modifier,
-        string declarationKind,
-        string accessorKind)
-    {
-        var source = (declarationKind, accessorKind) switch
-        {
-            ("property", "get") => $"class C {{ int P {{ {modifier} get; set; }} }}",
-            ("property", "set") => $"class C {{ int P {{ get; {modifier} set; }} }}",
-            ("property", "init") => $"class C {{ int P {{ get; {modifier} init; }} }}",
-            ("indexer", "get") => $"class C {{ int this[int i] {{ {modifier} get; set; }} }}",
-            ("event", "add") => $"class C {{ event System.Action E {{ {modifier} add {{ }} remove {{ }} }} }}",
-            ("event", "remove") => $"class C {{ event System.Action E {{ add {{ }} {modifier} remove {{ }} }} }}",
-            _ => throw ExceptionUtilities.Unreachable(),
-        };
-        var options = TestOptions.Regular.WithLanguageVersion(languageVersion);
-        var tree = SyntaxFactory.ParseSyntaxTree(source, options);
-
-        Assert.Contains(
-            tree.GetDiagnostics(),
-            diagnostic => diagnostic.Code == (int)(declarationKind == "event"
-                ? ErrorCode.ERR_AddOrRemoveExpected
-                : ErrorCode.ERR_GetOrSetExpected));
-
-        var accessor = tree.GetRoot().DescendantNodes().OfType<AccessorDeclarationSyntax>().Single(
-            accessor => accessor.Keyword.ValueText == accessorKind);
-        Assert.Empty(accessor.Modifiers);
-
-        Assert.Contains(
-            CreateCompilation(source, parseOptions: options).GetDiagnostics(),
-            diagnostic => diagnostic.Code == (int)(declarationKind == "event"
-                ? ErrorCode.ERR_AddOrRemoveExpected
-                : ErrorCode.ERR_GetOrSetExpected));
-    }
-
-    [Theory]
-    [MemberData(nameof(NewlyParsedAccessorModifierOrderings))]
-    public void NewlyParsedAccessorModifierOrdering(
-        LanguageVersion languageVersion,
-        string firstModifier,
-        string secondModifier,
-        string declarationKind)
-    {
-        var source = declarationKind switch
-        {
-            "property" => $"class C {{ int P {{ {firstModifier} {secondModifier} get; set; }} }}",
-            "event" => $"class C {{ event System.Action E {{ {firstModifier} {secondModifier} add {{ }} remove {{ }} }} }}",
-            _ => throw ExceptionUtilities.Unreachable(),
-        };
-        var options = TestOptions.Regular.WithLanguageVersion(languageVersion);
-        var tree = SyntaxFactory.ParseSyntaxTree(source, options);
-
-        Assert.Contains(tree.GetDiagnostics(), diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
-        Assert.Contains(
-            CreateCompilation(source, parseOptions: options).GetDiagnostics(),
-            diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
-    }
-
-    [Theory]
-    [MemberData(nameof(NewlyParsedAccessorModifiers))]
-    public void NewlyParsedAccessorModifierAfterAttribute(
-        LanguageVersion languageVersion,
-        string modifier,
-        string declarationKind,
-        string accessorKind)
-    {
-        var source = (declarationKind, accessorKind) switch
-        {
-            ("property", "get") => $"class C {{ int P {{ [System.Obsolete] {modifier} get; set; }} }}",
-            ("property", "set") => $"class C {{ int P {{ get; [System.Obsolete] {modifier} set; }} }}",
-            ("property", "init") => $"class C {{ int P {{ get; [System.Obsolete] {modifier} init; }} }}",
-            ("indexer", "get") => $"class C {{ int this[int i] {{ [System.Obsolete] {modifier} get; set; }} }}",
-            ("event", "add") => $"class C {{ event System.Action E {{ [System.Obsolete] {modifier} add {{ }} remove {{ }} }} }}",
-            ("event", "remove") => $"class C {{ event System.Action E {{ add {{ }} [System.Obsolete] {modifier} remove {{ }} }} }}",
-            _ => throw ExceptionUtilities.Unreachable(),
-        };
-        var options = TestOptions.Regular.WithLanguageVersion(languageVersion);
-        var tree = SyntaxFactory.ParseSyntaxTree(source, options);
-
-        Assert.Contains(
-            tree.GetDiagnostics(),
-            diagnostic => diagnostic.Code == (int)(declarationKind == "event"
-                ? ErrorCode.ERR_AddOrRemoveExpected
-                : ErrorCode.ERR_GetOrSetExpected));
-
-        var accessor = tree.GetRoot().DescendantNodes().OfType<AccessorDeclarationSyntax>().Single(
-            accessor => accessor.Keyword.ValueText == accessorKind);
-        Assert.Empty(accessor.AttributeLists);
-        Assert.Empty(accessor.Modifiers);
-
-        Assert.Contains(
-            CreateCompilation(source, parseOptions: options).GetDiagnostics(),
-            diagnostic => diagnostic.Code == (int)(declarationKind == "event"
-                ? ErrorCode.ERR_AddOrRemoveExpected
-                : ErrorCode.ERR_GetOrSetExpected));
-    }
-
-    [Fact]
-    public void ModifierBeforeAttributeRecovery()
-    {
-        const string source = "class C { int P { private [System.Obsolete] get; set; } }";
-        var tree = SyntaxFactory.ParseSyntaxTree(source);
-
-        Assert.Contains(tree.GetDiagnostics(), diagnostic => diagnostic.Code == (int)ErrorCode.ERR_RbraceExpected);
-        Assert.Contains(tree.GetDiagnostics(), diagnostic => diagnostic.Code == (int)ErrorCode.ERR_TypeExpected);
-        Assert.Contains(
-            CreateCompilation(source).GetDiagnostics(),
-            diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
-    }
-
-    [Theory]
-    [InlineData("property", ";")]
-    [InlineData("property", "{ }")]
-    [InlineData("event", ";")]
-    [InlineData("event", "{ }")]
-    public void NewlyParsedModifierWithMissingAccessorName(string declarationKind, string body)
-    {
-        var options = TestOptions.Regular10;
-
-        foreach (var modifier in s_allModifiers)
-        {
-            var source = declarationKind switch
-            {
-                "property" => $"class C {{ int P {{ {modifier} {body} }} }}",
-                "event" => $"class C {{ event System.Action E {{ {modifier} {body} }} }}",
-                _ => throw ExceptionUtilities.Unreachable(),
-            };
-            var tree = SyntaxFactory.ParseSyntaxTree(source, options);
-            Assert.Contains(tree.GetDiagnostics(), diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
-            Assert.Contains(
-                CreateCompilation(source, parseOptions: options).GetDiagnostics(),
-                diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
-        }
-    }
-
-    [Theory]
-    [InlineData("property", "get")]
-    [InlineData("property", "set")]
-    [InlineData("property", "init")]
-    [InlineData("indexer", "get")]
-    [InlineData("event", "add")]
-    [InlineData("event", "remove")]
-    public void NewlyParsedModifierOnAccessorWithMissingBody(string declarationKind, string accessorKind)
-    {
-        foreach (var modifier in new[] { "partial", "scoped" })
-        {
-            var source = (declarationKind, accessorKind) switch
-            {
-                ("property", "get") => $"class C {{ int P {{ {modifier} get }} }}",
-                ("property", "set") => $"class C {{ int P {{ {modifier} set }} }}",
-                ("property", "init") => $"class C {{ int P {{ {modifier} init }} }}",
-                ("indexer", "get") => $"class C {{ int this[int i] {{ {modifier} get }} }}",
-                ("event", "add") => $"class C {{ event System.Action E {{ {modifier} add }} }}",
-                ("event", "remove") => $"class C {{ event System.Action E {{ {modifier} remove }} }}",
-                _ => throw ExceptionUtilities.Unreachable(),
-            };
-            var tree = SyntaxFactory.ParseSyntaxTree(source, TestOptions.RegularPreview);
-            var accessor = tree.GetRoot().DescendantNodes().OfType<AccessorDeclarationSyntax>().Single(
-                accessor => accessor.Keyword.ValueText == accessorKind);
-
-            Assert.Equal(accessorKind, accessor.Keyword.ValueText);
-            Assert.Empty(accessor.Modifiers);
-            Assert.Contains(tree.GetDiagnostics(), diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
-            Assert.Contains(
-                CreateCompilation(source, parseOptions: TestOptions.RegularPreview).GetDiagnostics(),
-                diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
-        }
-    }
-
-    [Theory]
-    [InlineData("property")]
-    [InlineData("event")]
-    public void NewlyParsedModifierBeforeCloseBrace(string declarationKind)
-    {
-        foreach (var modifier in s_newlyParsedCSharp10Modifiers)
-        {
-            var source = declarationKind switch
-            {
-                "property" => $"class C {{ int P {{ {modifier} }} }}",
-                "event" => $"class C {{ event System.Action E {{ {modifier} }} }}",
-                _ => throw ExceptionUtilities.Unreachable(),
-            };
-            var tree = SyntaxFactory.ParseSyntaxTree(source, TestOptions.Regular10);
-            var accessor = tree.GetRoot().DescendantNodes().OfType<AccessorDeclarationSyntax>().Single();
-
-            Assert.Equal(SyntaxKind.UnknownAccessorDeclaration, accessor.Kind());
-            Assert.Equal(modifier, accessor.Keyword.ValueText);
-            Assert.Empty(accessor.Modifiers);
-            Assert.Contains(tree.GetDiagnostics(), diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
-            Assert.Contains(
-                CreateCompilation(source, parseOptions: TestOptions.Regular10).GetDiagnostics(),
-                diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
-        }
-    }
-
-    [Theory]
-    [InlineData("=> 0;")]
-    [InlineData("unknown;")]
-    public void ContextualModifierBeforeNonAccessor(string trailingTokens)
-    {
-        var source = $"class C {{ int P {{ partial {trailingTokens} }} }}";
-        var tree = SyntaxFactory.ParseSyntaxTree(source);
-
-        var accessors = tree.GetRoot().DescendantNodes().OfType<AccessorDeclarationSyntax>().ToArray();
-        Assert.Equal("partial", accessors[0].Keyword.ValueText);
-        Assert.All(accessors, accessor => Assert.Empty(accessor.Modifiers));
-        Assert.Contains(tree.GetDiagnostics(), diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
-        Assert.Contains(
-            CreateCompilation(source).GetDiagnostics(),
-            diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
-    }
-
-    [Fact]
-    public void ContextualModifierBeforeFollowingMember()
-    {
-        const string source = "class C { int P { partial int F; } }";
-        var tree = SyntaxFactory.ParseSyntaxTree(source);
-
-        var field = Assert.Single(tree.GetRoot().DescendantNodes().OfType<FieldDeclarationSyntax>());
-        Assert.Equal("F", field.Declaration.Variables.Single().Identifier.ValueText);
-        Assert.Empty(field.Modifiers);
-        var accessor = Assert.Single(tree.GetRoot().DescendantNodes().OfType<AccessorDeclarationSyntax>());
-        Assert.True(accessor.Keyword.IsMissing);
-        Assert.Equal("partial", Assert.Single(accessor.Modifiers).ValueText);
-        Assert.Contains(tree.GetDiagnostics(), diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
-        Assert.Contains(
-            CreateCompilation(source).GetDiagnostics(),
-            diagnostic => diagnostic.Code == (int)ErrorCode.ERR_GetOrSetExpected);
-    }
-
-    [Fact]
-    public void NewlyParsedModifierAtEndOfFile()
-    {
-        const string source = "class C { int P { partial";
-        var tree = SyntaxFactory.ParseSyntaxTree(source);
-        var accessor = tree.GetRoot().DescendantNodes().OfType<AccessorDeclarationSyntax>().Single();
-
-        Assert.Equal("partial", accessor.Keyword.ValueText);
-        Assert.Empty(accessor.Modifiers);
-        Assert.Contains(tree.GetDiagnostics(), diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
-        Assert.Contains(
-            CreateCompilation(source).GetDiagnostics(),
-            diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
-    }
-
-    [Fact]
-    public void NewlyParsedAttributedModifierWithMissingAccessorName()
-    {
-        const string source = "class C { int P { [System.Obsolete] partial } }";
-        var tree = SyntaxFactory.ParseSyntaxTree(source);
-        var accessor = tree.GetRoot().DescendantNodes().OfType<AccessorDeclarationSyntax>().Single();
-
-        Assert.Single(accessor.AttributeLists);
-        Assert.Equal("partial", accessor.Keyword.ValueText);
-        Assert.Empty(accessor.Modifiers);
-        Assert.Contains(tree.GetDiagnostics(), diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
-        Assert.Contains(
-            CreateCompilation(source).GetDiagnostics(),
-            diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
-    }
-
     [Fact]
     public void ValidPropertyAndIndexerAccessors()
     {
@@ -969,22 +605,165 @@ public sealed class AccessorModifierParsingTests(ITestOutputHelper output) : Par
             }
             """;
 
-        var tree = SyntaxFactory.ParseSyntaxTree(source, TestOptions.RegularPreview);
-        tree.GetDiagnostics().Verify(
+        UsingTree(
+            source,
+            TestOptions.RegularPreview,
             Diagnostic(ErrorCode.ERR_GetOrSetExpected, "scoped").WithLocation(3, 13),
             Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(4, 13),
             Diagnostic(ErrorCode.ERR_GetOrSetExpected, "async").WithLocation(5, 13),
             Diagnostic(ErrorCode.ERR_GetOrSetExpected, "async").WithLocation(6, 28),
             Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(7, 28));
-
-        var getAccessors = tree.GetRoot().DescendantNodes().OfType<AccessorDeclarationSyntax>()
-            .Where(accessor => accessor.Keyword.IsKind(SyntaxKind.GetKeyword));
-        Assert.Equal(5, getAccessors.Count());
-        Assert.All(getAccessors, accessor => Assert.Empty(accessor.Modifiers));
-
-        Assert.Contains(
-            CreateCompilation(source, parseOptions: TestOptions.RegularPreview).GetDiagnostics(),
-            diagnostic => diagnostic.Code == (int)ErrorCode.ERR_GetOrSetExpected);
+        N(SyntaxKind.CompilationUnit);
+        {
+            N(SyntaxKind.ClassDeclaration);
+            {
+                N(SyntaxKind.ClassKeyword);
+                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "P");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.UnknownAccessorDeclaration);
+                        {
+                            N(SyntaxKind.IdentifierToken, "scoped");
+                        }
+                        N(SyntaxKind.GetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.GetKeyword);
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.SetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.SetKeyword);
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "Q");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.UnknownAccessorDeclaration);
+                        {
+                            N(SyntaxKind.IdentifierToken, "partial");
+                        }
+                        N(SyntaxKind.GetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.GetKeyword);
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.SetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.SetKeyword);
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "R");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.UnknownAccessorDeclaration);
+                        {
+                            N(SyntaxKind.IdentifierToken, "async");
+                        }
+                        N(SyntaxKind.GetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.GetKeyword);
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.SetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.SetKeyword);
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PublicKeyword);
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "S");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.UnknownAccessorDeclaration);
+                        {
+                            N(SyntaxKind.PrivateKeyword);
+                            N(SyntaxKind.IdentifierToken, "async");
+                        }
+                        N(SyntaxKind.GetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.GetKeyword);
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.SetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.SetKeyword);
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PublicKeyword);
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "T");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.UnknownAccessorDeclaration);
+                        {
+                            N(SyntaxKind.PrivateKeyword);
+                            N(SyntaxKind.IdentifierToken, "partial");
+                        }
+                        N(SyntaxKind.GetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.GetKeyword);
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.SetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.SetKeyword);
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+            N(SyntaxKind.EndOfFileToken);
+        }
+        EOF();
     }
 
     [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/AccessorModifierParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/AccessorModifierParsingTests.cs
@@ -1,0 +1,1380 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests;
+
+public sealed class AccessorModifierParsingTests(ITestOutputHelper output) : ParsingTests(output)
+{
+    public static TheoryData<LanguageVersion, string, string, string> NewlyParsedAccessorModifiers
+    {
+        get
+        {
+            var data = new TheoryData<LanguageVersion, string, string, string>();
+            var accessorKinds = new[]
+            {
+                ("property", "get"),
+                ("property", "set"),
+                ("property", "init"),
+                ("indexer", "get"),
+                ("event", "add"),
+                ("event", "remove"),
+            };
+
+            add(LanguageVersion.CSharp10, "partial", "async", "required", "file", "closed", "scoped");
+            add(LanguageVersion.CSharp11, "partial", "async", "closed", "scoped");
+            add(LanguageVersion.CSharp14, "partial", "async", "closed", "scoped");
+            add(LanguageVersion.Preview, "partial", "async", "scoped");
+
+            return data;
+
+            void add(LanguageVersion languageVersion, params string[] modifiers)
+            {
+                foreach (var modifier in modifiers)
+                {
+                    foreach (var (declarationKind, accessorKind) in accessorKinds)
+                    {
+                        data.Add(languageVersion, modifier, declarationKind, accessorKind);
+                    }
+                }
+            }
+        }
+    }
+
+    public static TheoryData<LanguageVersion, string, string, string> NewlyParsedAccessorModifierOrderings
+    {
+        get
+        {
+            var data = new TheoryData<LanguageVersion, string, string, string>();
+            var modifiers = new[]
+            {
+                "public", "internal", "protected", "private", "sealed", "abstract", "static", "virtual",
+                "extern", "new", "override", "readonly", "volatile", "unsafe", "partial", "async", "ref",
+                "required", "file", "closed", "safe", "scoped",
+            };
+            var partialFollowers = new[] { "virtual", "extern", "override", "readonly", "volatile", "ref" };
+
+            add(LanguageVersion.CSharp10, "partial", "async", "required", "file", "closed", "scoped");
+            add(LanguageVersion.CSharp11, "partial", "async", "closed", "scoped");
+            add(LanguageVersion.CSharp14, "partial", "async", "closed", "scoped");
+            add(LanguageVersion.Preview, "partial", "async", "scoped");
+
+            return data;
+
+            void add(LanguageVersion languageVersion, params string[] secondModifiers)
+            {
+                var pairs = new HashSet<(string first, string second)>();
+
+                foreach (var first in modifiers)
+                {
+                    foreach (var second in secondModifiers)
+                    {
+                        pairs.Add((first, second));
+                    }
+                }
+
+                foreach (var second in modifiers)
+                {
+                    pairs.Add(("scoped", second));
+                }
+
+                foreach (var second in partialFollowers)
+                {
+                    pairs.Add(("partial", second));
+                }
+
+                foreach (var (first, second) in pairs)
+                {
+                    data.Add(languageVersion, first, second, "property");
+                    data.Add(languageVersion, first, second, "event");
+                }
+            }
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(NewlyParsedAccessorModifiers))]
+    public void NewlyParsedAccessorModifier(
+        LanguageVersion languageVersion,
+        string modifier,
+        string declarationKind,
+        string accessorKind)
+    {
+        var source = (declarationKind, accessorKind) switch
+        {
+            ("property", "get") => $"class C {{ int P {{ {modifier} get; set; }} }}",
+            ("property", "set") => $"class C {{ int P {{ get; {modifier} set; }} }}",
+            ("property", "init") => $"class C {{ int P {{ get; {modifier} init; }} }}",
+            ("indexer", "get") => $"class C {{ int this[int i] {{ {modifier} get; set; }} }}",
+            ("event", "add") => $"class C {{ event System.Action E {{ {modifier} add {{ }} remove {{ }} }} }}",
+            ("event", "remove") => $"class C {{ event System.Action E {{ add {{ }} {modifier} remove {{ }} }} }}",
+            _ => throw ExceptionUtilities.Unreachable(),
+        };
+        var options = TestOptions.Regular.WithLanguageVersion(languageVersion);
+        var tree = SyntaxFactory.ParseSyntaxTree(source, options);
+
+        Assert.Contains(
+            tree.GetDiagnostics(),
+            diagnostic => diagnostic.Code == (int)(declarationKind == "event"
+                ? ErrorCode.ERR_AddOrRemoveExpected
+                : ErrorCode.ERR_GetOrSetExpected));
+
+        var accessor = tree.GetRoot().DescendantNodes().OfType<AccessorDeclarationSyntax>().Single(
+            accessor => accessor.Keyword.ValueText == accessorKind);
+        Assert.Empty(accessor.Modifiers);
+
+        Assert.Contains(
+            CreateCompilation(source, parseOptions: options).GetDiagnostics(),
+            diagnostic => diagnostic.Code == (int)(declarationKind == "event"
+                ? ErrorCode.ERR_AddOrRemoveExpected
+                : ErrorCode.ERR_GetOrSetExpected));
+    }
+
+    [Theory]
+    [MemberData(nameof(NewlyParsedAccessorModifierOrderings))]
+    public void NewlyParsedAccessorModifierOrdering(
+        LanguageVersion languageVersion,
+        string firstModifier,
+        string secondModifier,
+        string declarationKind)
+    {
+        var source = declarationKind switch
+        {
+            "property" => $"class C {{ int P {{ {firstModifier} {secondModifier} get; set; }} }}",
+            "event" => $"class C {{ event System.Action E {{ {firstModifier} {secondModifier} add {{ }} remove {{ }} }} }}",
+            _ => throw ExceptionUtilities.Unreachable(),
+        };
+        var options = TestOptions.Regular.WithLanguageVersion(languageVersion);
+        var tree = SyntaxFactory.ParseSyntaxTree(source, options);
+
+        Assert.Contains(tree.GetDiagnostics(), diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(
+            CreateCompilation(source, parseOptions: options).GetDiagnostics(),
+            diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+    }
+
+    [Theory]
+    [MemberData(nameof(NewlyParsedAccessorModifiers))]
+    public void NewlyParsedAccessorModifierAfterAttribute(
+        LanguageVersion languageVersion,
+        string modifier,
+        string declarationKind,
+        string accessorKind)
+    {
+        var source = (declarationKind, accessorKind) switch
+        {
+            ("property", "get") => $"class C {{ int P {{ [System.Obsolete] {modifier} get; set; }} }}",
+            ("property", "set") => $"class C {{ int P {{ get; [System.Obsolete] {modifier} set; }} }}",
+            ("property", "init") => $"class C {{ int P {{ get; [System.Obsolete] {modifier} init; }} }}",
+            ("indexer", "get") => $"class C {{ int this[int i] {{ [System.Obsolete] {modifier} get; set; }} }}",
+            ("event", "add") => $"class C {{ event System.Action E {{ [System.Obsolete] {modifier} add {{ }} remove {{ }} }} }}",
+            ("event", "remove") => $"class C {{ event System.Action E {{ add {{ }} [System.Obsolete] {modifier} remove {{ }} }} }}",
+            _ => throw ExceptionUtilities.Unreachable(),
+        };
+        var options = TestOptions.Regular.WithLanguageVersion(languageVersion);
+        var tree = SyntaxFactory.ParseSyntaxTree(source, options);
+
+        Assert.Contains(
+            tree.GetDiagnostics(),
+            diagnostic => diagnostic.Code == (int)(declarationKind == "event"
+                ? ErrorCode.ERR_AddOrRemoveExpected
+                : ErrorCode.ERR_GetOrSetExpected));
+
+        var accessor = tree.GetRoot().DescendantNodes().OfType<AccessorDeclarationSyntax>().Single(
+            accessor => accessor.Keyword.ValueText == accessorKind);
+        Assert.Empty(accessor.AttributeLists);
+        Assert.Empty(accessor.Modifiers);
+
+        Assert.Contains(
+            CreateCompilation(source, parseOptions: options).GetDiagnostics(),
+            diagnostic => diagnostic.Code == (int)(declarationKind == "event"
+                ? ErrorCode.ERR_AddOrRemoveExpected
+                : ErrorCode.ERR_GetOrSetExpected));
+    }
+
+    [Fact]
+    public void ModifierBeforeAttributeRecovery()
+    {
+        const string source = "class C { int P { private [System.Obsolete] get; set; } }";
+        var tree = SyntaxFactory.ParseSyntaxTree(source);
+
+        Assert.Contains(tree.GetDiagnostics(), diagnostic => diagnostic.Code == (int)ErrorCode.ERR_RbraceExpected);
+        Assert.Contains(tree.GetDiagnostics(), diagnostic => diagnostic.Code == (int)ErrorCode.ERR_TypeExpected);
+        Assert.Contains(
+            CreateCompilation(source).GetDiagnostics(),
+            diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+    }
+
+    [Theory]
+    [InlineData("property", ";")]
+    [InlineData("property", "{ }")]
+    [InlineData("event", ";")]
+    [InlineData("event", "{ }")]
+    public void NewlyParsedModifierWithMissingAccessorName(string declarationKind, string body)
+    {
+        var modifiers = new[]
+        {
+            "public", "internal", "protected", "private", "sealed", "abstract", "static", "virtual",
+            "extern", "new", "override", "readonly", "volatile", "unsafe", "partial", "async", "ref",
+            "required", "file", "closed", "safe", "scoped",
+        };
+        var options = TestOptions.Regular10;
+
+        foreach (var modifier in modifiers)
+        {
+            var source = declarationKind switch
+            {
+                "property" => $"class C {{ int P {{ {modifier} {body} }} }}",
+                "event" => $"class C {{ event System.Action E {{ {modifier} {body} }} }}",
+                _ => throw ExceptionUtilities.Unreachable(),
+            };
+            var tree = SyntaxFactory.ParseSyntaxTree(source, options);
+            Assert.Contains(tree.GetDiagnostics(), diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+            Assert.Contains(
+                CreateCompilation(source, parseOptions: options).GetDiagnostics(),
+                diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+        }
+    }
+
+    [Theory]
+    [InlineData("property", "get")]
+    [InlineData("property", "set")]
+    [InlineData("property", "init")]
+    [InlineData("indexer", "get")]
+    [InlineData("event", "add")]
+    [InlineData("event", "remove")]
+    public void NewlyParsedModifierOnAccessorWithMissingBody(string declarationKind, string accessorKind)
+    {
+        foreach (var modifier in new[] { "partial", "scoped" })
+        {
+            var source = (declarationKind, accessorKind) switch
+            {
+                ("property", "get") => $"class C {{ int P {{ {modifier} get }} }}",
+                ("property", "set") => $"class C {{ int P {{ {modifier} set }} }}",
+                ("property", "init") => $"class C {{ int P {{ {modifier} init }} }}",
+                ("indexer", "get") => $"class C {{ int this[int i] {{ {modifier} get }} }}",
+                ("event", "add") => $"class C {{ event System.Action E {{ {modifier} add }} }}",
+                ("event", "remove") => $"class C {{ event System.Action E {{ {modifier} remove }} }}",
+                _ => throw ExceptionUtilities.Unreachable(),
+            };
+            var tree = SyntaxFactory.ParseSyntaxTree(source, TestOptions.RegularPreview);
+            var accessor = tree.GetRoot().DescendantNodes().OfType<AccessorDeclarationSyntax>().Single(
+                accessor => accessor.Keyword.ValueText == accessorKind);
+
+            Assert.Equal(accessorKind, accessor.Keyword.ValueText);
+            Assert.Empty(accessor.Modifiers);
+            Assert.Contains(tree.GetDiagnostics(), diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+            Assert.Contains(
+                CreateCompilation(source, parseOptions: TestOptions.RegularPreview).GetDiagnostics(),
+                diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+        }
+    }
+
+    [Theory]
+    [InlineData("property")]
+    [InlineData("event")]
+    public void NewlyParsedModifierBeforeCloseBrace(string declarationKind)
+    {
+        foreach (var modifier in new[] { "partial", "async", "required", "file", "closed", "scoped" })
+        {
+            var source = declarationKind switch
+            {
+                "property" => $"class C {{ int P {{ {modifier} }} }}",
+                "event" => $"class C {{ event System.Action E {{ {modifier} }} }}",
+                _ => throw ExceptionUtilities.Unreachable(),
+            };
+            var tree = SyntaxFactory.ParseSyntaxTree(source, TestOptions.Regular10);
+            var accessor = tree.GetRoot().DescendantNodes().OfType<AccessorDeclarationSyntax>().Single();
+
+            Assert.Equal(SyntaxKind.UnknownAccessorDeclaration, accessor.Kind());
+            Assert.Equal(modifier, accessor.Keyword.ValueText);
+            Assert.Empty(accessor.Modifiers);
+            Assert.Contains(tree.GetDiagnostics(), diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+            Assert.Contains(
+                CreateCompilation(source, parseOptions: TestOptions.Regular10).GetDiagnostics(),
+                diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+        }
+    }
+
+    [Theory]
+    [InlineData("=> 0;")]
+    [InlineData("unknown;")]
+    public void ContextualModifierBeforeNonAccessor(string trailingTokens)
+    {
+        var source = $"class C {{ int P {{ partial {trailingTokens} }} }}";
+        var tree = SyntaxFactory.ParseSyntaxTree(source);
+
+        var accessors = tree.GetRoot().DescendantNodes().OfType<AccessorDeclarationSyntax>().ToArray();
+        Assert.Equal("partial", accessors[0].Keyword.ValueText);
+        Assert.All(accessors, accessor => Assert.Empty(accessor.Modifiers));
+        Assert.Contains(tree.GetDiagnostics(), diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(
+            CreateCompilation(source).GetDiagnostics(),
+            diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+    }
+
+    [Fact]
+    public void ContextualModifierBeforeFollowingMember()
+    {
+        const string source = "class C { int P { partial int F; } }";
+        var tree = SyntaxFactory.ParseSyntaxTree(source);
+
+        var field = Assert.Single(tree.GetRoot().DescendantNodes().OfType<FieldDeclarationSyntax>());
+        Assert.Equal("F", field.Declaration.Variables.Single().Identifier.ValueText);
+        Assert.Empty(field.Modifiers);
+        var accessor = Assert.Single(tree.GetRoot().DescendantNodes().OfType<AccessorDeclarationSyntax>());
+        Assert.True(accessor.Keyword.IsMissing);
+        Assert.Equal("partial", Assert.Single(accessor.Modifiers).ValueText);
+        Assert.Contains(tree.GetDiagnostics(), diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(
+            CreateCompilation(source).GetDiagnostics(),
+            diagnostic => diagnostic.Code == (int)ErrorCode.ERR_GetOrSetExpected);
+    }
+
+    [Fact]
+    public void NewlyParsedModifierAtEndOfFile()
+    {
+        const string source = "class C { int P { partial";
+        var tree = SyntaxFactory.ParseSyntaxTree(source);
+        var accessor = tree.GetRoot().DescendantNodes().OfType<AccessorDeclarationSyntax>().Single();
+
+        Assert.Equal("partial", accessor.Keyword.ValueText);
+        Assert.Empty(accessor.Modifiers);
+        Assert.Contains(tree.GetDiagnostics(), diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(
+            CreateCompilation(source).GetDiagnostics(),
+            diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+    }
+
+    [Fact]
+    public void NewlyParsedAttributedModifierWithMissingAccessorName()
+    {
+        const string source = "class C { int P { [System.Obsolete] partial } }";
+        var tree = SyntaxFactory.ParseSyntaxTree(source);
+        var accessor = tree.GetRoot().DescendantNodes().OfType<AccessorDeclarationSyntax>().Single();
+
+        Assert.Single(accessor.AttributeLists);
+        Assert.Equal("partial", accessor.Keyword.ValueText);
+        Assert.Empty(accessor.Modifiers);
+        Assert.Contains(tree.GetDiagnostics(), diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(
+            CreateCompilation(source).GetDiagnostics(),
+            diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+    }
+
+    [Fact]
+    public void ValidPropertyAndIndexerAccessors()
+    {
+        const string source = """
+            class C
+            {
+                public int P { get; private set; }
+                public int Q { get; private init; }
+                public int this[int i] { private get => 0; set { } }
+            }
+            """;
+
+        UsingTree(source);
+        N(SyntaxKind.CompilationUnit);
+        {
+            N(SyntaxKind.ClassDeclaration);
+            {
+                N(SyntaxKind.ClassKeyword);
+                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PublicKeyword);
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "P");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.GetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.GetKeyword);
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.SetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.PrivateKeyword);
+                            N(SyntaxKind.SetKeyword);
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PublicKeyword);
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "Q");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.GetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.GetKeyword);
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.InitAccessorDeclaration);
+                        {
+                            N(SyntaxKind.PrivateKeyword);
+                            N(SyntaxKind.InitKeyword);
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.IndexerDeclaration);
+                {
+                    N(SyntaxKind.PublicKeyword);
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.ThisKeyword);
+                    N(SyntaxKind.BracketedParameterList);
+                    {
+                        N(SyntaxKind.OpenBracketToken);
+                        N(SyntaxKind.Parameter);
+                        {
+                            N(SyntaxKind.PredefinedType);
+                            {
+                                N(SyntaxKind.IntKeyword);
+                            }
+                            N(SyntaxKind.IdentifierToken, "i");
+                        }
+                        N(SyntaxKind.CloseBracketToken);
+                    }
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.GetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.PrivateKeyword);
+                            N(SyntaxKind.GetKeyword);
+                            N(SyntaxKind.ArrowExpressionClause);
+                            {
+                                N(SyntaxKind.EqualsGreaterThanToken);
+                                N(SyntaxKind.NumericLiteralExpression);
+                                {
+                                    N(SyntaxKind.NumericLiteralToken, "0");
+                                }
+                            }
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.SetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.SetKeyword);
+                            N(SyntaxKind.Block);
+                            {
+                                N(SyntaxKind.OpenBraceToken);
+                                N(SyntaxKind.CloseBraceToken);
+                            }
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+            N(SyntaxKind.EndOfFileToken);
+        }
+        EOF();
+
+        CreateCompilation(source, targetFramework: TargetFramework.NetCoreApp).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void RefModifiersRemainOnPropertyAndEventAccessors()
+    {
+        const string source = """
+            class C
+            {
+                int P { ref get => 0; abstract ref set { } }
+                event System.Action E { ref add { } abstract ref remove { } }
+            }
+            """;
+
+        UsingTree(source);
+        N(SyntaxKind.CompilationUnit);
+        {
+            N(SyntaxKind.ClassDeclaration);
+            {
+                N(SyntaxKind.ClassKeyword);
+                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "P");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.GetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.RefKeyword);
+                            N(SyntaxKind.GetKeyword);
+                            N(SyntaxKind.ArrowExpressionClause);
+                            {
+                                N(SyntaxKind.EqualsGreaterThanToken);
+                                N(SyntaxKind.NumericLiteralExpression);
+                                {
+                                    N(SyntaxKind.NumericLiteralToken, "0");
+                                }
+                            }
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.SetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.AbstractKeyword);
+                            N(SyntaxKind.RefKeyword);
+                            N(SyntaxKind.SetKeyword);
+                            N(SyntaxKind.Block);
+                            {
+                                N(SyntaxKind.OpenBraceToken);
+                                N(SyntaxKind.CloseBraceToken);
+                            }
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.EventDeclaration);
+                {
+                    N(SyntaxKind.EventKeyword);
+                    N(SyntaxKind.QualifiedName);
+                    {
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "System");
+                        }
+                        N(SyntaxKind.DotToken);
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "Action");
+                        }
+                    }
+                    N(SyntaxKind.IdentifierToken, "E");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.AddAccessorDeclaration);
+                        {
+                            N(SyntaxKind.RefKeyword);
+                            N(SyntaxKind.AddKeyword);
+                            N(SyntaxKind.Block);
+                            {
+                                N(SyntaxKind.OpenBraceToken);
+                                N(SyntaxKind.CloseBraceToken);
+                            }
+                        }
+                        N(SyntaxKind.RemoveAccessorDeclaration);
+                        {
+                            N(SyntaxKind.AbstractKeyword);
+                            N(SyntaxKind.RefKeyword);
+                            N(SyntaxKind.RemoveKeyword);
+                            N(SyntaxKind.Block);
+                            {
+                                N(SyntaxKind.OpenBraceToken);
+                                N(SyntaxKind.CloseBraceToken);
+                            }
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+            N(SyntaxKind.EndOfFileToken);
+        }
+        EOF();
+
+        CreateCompilation(source).VerifyDiagnostics(
+            Diagnostic(ErrorCode.ERR_BadMemberFlag, "get").WithArguments("ref").WithLocation(3, 17),
+            Diagnostic(ErrorCode.ERR_BadMemberFlag, "set").WithArguments("abstract").WithLocation(3, 40),
+            Diagnostic(ErrorCode.ERR_BadMemberFlag, "set").WithArguments("ref").WithLocation(3, 40),
+            Diagnostic(ErrorCode.ERR_NoModifiersOnAccessor, "ref").WithLocation(4, 29),
+            Diagnostic(ErrorCode.ERR_NoModifiersOnAccessor, "abstract").WithLocation(4, 41));
+    }
+
+    [Fact]
+    public void RefReturningPropertyWithAccessorKeywordType()
+    {
+        const string source = """
+            #pragma warning disable CS8981
+            class get { }
+            class C
+            {
+                get _value;
+                ref get A => ref _value;
+            }
+            """;
+
+        UsingTree(source);
+        N(SyntaxKind.CompilationUnit);
+        {
+            N(SyntaxKind.ClassDeclaration);
+            {
+                N(SyntaxKind.ClassKeyword);
+                N(SyntaxKind.IdentifierToken, "get");
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.CloseBraceToken);
+            }
+            N(SyntaxKind.ClassDeclaration);
+            {
+                N(SyntaxKind.ClassKeyword);
+                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.FieldDeclaration);
+                {
+                    N(SyntaxKind.VariableDeclaration);
+                    {
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "get");
+                        }
+                        N(SyntaxKind.VariableDeclarator);
+                        {
+                            N(SyntaxKind.IdentifierToken, "_value");
+                        }
+                    }
+                    N(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.RefType);
+                    {
+                        N(SyntaxKind.RefKeyword);
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "get");
+                        }
+                    }
+                    N(SyntaxKind.IdentifierToken, "A");
+                    N(SyntaxKind.ArrowExpressionClause);
+                    {
+                        N(SyntaxKind.EqualsGreaterThanToken);
+                        N(SyntaxKind.RefExpression);
+                        {
+                            N(SyntaxKind.RefKeyword);
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "_value");
+                            }
+                        }
+                    }
+                    N(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+            N(SyntaxKind.EndOfFileToken);
+        }
+        EOF();
+
+        CreateCompilation(source).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void IncompleteRefAccessorBeforeCloseBrace()
+    {
+        const string source = """
+            class C
+            {
+                int P { ref get }
+            }
+            """;
+
+        UsingTree(
+            source,
+            Diagnostic(ErrorCode.ERR_SemiOrLBraceOrArrowExpected, "}").WithLocation(3, 21));
+        N(SyntaxKind.CompilationUnit);
+        {
+            N(SyntaxKind.ClassDeclaration);
+            {
+                N(SyntaxKind.ClassKeyword);
+                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "P");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.GetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.RefKeyword);
+                            N(SyntaxKind.GetKeyword);
+                            M(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+            N(SyntaxKind.EndOfFileToken);
+        }
+        EOF();
+
+        CreateCompilation(source).VerifyDiagnostics(
+            Diagnostic(ErrorCode.ERR_BadMemberFlag, "get").WithArguments("ref").WithLocation(3, 17),
+            Diagnostic(ErrorCode.ERR_SemiOrLBraceOrArrowExpected, "}").WithLocation(3, 21));
+    }
+
+    [Fact]
+    public void ScopedRefModifiersRemainOnAccessor()
+    {
+        const string source = """
+            class C
+            {
+                public int P { scoped ref get; set; }
+            }
+            """;
+
+        UsingTree(
+            source,
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "scoped").WithLocation(3, 20));
+        N(SyntaxKind.CompilationUnit);
+        {
+            N(SyntaxKind.ClassDeclaration);
+            {
+                N(SyntaxKind.ClassKeyword);
+                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PublicKeyword);
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "P");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.UnknownAccessorDeclaration);
+                        {
+                            N(SyntaxKind.IdentifierToken, "scoped");
+                        }
+                        N(SyntaxKind.GetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.RefKeyword);
+                            N(SyntaxKind.GetKeyword);
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.SetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.SetKeyword);
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+            N(SyntaxKind.EndOfFileToken);
+        }
+        EOF();
+
+        CreateCompilation(source).VerifyDiagnostics(
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "scoped").WithLocation(3, 20),
+            Diagnostic(ErrorCode.ERR_BadMemberFlag, "get").WithArguments("ref").WithLocation(3, 31));
+    }
+
+    [Fact]
+    public void SafeModifierOrderingAndAccessorName()
+    {
+        const string source = """
+            class C
+            {
+                public int P { private safe get => 0; set { } }
+                public int Q { get => 0; safe private set { } }
+                int R { safe; get => 0; set { } }
+            }
+            """;
+
+        UsingTree(
+            source,
+            TestOptions.RegularPreview,
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "safe").WithLocation(5, 13));
+        N(SyntaxKind.CompilationUnit);
+        {
+            N(SyntaxKind.ClassDeclaration);
+            {
+                N(SyntaxKind.ClassKeyword);
+                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PublicKeyword);
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "P");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.GetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.PrivateKeyword);
+                            N(SyntaxKind.SafeKeyword);
+                            N(SyntaxKind.GetKeyword);
+                            N(SyntaxKind.ArrowExpressionClause);
+                            {
+                                N(SyntaxKind.EqualsGreaterThanToken);
+                                N(SyntaxKind.NumericLiteralExpression);
+                                {
+                                    N(SyntaxKind.NumericLiteralToken, "0");
+                                }
+                            }
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.SetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.SetKeyword);
+                            N(SyntaxKind.Block);
+                            {
+                                N(SyntaxKind.OpenBraceToken);
+                                N(SyntaxKind.CloseBraceToken);
+                            }
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PublicKeyword);
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "Q");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.GetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.GetKeyword);
+                            N(SyntaxKind.ArrowExpressionClause);
+                            {
+                                N(SyntaxKind.EqualsGreaterThanToken);
+                                N(SyntaxKind.NumericLiteralExpression);
+                                {
+                                    N(SyntaxKind.NumericLiteralToken, "0");
+                                }
+                            }
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.SetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.SafeKeyword);
+                            N(SyntaxKind.PrivateKeyword);
+                            N(SyntaxKind.SetKeyword);
+                            N(SyntaxKind.Block);
+                            {
+                                N(SyntaxKind.OpenBraceToken);
+                                N(SyntaxKind.CloseBraceToken);
+                            }
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "R");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.UnknownAccessorDeclaration);
+                        {
+                            N(SyntaxKind.IdentifierToken, "safe");
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.GetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.GetKeyword);
+                            N(SyntaxKind.ArrowExpressionClause);
+                            {
+                                N(SyntaxKind.EqualsGreaterThanToken);
+                                N(SyntaxKind.NumericLiteralExpression);
+                                {
+                                    N(SyntaxKind.NumericLiteralToken, "0");
+                                }
+                            }
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.SetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.SetKeyword);
+                            N(SyntaxKind.Block);
+                            {
+                                N(SyntaxKind.OpenBraceToken);
+                                N(SyntaxKind.CloseBraceToken);
+                            }
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+            N(SyntaxKind.EndOfFileToken);
+        }
+        EOF();
+
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "safe").WithLocation(5, 13));
+    }
+
+    [Fact]
+    public void ContextualKeywordsAreRecoveredBeforeAccessors()
+    {
+        const string source = """
+            class C
+            {
+                int P { scoped get; set; }
+                int Q { partial get; set; }
+                int R { async get; set; }
+                public int S { private async get; set; }
+                public int T { private partial get; set; }
+            }
+            """;
+
+        var tree = SyntaxFactory.ParseSyntaxTree(source, TestOptions.RegularPreview);
+        tree.GetDiagnostics().Verify(
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "scoped").WithLocation(3, 13),
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(4, 13),
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "async").WithLocation(5, 13),
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "async").WithLocation(6, 28),
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(7, 28));
+
+        var getAccessors = tree.GetRoot().DescendantNodes().OfType<AccessorDeclarationSyntax>()
+            .Where(accessor => accessor.Keyword.IsKind(SyntaxKind.GetKeyword));
+        Assert.Equal(5, getAccessors.Count());
+        Assert.All(getAccessors, accessor => Assert.Empty(accessor.Modifiers));
+
+        Assert.Contains(
+            CreateCompilation(source, parseOptions: TestOptions.RegularPreview).GetDiagnostics(),
+            diagnostic => diagnostic.Code == (int)ErrorCode.ERR_GetOrSetExpected);
+    }
+
+    [Fact]
+    public void InvalidModifiersRemainOnAccessors()
+    {
+        const string source = """
+            class C
+            {
+                int P { required get; file set; }
+                int Q { closed get; static set; }
+                public int R { private private get; set; }
+            }
+            """;
+
+        UsingTree(source, TestOptions.RegularPreview);
+        N(SyntaxKind.CompilationUnit);
+        {
+            N(SyntaxKind.ClassDeclaration);
+            {
+                N(SyntaxKind.ClassKeyword);
+                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "P");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.GetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.RequiredKeyword);
+                            N(SyntaxKind.GetKeyword);
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.SetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.FileKeyword);
+                            N(SyntaxKind.SetKeyword);
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "Q");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.GetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.ClosedKeyword);
+                            N(SyntaxKind.GetKeyword);
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.SetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.StaticKeyword);
+                            N(SyntaxKind.SetKeyword);
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PublicKeyword);
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "R");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.GetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.PrivateKeyword);
+                            N(SyntaxKind.PrivateKeyword);
+                            N(SyntaxKind.GetKeyword);
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.SetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.SetKeyword);
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+            N(SyntaxKind.EndOfFileToken);
+        }
+        EOF();
+
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            Diagnostic(ErrorCode.ERR_BadMemberFlag, "get").WithArguments("required").WithLocation(3, 22),
+            Diagnostic(ErrorCode.ERR_BadMemberFlag, "set").WithArguments("file").WithLocation(3, 32),
+            Diagnostic(ErrorCode.ERR_BadMemberFlag, "get").WithArguments("closed").WithLocation(4, 20),
+            Diagnostic(ErrorCode.ERR_BadMemberFlag, "set").WithArguments("static").WithLocation(4, 32),
+            Diagnostic(ErrorCode.ERR_DuplicateModifier, "private").WithArguments("private").WithLocation(5, 28));
+    }
+
+    [Fact]
+    public void AttributeBeforeReadonlyAccessorModifier()
+    {
+        const string source = """
+            struct S
+            {
+                public int P { [System.Obsolete] readonly get => 0; set { } }
+            }
+            """;
+
+        UsingTree(source);
+        N(SyntaxKind.CompilationUnit);
+        {
+            N(SyntaxKind.StructDeclaration);
+            {
+                N(SyntaxKind.StructKeyword);
+                N(SyntaxKind.IdentifierToken, "S");
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PublicKeyword);
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "P");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.GetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.AttributeList);
+                            {
+                                N(SyntaxKind.OpenBracketToken);
+                                N(SyntaxKind.Attribute);
+                                {
+                                    N(SyntaxKind.QualifiedName);
+                                    {
+                                        N(SyntaxKind.IdentifierName);
+                                        {
+                                            N(SyntaxKind.IdentifierToken, "System");
+                                        }
+                                        N(SyntaxKind.DotToken);
+                                        N(SyntaxKind.IdentifierName);
+                                        {
+                                            N(SyntaxKind.IdentifierToken, "Obsolete");
+                                        }
+                                    }
+                                }
+                                N(SyntaxKind.CloseBracketToken);
+                            }
+                            N(SyntaxKind.ReadOnlyKeyword);
+                            N(SyntaxKind.GetKeyword);
+                            N(SyntaxKind.ArrowExpressionClause);
+                            {
+                                N(SyntaxKind.EqualsGreaterThanToken);
+                                N(SyntaxKind.NumericLiteralExpression);
+                                {
+                                    N(SyntaxKind.NumericLiteralToken, "0");
+                                }
+                            }
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.SetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.SetKeyword);
+                            N(SyntaxKind.Block);
+                            {
+                                N(SyntaxKind.OpenBraceToken);
+                                N(SyntaxKind.CloseBraceToken);
+                            }
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+            N(SyntaxKind.EndOfFileToken);
+        }
+        EOF();
+
+        CreateCompilation(source).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void AccessorRecoveryDoesNotConsumeFollowingMember()
+    {
+        const string source = """
+            class C
+            {
+                int P
+                {
+                    get { return 0; }
+                private int F;
+            }
+            """;
+
+        UsingTree(
+            source,
+            Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(5, 26));
+        N(SyntaxKind.CompilationUnit);
+        {
+            N(SyntaxKind.ClassDeclaration);
+            {
+                N(SyntaxKind.ClassKeyword);
+                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "P");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.GetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.GetKeyword);
+                            N(SyntaxKind.Block);
+                            {
+                                N(SyntaxKind.OpenBraceToken);
+                                N(SyntaxKind.ReturnStatement);
+                                {
+                                    N(SyntaxKind.ReturnKeyword);
+                                    N(SyntaxKind.NumericLiteralExpression);
+                                    {
+                                        N(SyntaxKind.NumericLiteralToken, "0");
+                                    }
+                                    N(SyntaxKind.SemicolonToken);
+                                }
+                                N(SyntaxKind.CloseBraceToken);
+                            }
+                        }
+                        M(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.FieldDeclaration);
+                {
+                    N(SyntaxKind.PrivateKeyword);
+                    N(SyntaxKind.VariableDeclaration);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.IntKeyword);
+                        }
+                        N(SyntaxKind.VariableDeclarator);
+                        {
+                            N(SyntaxKind.IdentifierToken, "F");
+                        }
+                    }
+                    N(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+            N(SyntaxKind.EndOfFileToken);
+        }
+        EOF();
+
+        CreateCompilation(source).VerifyDiagnostics(
+            Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(5, 26),
+            Diagnostic(ErrorCode.WRN_UnreferencedField, "F").WithArguments("C.F").WithLocation(6, 17));
+    }
+
+    [Fact]
+    public void AccessorModifierBeforeFeature()
+    {
+        const string source = """
+            class C
+            {
+                public int P { get; private set; }
+            }
+            """;
+        var options = TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp1);
+
+        UsingTree(source, options);
+        N(SyntaxKind.CompilationUnit);
+        {
+            N(SyntaxKind.ClassDeclaration);
+            {
+                N(SyntaxKind.ClassKeyword);
+                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PublicKeyword);
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "P");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.GetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.GetKeyword);
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.SetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.PrivateKeyword);
+                            N(SyntaxKind.SetKeyword);
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+            N(SyntaxKind.EndOfFileToken);
+        }
+        EOF();
+
+        CreateCompilation(source, parseOptions: options).VerifyDiagnostics(
+            Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion1, "P").WithArguments("automatically implemented properties", "3").WithLocation(3, 16),
+            Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion1, "private").WithArguments("access modifiers on properties", "2").WithLocation(3, 25));
+    }
+
+    [Fact]
+    public void SafeAccessorModifierBeforeFeature()
+    {
+        const string source = """
+            class C
+            {
+                public int P { private safe get => 0; set { } }
+            }
+            """;
+
+        UsingTree(source, TestOptions.Regular14);
+        N(SyntaxKind.CompilationUnit);
+        {
+            N(SyntaxKind.ClassDeclaration);
+            {
+                N(SyntaxKind.ClassKeyword);
+                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PublicKeyword);
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "P");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.GetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.PrivateKeyword);
+                            N(SyntaxKind.SafeKeyword);
+                            N(SyntaxKind.GetKeyword);
+                            N(SyntaxKind.ArrowExpressionClause);
+                            {
+                                N(SyntaxKind.EqualsGreaterThanToken);
+                                N(SyntaxKind.NumericLiteralExpression);
+                                {
+                                    N(SyntaxKind.NumericLiteralToken, "0");
+                                }
+                            }
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.SetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.SetKeyword);
+                            N(SyntaxKind.Block);
+                            {
+                                N(SyntaxKind.OpenBraceToken);
+                                N(SyntaxKind.CloseBraceToken);
+                            }
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+            N(SyntaxKind.EndOfFileToken);
+        }
+        EOF();
+
+        CreateCompilation(source, parseOptions: TestOptions.Regular14).VerifyDiagnostics(
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "safe").WithArguments("updated memory safety rules").WithLocation(3, 28));
+    }
+}

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/AccessorModifierParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/AccessorModifierParsingTests.cs
@@ -1161,4 +1161,498 @@ public sealed class AccessorModifierParsingTests(ITestOutputHelper output) : Par
         CreateCompilation(source, parseOptions: TestOptions.Regular14).VerifyDiagnostics(
             Diagnostic(ErrorCode.ERR_FeatureInPreview, "safe").WithArguments("updated memory safety rules").WithLocation(3, 28));
     }
+
+    [Fact]
+    public void OlderLanguageVersionDoesNotRecognizeNewAccessorModifiers()
+    {
+        const string source = """
+            class C
+            {
+                int P { required get; file set; closed init; }
+            }
+            """;
+
+        UsingTree(
+            source,
+            TestOptions.Regular10,
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "required").WithLocation(3, 13),
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "file").WithLocation(3, 27),
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "closed").WithLocation(3, 37));
+        N(SyntaxKind.CompilationUnit);
+        {
+            N(SyntaxKind.ClassDeclaration);
+            {
+                N(SyntaxKind.ClassKeyword);
+                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "P");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.UnknownAccessorDeclaration);
+                        {
+                            N(SyntaxKind.IdentifierToken, "required");
+                        }
+                        N(SyntaxKind.GetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.GetKeyword);
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.UnknownAccessorDeclaration);
+                        {
+                            N(SyntaxKind.IdentifierToken, "file");
+                        }
+                        N(SyntaxKind.SetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.SetKeyword);
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.UnknownAccessorDeclaration);
+                        {
+                            N(SyntaxKind.IdentifierToken, "closed");
+                        }
+                        N(SyntaxKind.InitAccessorDeclaration);
+                        {
+                            N(SyntaxKind.InitKeyword);
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+            N(SyntaxKind.EndOfFileToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialAccessorModifierBeforeCloseBrace()
+    {
+        const string source = """
+            class C
+            {
+                int P { partial }
+            }
+            """;
+
+        UsingTree(
+            source,
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(3, 13));
+        N(SyntaxKind.CompilationUnit);
+        {
+            N(SyntaxKind.ClassDeclaration);
+            {
+                N(SyntaxKind.ClassKeyword);
+                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "P");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.UnknownAccessorDeclaration);
+                        {
+                            N(SyntaxKind.IdentifierToken, "partial");
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+            N(SyntaxKind.EndOfFileToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialAccessorModifierBeforeEndOfFile()
+    {
+        const string source = "class C { int P { partial";
+
+        UsingTree(
+            source,
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(1, 19),
+            Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(1, 26),
+            Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(1, 26));
+        N(SyntaxKind.CompilationUnit);
+        {
+            N(SyntaxKind.ClassDeclaration);
+            {
+                N(SyntaxKind.ClassKeyword);
+                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "P");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.UnknownAccessorDeclaration);
+                        {
+                            N(SyntaxKind.IdentifierToken, "partial");
+                        }
+                        M(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                M(SyntaxKind.CloseBraceToken);
+            }
+            N(SyntaxKind.EndOfFileToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void AttributeAndPartialAccessorModifierBeforeCloseBrace()
+    {
+        const string source = """
+            class C
+            {
+                int P { [System.Obsolete] partial }
+            }
+            """;
+
+        UsingTree(
+            source,
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(3, 31));
+        N(SyntaxKind.CompilationUnit);
+        {
+            N(SyntaxKind.ClassDeclaration);
+            {
+                N(SyntaxKind.ClassKeyword);
+                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "P");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.UnknownAccessorDeclaration);
+                        {
+                            N(SyntaxKind.AttributeList);
+                            {
+                                N(SyntaxKind.OpenBracketToken);
+                                N(SyntaxKind.Attribute);
+                                {
+                                    N(SyntaxKind.QualifiedName);
+                                    {
+                                        N(SyntaxKind.IdentifierName);
+                                        {
+                                            N(SyntaxKind.IdentifierToken, "System");
+                                        }
+                                        N(SyntaxKind.DotToken);
+                                        N(SyntaxKind.IdentifierName);
+                                        {
+                                            N(SyntaxKind.IdentifierToken, "Obsolete");
+                                        }
+                                    }
+                                }
+                                N(SyntaxKind.CloseBracketToken);
+                            }
+                            N(SyntaxKind.IdentifierToken, "partial");
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+            N(SyntaxKind.EndOfFileToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialFieldAfterIncompleteAccessorList()
+    {
+        const string source = """
+            class C
+            {
+                int P
+                {
+                    get;
+                partial int F;
+            }
+            """;
+
+        UsingTree(
+            source,
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "int").WithLocation(6, 13),
+            Diagnostic(ErrorCode.ERR_RbraceExpected, "int").WithLocation(6, 13));
+        N(SyntaxKind.CompilationUnit);
+        {
+            N(SyntaxKind.ClassDeclaration);
+            {
+                N(SyntaxKind.ClassKeyword);
+                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "P");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.GetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.GetKeyword);
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.UnknownAccessorDeclaration);
+                        {
+                            N(SyntaxKind.PartialKeyword);
+                            M(SyntaxKind.IdentifierToken);
+                        }
+                        M(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.FieldDeclaration);
+                {
+                    N(SyntaxKind.VariableDeclaration);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.IntKeyword);
+                        }
+                        N(SyntaxKind.VariableDeclarator);
+                        {
+                            N(SyntaxKind.IdentifierToken, "F");
+                        }
+                    }
+                    N(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+            N(SyntaxKind.EndOfFileToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void AttributeBeforeScopedAccessorModifier()
+    {
+        const string source = """
+            class C
+            {
+                int P { [System.Obsolete] scoped get; }
+            }
+            """;
+
+        UsingTree(
+            source,
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "scoped").WithLocation(3, 31));
+        N(SyntaxKind.CompilationUnit);
+        {
+            N(SyntaxKind.ClassDeclaration);
+            {
+                N(SyntaxKind.ClassKeyword);
+                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "P");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.UnknownAccessorDeclaration);
+                        {
+                            N(SyntaxKind.AttributeList);
+                            {
+                                N(SyntaxKind.OpenBracketToken);
+                                N(SyntaxKind.Attribute);
+                                {
+                                    N(SyntaxKind.QualifiedName);
+                                    {
+                                        N(SyntaxKind.IdentifierName);
+                                        {
+                                            N(SyntaxKind.IdentifierToken, "System");
+                                        }
+                                        N(SyntaxKind.DotToken);
+                                        N(SyntaxKind.IdentifierName);
+                                        {
+                                            N(SyntaxKind.IdentifierToken, "Obsolete");
+                                        }
+                                    }
+                                }
+                                N(SyntaxKind.CloseBracketToken);
+                            }
+                            N(SyntaxKind.IdentifierToken, "scoped");
+                        }
+                        N(SyntaxKind.GetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.GetKeyword);
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+            N(SyntaxKind.EndOfFileToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void ContextualModifiersOnOtherAccessorKinds()
+    {
+        const string source = """
+            class C
+            {
+                int P { partial init; }
+                int this[int i] { scoped get; }
+                event System.Action E { partial add { } scoped remove { } }
+            }
+            """;
+
+        UsingTree(
+            source,
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "partial").WithLocation(3, 13),
+            Diagnostic(ErrorCode.ERR_GetOrSetExpected, "scoped").WithLocation(4, 23),
+            Diagnostic(ErrorCode.ERR_AddOrRemoveExpected, "partial").WithLocation(5, 29),
+            Diagnostic(ErrorCode.ERR_AddOrRemoveExpected, "scoped").WithLocation(5, 45));
+        N(SyntaxKind.CompilationUnit);
+        {
+            N(SyntaxKind.ClassDeclaration);
+            {
+                N(SyntaxKind.ClassKeyword);
+                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.PropertyDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "P");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.UnknownAccessorDeclaration);
+                        {
+                            N(SyntaxKind.IdentifierToken, "partial");
+                        }
+                        N(SyntaxKind.InitAccessorDeclaration);
+                        {
+                            N(SyntaxKind.InitKeyword);
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.IndexerDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.ThisKeyword);
+                    N(SyntaxKind.BracketedParameterList);
+                    {
+                        N(SyntaxKind.OpenBracketToken);
+                        N(SyntaxKind.Parameter);
+                        {
+                            N(SyntaxKind.PredefinedType);
+                            {
+                                N(SyntaxKind.IntKeyword);
+                            }
+                            N(SyntaxKind.IdentifierToken, "i");
+                        }
+                        N(SyntaxKind.CloseBracketToken);
+                    }
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.UnknownAccessorDeclaration);
+                        {
+                            N(SyntaxKind.IdentifierToken, "scoped");
+                        }
+                        N(SyntaxKind.GetAccessorDeclaration);
+                        {
+                            N(SyntaxKind.GetKeyword);
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.EventDeclaration);
+                {
+                    N(SyntaxKind.EventKeyword);
+                    N(SyntaxKind.QualifiedName);
+                    {
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "System");
+                        }
+                        N(SyntaxKind.DotToken);
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "Action");
+                        }
+                    }
+                    N(SyntaxKind.IdentifierToken, "E");
+                    N(SyntaxKind.AccessorList);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.UnknownAccessorDeclaration);
+                        {
+                            N(SyntaxKind.IdentifierToken, "partial");
+                        }
+                        N(SyntaxKind.AddAccessorDeclaration);
+                        {
+                            N(SyntaxKind.AddKeyword);
+                            N(SyntaxKind.Block);
+                            {
+                                N(SyntaxKind.OpenBraceToken);
+                                N(SyntaxKind.CloseBraceToken);
+                            }
+                        }
+                        N(SyntaxKind.UnknownAccessorDeclaration);
+                        {
+                            N(SyntaxKind.IdentifierToken, "scoped");
+                        }
+                        N(SyntaxKind.RemoveAccessorDeclaration);
+                        {
+                            N(SyntaxKind.RemoveKeyword);
+                            N(SyntaxKind.Block);
+                            {
+                                N(SyntaxKind.OpenBraceToken);
+                                N(SyntaxKind.CloseBraceToken);
+                            }
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+            N(SyntaxKind.EndOfFileToken);
+        }
+        EOF();
+    }
 }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/PartialEventsAndConstructorsParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/PartialEventsAndConstructorsParsingTests.cs
@@ -632,16 +632,39 @@ public sealed class PartialEventsAndConstructorsParsingTests(ITestOutputHelper o
     [Theory, CombinatorialData]
     public void Event_Implementation_PartialAccessors([CSharp14_Preview] LanguageVersion langVersion)
     {
-        UsingDeclaration("""
-            partial event Action E { partial add; partial remove; }
-            """,
-            TestOptions.Regular.WithLanguageVersion(langVersion),
+        var source = "partial event Action E { partial add; partial remove; }";
+        var parseOptions = TestOptions.Regular.WithLanguageVersion(langVersion);
+
+        UsingDeclaration(
+            source,
+            parseOptions,
             // (1,26): error CS1055: An add or remove accessor expected
             // partial event Action E { partial add; partial remove; }
             Diagnostic(ErrorCode.ERR_AddOrRemoveExpected, "partial").WithLocation(1, 26),
             // (1,39): error CS1055: An add or remove accessor expected
             // partial event Action E { partial add; partial remove; }
             Diagnostic(ErrorCode.ERR_AddOrRemoveExpected, "partial").WithLocation(1, 39));
+        CreateCompilation($$"""
+            using System;
+
+            partial class C
+            {
+                partial event Action E;
+                {{source}}
+            }
+            """, parseOptions: parseOptions).VerifyDiagnostics(
+            // (6,30): error CS1055: An add or remove accessor expected
+            //     partial event Action E { partial add; partial remove; }
+            Diagnostic(ErrorCode.ERR_AddOrRemoveExpected, "partial").WithLocation(6, 30),
+            // (6,41): error CS0073: An add or remove accessor must have a body
+            //     partial event Action E { partial add; partial remove; }
+            Diagnostic(ErrorCode.ERR_AddRemoveMustHaveBody, ";").WithLocation(6, 41),
+            // (6,43): error CS1055: An add or remove accessor expected
+            //     partial event Action E { partial add; partial remove; }
+            Diagnostic(ErrorCode.ERR_AddOrRemoveExpected, "partial").WithLocation(6, 43),
+            // (6,57): error CS0073: An add or remove accessor must have a body
+            //     partial event Action E { partial add; partial remove; }
+            Diagnostic(ErrorCode.ERR_AddRemoveMustHaveBody, ";").WithLocation(6, 57));
 
         N(SyntaxKind.EventDeclaration);
         {

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/SafeModifierParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/SafeModifierParsingTests.cs
@@ -418,19 +418,20 @@ public sealed class SafeModifierParsingTests(ITestOutputHelper output) : Parsing
     [Fact]
     public void PropertyAccessor()
     {
-        const string source = "public int P { safe get; set; }";
-        UsingDeclaration(source);
+        const string declaration = """public int P { safe get; set; }""";
+        var source = $$"""class C { {{declaration}} }""";
+        UsingDeclaration(declaration);
 
-        CreateCompilation($"class C {{ {source} }}", parseOptions: TestOptions.Regular14).VerifyDiagnostics(
+        CreateCompilation(source, parseOptions: TestOptions.Regular14).VerifyDiagnostics(
             // (1,26): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
             // class C { public int P { safe get; set; } }
             Diagnostic(ErrorCode.ERR_FeatureInPreview, "safe").WithArguments("updated memory safety rules").WithLocation(1, 26));
-        CreateCompilation($"class C {{ {source} }}", parseOptions: TestOptions.Regular15).VerifyDiagnostics(
+        CreateCompilation(source, parseOptions: TestOptions.Regular15).VerifyDiagnostics(
             // (1,26): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
             // class C { public int P { safe get; set; } }
             Diagnostic(ErrorCode.ERR_FeatureInPreview, "safe").WithArguments("updated memory safety rules").WithLocation(1, 26));
-        CreateCompilation($"class C {{ {source} }}", parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
-        CreateCompilation($"class C {{ {source} }}", parseOptions: TestOptions.RegularPreview).VerifyDiagnostics();
+        CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics();
 
         N(SyntaxKind.PropertyDeclaration);
         {
@@ -481,39 +482,41 @@ public sealed class SafeModifierParsingTests(ITestOutputHelper output) : Parsing
     [Fact]
     public void PropertyAccessor_WithOtherModifiers()
     {
-        const string source = "public int P { private safe get; set; }";
+        const string declaration = """public int P { private safe get; set; }""";
+        var source = $$"""class C { {{declaration}} }""";
 
-        CreateCompilation($"class C {{ {source} }}", parseOptions: TestOptions.Regular14).VerifyDiagnostics(
+        CreateCompilation(source, parseOptions: TestOptions.Regular14).VerifyDiagnostics(
             // (1,34): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
             // class C { public int P { private safe get; set; } }
             Diagnostic(ErrorCode.ERR_FeatureInPreview, "safe").WithArguments("updated memory safety rules").WithLocation(1, 34));
-        CreateCompilation($"class C {{ {source} }}", parseOptions: TestOptions.Regular15).VerifyDiagnostics(
+        CreateCompilation(source, parseOptions: TestOptions.Regular15).VerifyDiagnostics(
             // (1,34): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
             // class C { public int P { private safe get; set; } }
             Diagnostic(ErrorCode.ERR_FeatureInPreview, "safe").WithArguments("updated memory safety rules").WithLocation(1, 34));
-        CreateCompilation($"class C {{ {source} }}", parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
-        CreateCompilation($"class C {{ {source} }}", parseOptions: TestOptions.RegularPreview).VerifyDiagnostics();
+        CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics();
     }
 
     [Fact]
     public void EventAccessor()
     {
-        const string source = "public event EHandler E { safe add { } remove { } }";
-        UsingDeclaration(source);
+        const string declaration = """public event EHandler E { safe add { } remove { } }""";
+        var source = $$"""delegate void EHandler(); class C { {{declaration}} }""";
+        UsingDeclaration(declaration);
 
-        CreateCompilation($"delegate void EHandler(); class C {{ {source} }}", parseOptions: TestOptions.Regular14).VerifyDiagnostics(
+        CreateCompilation(source, parseOptions: TestOptions.Regular14).VerifyDiagnostics(
             // (1,63): error CS1609: Modifiers cannot be placed on event accessor declarations
             // delegate void EHandler(); class C { public event EHandler E { safe add { } remove { } } }
             Diagnostic(ErrorCode.ERR_NoModifiersOnAccessor, "safe").WithLocation(1, 63));
-        CreateCompilation($"delegate void EHandler(); class C {{ {source} }}", parseOptions: TestOptions.Regular15).VerifyDiagnostics(
+        CreateCompilation(source, parseOptions: TestOptions.Regular15).VerifyDiagnostics(
             // (1,63): error CS1609: Modifiers cannot be placed on event accessor declarations
             // delegate void EHandler(); class C { public event EHandler E { safe add { } remove { } } }
             Diagnostic(ErrorCode.ERR_NoModifiersOnAccessor, "safe").WithLocation(1, 63));
-        CreateCompilation($"delegate void EHandler(); class C {{ {source} }}", parseOptions: TestOptions.RegularNext).VerifyDiagnostics(
+        CreateCompilation(source, parseOptions: TestOptions.RegularNext).VerifyDiagnostics(
             // (1,63): error CS1609: Modifiers cannot be placed on event accessor declarations
             // delegate void EHandler(); class C { public event EHandler E { safe add { } remove { } } }
             Diagnostic(ErrorCode.ERR_NoModifiersOnAccessor, "safe").WithLocation(1, 63));
-        CreateCompilation($"delegate void EHandler(); class C {{ {source} }}", parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
             // (1,63): error CS1609: Modifiers cannot be placed on event accessor declarations
             // delegate void EHandler(); class C { public event EHandler E { safe add { } remove { } } }
             Diagnostic(ErrorCode.ERR_NoModifiersOnAccessor, "safe").WithLocation(1, 63));

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/SafeModifierParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/SafeModifierParsingTests.cs
@@ -210,63 +210,26 @@ public sealed class SafeModifierParsingTests(ITestOutputHelper output) : Parsing
     [InlineData("static extern safe void Local();", SyntaxKind.StaticKeyword, SyntaxKind.ExternKeyword, SyntaxKind.SafeKeyword)]
     public void LocalFunction(string localFunction, params SyntaxKind[] expectedModifiers)
     {
-        UsingTree($$"""
-            class C
-            {
-                void M()
-                {
-                    {{localFunction}}
-                }
-            }
-            """);
+        UsingStatement(localFunction);
 
-        N(SyntaxKind.CompilationUnit);
+        N(SyntaxKind.LocalFunctionStatement);
         {
-            N(SyntaxKind.ClassDeclaration);
+            foreach (var expectedModifier in expectedModifiers)
             {
-                N(SyntaxKind.ClassKeyword);
-                N(SyntaxKind.IdentifierToken, "C");
-                N(SyntaxKind.OpenBraceToken);
-                N(SyntaxKind.MethodDeclaration);
-                {
-                    N(SyntaxKind.PredefinedType);
-                    {
-                        N(SyntaxKind.VoidKeyword);
-                    }
-                    N(SyntaxKind.IdentifierToken, "M");
-                    N(SyntaxKind.ParameterList);
-                    {
-                        N(SyntaxKind.OpenParenToken);
-                        N(SyntaxKind.CloseParenToken);
-                    }
-                    N(SyntaxKind.Block);
-                    {
-                        N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.LocalFunctionStatement);
-                        {
-                            foreach (var expectedModifier in expectedModifiers)
-                            {
-                                N(expectedModifier);
-                            }
-
-                            N(SyntaxKind.PredefinedType);
-                            {
-                                N(SyntaxKind.VoidKeyword);
-                            }
-                            N(SyntaxKind.IdentifierToken, "Local");
-                            N(SyntaxKind.ParameterList);
-                            {
-                                N(SyntaxKind.OpenParenToken);
-                                N(SyntaxKind.CloseParenToken);
-                            }
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.CloseBraceToken);
-                    }
-                }
-                N(SyntaxKind.CloseBraceToken);
+                N(expectedModifier);
             }
-            N(SyntaxKind.EndOfFileToken);
+
+            N(SyntaxKind.PredefinedType);
+            {
+                N(SyntaxKind.VoidKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "Local");
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.SemicolonToken);
         }
         EOF();
     }
@@ -734,60 +697,23 @@ public sealed class SafeModifierParsingTests(ITestOutputHelper output) : Parsing
     [Fact]
     public void InvocationExpression()
     {
-        UsingTree("""
-            class C
-            {
-                void M()
-                {
-                    safe();
-                }
-            }
-            """);
+        UsingStatement("""safe();""");
 
-        N(SyntaxKind.CompilationUnit);
+        N(SyntaxKind.ExpressionStatement);
         {
-            N(SyntaxKind.ClassDeclaration);
+            N(SyntaxKind.InvocationExpression);
             {
-                N(SyntaxKind.ClassKeyword);
-                N(SyntaxKind.IdentifierToken, "C");
-                N(SyntaxKind.OpenBraceToken);
-                N(SyntaxKind.MethodDeclaration);
+                N(SyntaxKind.IdentifierName);
                 {
-                    N(SyntaxKind.PredefinedType);
-                    {
-                        N(SyntaxKind.VoidKeyword);
-                    }
-                    N(SyntaxKind.IdentifierToken, "M");
-                    N(SyntaxKind.ParameterList);
-                    {
-                        N(SyntaxKind.OpenParenToken);
-                        N(SyntaxKind.CloseParenToken);
-                    }
-                    N(SyntaxKind.Block);
-                    {
-                        N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.ExpressionStatement);
-                        {
-                            N(SyntaxKind.InvocationExpression);
-                            {
-                                N(SyntaxKind.IdentifierName);
-                                {
-                                    N(SyntaxKind.IdentifierToken, "safe");
-                                }
-                                N(SyntaxKind.ArgumentList);
-                                {
-                                    N(SyntaxKind.OpenParenToken);
-                                    N(SyntaxKind.CloseParenToken);
-                                }
-                            }
-                            N(SyntaxKind.SemicolonToken);
-                        }
-                        N(SyntaxKind.CloseBraceToken);
-                    }
+                    N(SyntaxKind.IdentifierToken, "safe");
                 }
-                N(SyntaxKind.CloseBraceToken);
+                N(SyntaxKind.ArgumentList);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.CloseParenToken);
+                }
             }
-            N(SyntaxKind.EndOfFileToken);
+            N(SyntaxKind.SemicolonToken);
         }
         EOF();
     }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/SafeModifierParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/SafeModifierParsingTests.cs
@@ -210,26 +210,63 @@ public sealed class SafeModifierParsingTests(ITestOutputHelper output) : Parsing
     [InlineData("static extern safe void Local();", SyntaxKind.StaticKeyword, SyntaxKind.ExternKeyword, SyntaxKind.SafeKeyword)]
     public void LocalFunction(string localFunction, params SyntaxKind[] expectedModifiers)
     {
-        UsingStatement(localFunction);
+        UsingTree($$"""
+            class C
+            {
+                void M()
+                {
+                    {{localFunction}}
+                }
+            }
+            """);
 
-        N(SyntaxKind.LocalFunctionStatement);
+        N(SyntaxKind.CompilationUnit);
         {
-            foreach (var expectedModifier in expectedModifiers)
+            N(SyntaxKind.ClassDeclaration);
             {
-                N(expectedModifier);
-            }
+                N(SyntaxKind.ClassKeyword);
+                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.MethodDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.VoidKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "M");
+                    N(SyntaxKind.ParameterList);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                    N(SyntaxKind.Block);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.LocalFunctionStatement);
+                        {
+                            foreach (var expectedModifier in expectedModifiers)
+                            {
+                                N(expectedModifier);
+                            }
 
-            N(SyntaxKind.PredefinedType);
-            {
-                N(SyntaxKind.VoidKeyword);
+                            N(SyntaxKind.PredefinedType);
+                            {
+                                N(SyntaxKind.VoidKeyword);
+                            }
+                            N(SyntaxKind.IdentifierToken, "Local");
+                            N(SyntaxKind.ParameterList);
+                            {
+                                N(SyntaxKind.OpenParenToken);
+                                N(SyntaxKind.CloseParenToken);
+                            }
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
             }
-            N(SyntaxKind.IdentifierToken, "Local");
-            N(SyntaxKind.ParameterList);
-            {
-                N(SyntaxKind.OpenParenToken);
-                N(SyntaxKind.CloseParenToken);
-            }
-            N(SyntaxKind.SemicolonToken);
+            N(SyntaxKind.EndOfFileToken);
         }
         EOF();
     }
@@ -697,23 +734,60 @@ public sealed class SafeModifierParsingTests(ITestOutputHelper output) : Parsing
     [Fact]
     public void InvocationExpression()
     {
-        UsingStatement("""safe();""");
-
-        N(SyntaxKind.ExpressionStatement);
-        {
-            N(SyntaxKind.InvocationExpression);
+        UsingTree("""
+            class C
             {
-                N(SyntaxKind.IdentifierName);
+                void M()
                 {
-                    N(SyntaxKind.IdentifierToken, "safe");
-                }
-                N(SyntaxKind.ArgumentList);
-                {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.CloseParenToken);
+                    safe();
                 }
             }
-            N(SyntaxKind.SemicolonToken);
+            """);
+
+        N(SyntaxKind.CompilationUnit);
+        {
+            N(SyntaxKind.ClassDeclaration);
+            {
+                N(SyntaxKind.ClassKeyword);
+                N(SyntaxKind.IdentifierToken, "C");
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.MethodDeclaration);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.VoidKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "M");
+                    N(SyntaxKind.ParameterList);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                    N(SyntaxKind.Block);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.ExpressionStatement);
+                        {
+                            N(SyntaxKind.InvocationExpression);
+                            {
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "safe");
+                                }
+                                N(SyntaxKind.ArgumentList);
+                                {
+                                    N(SyntaxKind.OpenParenToken);
+                                    N(SyntaxKind.CloseParenToken);
+                                }
+                            }
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+            N(SyntaxKind.EndOfFileToken);
         }
         EOF();
     }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/SafeModifierParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/SafeModifierParsingTests.cs
@@ -418,7 +418,14 @@ public sealed class SafeModifierParsingTests(ITestOutputHelper output) : Parsing
     [Fact]
     public void PropertyAccessor()
     {
-        UsingDeclaration("public int P { safe get; set; }");
+        const string source = "public int P { safe get; set; }";
+        UsingDeclaration(source);
+
+        CreateCompilation($"class C {{ {source} }}", parseOptions: TestOptions.Regular14).VerifyDiagnostics(
+            // (1,26): error CS9202: Feature 'updated memory safety rules' is not available in C# 14.0. Please use language version 'Preview' or greater.
+            // class C { public int P { safe get; set; } }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "safe").WithArguments("updated memory safety rules").WithLocation(1, 26));
+        CreateCompilation($"class C {{ {source} }}", parseOptions: TestOptions.RegularPreview).VerifyDiagnostics();
 
         N(SyntaxKind.PropertyDeclaration);
         {
@@ -449,13 +456,17 @@ public sealed class SafeModifierParsingTests(ITestOutputHelper output) : Parsing
     }
 
     [Theory]
-    [InlineData("public int P { private safe get; set; }", 0, SyntaxKind.PrivateKeyword, SyntaxKind.SafeKeyword)]
-    [InlineData("public int P { safe private get; set; }", 0, SyntaxKind.SafeKeyword, SyntaxKind.PrivateKeyword)]
-    [InlineData("public int P { get; private safe set; }", 1, SyntaxKind.PrivateKeyword, SyntaxKind.SafeKeyword)]
-    public void PropertyAccessor_WithOtherModifiers(string source, int accessorIndex, params SyntaxKind[] expectedModifiers)
+    [InlineData("public int P { private safe get; set; }", 34, 0, SyntaxKind.PrivateKeyword, SyntaxKind.SafeKeyword)]
+    [InlineData("public int P { safe private get; set; }", 26, 0, SyntaxKind.SafeKeyword, SyntaxKind.PrivateKeyword)]
+    [InlineData("public int P { get; private safe set; }", 39, 1, SyntaxKind.PrivateKeyword, SyntaxKind.SafeKeyword)]
+    public void PropertyAccessor_WithOtherModifiers(string source, int safeColumn, int accessorIndex, params SyntaxKind[] expectedModifiers)
     {
         var declaration = Assert.IsType<PropertyDeclarationSyntax>(SyntaxFactory.ParseMemberDeclaration(source));
         declaration.GetDiagnostics().Verify();
+
+        CreateCompilation($"class C {{ {source} }}", parseOptions: TestOptions.Regular14).VerifyDiagnostics(
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "safe").WithArguments("updated memory safety rules").WithLocation(1, safeColumn));
+        CreateCompilation($"class C {{ {source} }}", parseOptions: TestOptions.RegularPreview).VerifyDiagnostics();
 
         var modifiers = declaration.AccessorList!.Accessors[accessorIndex].Modifiers;
         Assert.Equal(expectedModifiers.Length, modifiers.Count);
@@ -469,7 +480,17 @@ public sealed class SafeModifierParsingTests(ITestOutputHelper output) : Parsing
     [Fact]
     public void EventAccessor()
     {
-        UsingDeclaration("public event EHandler E { safe add { } remove { } }");
+        const string source = "public event EHandler E { safe add { } remove { } }";
+        UsingDeclaration(source);
+
+        var expectedDiagnostics = new[]
+        {
+            // (1,63): error CS1609: Modifiers cannot be placed on event accessor declarations
+            // delegate void EHandler(); class C { public event EHandler E { safe add { } remove { } } }
+            Diagnostic(ErrorCode.ERR_NoModifiersOnAccessor, "safe").WithLocation(1, 63),
+        };
+        CreateCompilation($"delegate void EHandler(); class C {{ {source} }}", parseOptions: TestOptions.Regular14).VerifyDiagnostics(expectedDiagnostics);
+        CreateCompilation($"delegate void EHandler(); class C {{ {source} }}", parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(expectedDiagnostics);
 
         N(SyntaxKind.EventDeclaration);
         {

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/SafeModifierParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/SafeModifierParsingTests.cs
@@ -422,9 +422,14 @@ public sealed class SafeModifierParsingTests(ITestOutputHelper output) : Parsing
         UsingDeclaration(source);
 
         CreateCompilation($"class C {{ {source} }}", parseOptions: TestOptions.Regular14).VerifyDiagnostics(
-            // (1,26): error CS9202: Feature 'updated memory safety rules' is not available in C# 14.0. Please use language version 'Preview' or greater.
+            // (1,26): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
             // class C { public int P { safe get; set; } }
             Diagnostic(ErrorCode.ERR_FeatureInPreview, "safe").WithArguments("updated memory safety rules").WithLocation(1, 26));
+        CreateCompilation($"class C {{ {source} }}", parseOptions: TestOptions.Regular15).VerifyDiagnostics(
+            // (1,26): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            // class C { public int P { safe get; set; } }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "safe").WithArguments("updated memory safety rules").WithLocation(1, 26));
+        CreateCompilation($"class C {{ {source} }}", parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
         CreateCompilation($"class C {{ {source} }}", parseOptions: TestOptions.RegularPreview).VerifyDiagnostics();
 
         N(SyntaxKind.PropertyDeclaration);
@@ -456,17 +461,13 @@ public sealed class SafeModifierParsingTests(ITestOutputHelper output) : Parsing
     }
 
     [Theory]
-    [InlineData("public int P { private safe get; set; }", 34, 0, SyntaxKind.PrivateKeyword, SyntaxKind.SafeKeyword)]
-    [InlineData("public int P { safe private get; set; }", 26, 0, SyntaxKind.SafeKeyword, SyntaxKind.PrivateKeyword)]
-    [InlineData("public int P { get; private safe set; }", 39, 1, SyntaxKind.PrivateKeyword, SyntaxKind.SafeKeyword)]
-    public void PropertyAccessor_WithOtherModifiers(string source, int safeColumn, int accessorIndex, params SyntaxKind[] expectedModifiers)
+    [InlineData("public int P { private safe get; set; }", 0, SyntaxKind.PrivateKeyword, SyntaxKind.SafeKeyword)]
+    [InlineData("public int P { safe private get; set; }", 0, SyntaxKind.SafeKeyword, SyntaxKind.PrivateKeyword)]
+    [InlineData("public int P { get; private safe set; }", 1, SyntaxKind.PrivateKeyword, SyntaxKind.SafeKeyword)]
+    public void PropertyAccessor_WithOtherModifiers_ModifierOrder(string source, int accessorIndex, params SyntaxKind[] expectedModifiers)
     {
         var declaration = Assert.IsType<PropertyDeclarationSyntax>(SyntaxFactory.ParseMemberDeclaration(source));
         declaration.GetDiagnostics().Verify();
-
-        CreateCompilation($"class C {{ {source} }}", parseOptions: TestOptions.Regular14).VerifyDiagnostics(
-            Diagnostic(ErrorCode.ERR_FeatureInPreview, "safe").WithArguments("updated memory safety rules").WithLocation(1, safeColumn));
-        CreateCompilation($"class C {{ {source} }}", parseOptions: TestOptions.RegularPreview).VerifyDiagnostics();
 
         var modifiers = declaration.AccessorList!.Accessors[accessorIndex].Modifiers;
         Assert.Equal(expectedModifiers.Length, modifiers.Count);
@@ -478,19 +479,44 @@ public sealed class SafeModifierParsingTests(ITestOutputHelper output) : Parsing
     }
 
     [Fact]
+    public void PropertyAccessor_WithOtherModifiers()
+    {
+        const string source = "public int P { private safe get; set; }";
+
+        CreateCompilation($"class C {{ {source} }}", parseOptions: TestOptions.Regular14).VerifyDiagnostics(
+            // (1,34): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            // class C { public int P { private safe get; set; } }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "safe").WithArguments("updated memory safety rules").WithLocation(1, 34));
+        CreateCompilation($"class C {{ {source} }}", parseOptions: TestOptions.Regular15).VerifyDiagnostics(
+            // (1,34): error CS8652: The feature 'updated memory safety rules' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
+            // class C { public int P { private safe get; set; } }
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "safe").WithArguments("updated memory safety rules").WithLocation(1, 34));
+        CreateCompilation($"class C {{ {source} }}", parseOptions: TestOptions.RegularNext).VerifyDiagnostics();
+        CreateCompilation($"class C {{ {source} }}", parseOptions: TestOptions.RegularPreview).VerifyDiagnostics();
+    }
+
+    [Fact]
     public void EventAccessor()
     {
         const string source = "public event EHandler E { safe add { } remove { } }";
         UsingDeclaration(source);
 
-        var expectedDiagnostics = new[]
-        {
+        CreateCompilation($"delegate void EHandler(); class C {{ {source} }}", parseOptions: TestOptions.Regular14).VerifyDiagnostics(
             // (1,63): error CS1609: Modifiers cannot be placed on event accessor declarations
             // delegate void EHandler(); class C { public event EHandler E { safe add { } remove { } } }
-            Diagnostic(ErrorCode.ERR_NoModifiersOnAccessor, "safe").WithLocation(1, 63),
-        };
-        CreateCompilation($"delegate void EHandler(); class C {{ {source} }}", parseOptions: TestOptions.Regular14).VerifyDiagnostics(expectedDiagnostics);
-        CreateCompilation($"delegate void EHandler(); class C {{ {source} }}", parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(expectedDiagnostics);
+            Diagnostic(ErrorCode.ERR_NoModifiersOnAccessor, "safe").WithLocation(1, 63));
+        CreateCompilation($"delegate void EHandler(); class C {{ {source} }}", parseOptions: TestOptions.Regular15).VerifyDiagnostics(
+            // (1,63): error CS1609: Modifiers cannot be placed on event accessor declarations
+            // delegate void EHandler(); class C { public event EHandler E { safe add { } remove { } } }
+            Diagnostic(ErrorCode.ERR_NoModifiersOnAccessor, "safe").WithLocation(1, 63));
+        CreateCompilation($"delegate void EHandler(); class C {{ {source} }}", parseOptions: TestOptions.RegularNext).VerifyDiagnostics(
+            // (1,63): error CS1609: Modifiers cannot be placed on event accessor declarations
+            // delegate void EHandler(); class C { public event EHandler E { safe add { } remove { } } }
+            Diagnostic(ErrorCode.ERR_NoModifiersOnAccessor, "safe").WithLocation(1, 63));
+        CreateCompilation($"delegate void EHandler(); class C {{ {source} }}", parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (1,63): error CS1609: Modifiers cannot be placed on event accessor declarations
+            // delegate void EHandler(); class C { public event EHandler E { safe add { } remove { } } }
+            Diagnostic(ErrorCode.ERR_NoModifiersOnAccessor, "safe").WithLocation(1, 63));
 
         N(SyntaxKind.EventDeclaration);
         {


### PR DESCRIPTION
## Summary
- add exact syntax-tree baselines for accessor modifier parsing and recovery
- cover one accessibility keyword and every contextual modifier
- record older language versions, malformed accessors, attributes, following-member recovery, and non-get accessor kinds

## Test plan
- [x] Focused C# syntax tests (84 passed)