### PR TITLE
Use non-null initial state for null-resilient properties in constructors

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/LocalDataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/LocalDataFlowPass.cs
@@ -61,7 +61,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         protected abstract int AddVariable(VariableIdentifier identifier);
 
-        /// <summary>
+        /// <summary>Get the slot for a variable, if the slot already exists.</summary>
+        /// <remarks>
         /// Locals are given slots when their declarations are encountered.  We only need give slots
         /// to local variables, out parameters, and the "this" variable of a struct constructs.
         /// Other variables are not given slots, and are therefore not tracked by the analysis.  This
@@ -71,7 +72,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// variables that occur before the variable is declared, as those are reported in an
         /// earlier phase as "use before declaration". That allows us to avoid giving slots to local
         /// variables before processing their declarations.
-        /// </summary>
+        /// </remarks>
         protected int VariableSlot(Symbol symbol, int containingSlot = 0)
         {
             // Skip LocalStoreTracker from data flow analysis.

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -568,6 +568,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         protected override bool TryGetVariable(VariableIdentifier identifier, out int slot)
         {
+            // Only the owning symbol should be used to look up the slot.
+            Debug.Assert(GetOwningSymbolAndContainingSlot(identifier.Symbol, identifier.ContainingSlot) == ((object)identifier.Symbol, identifier.ContainingSlot));
             return _variables.TryGetValue(identifier, out slot);
         }
 
@@ -757,6 +759,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             void checkMemberStateOnConstructorExit(MethodSymbol constructor, Symbol member, LocalState state, int thisSlot, Location? exitLocation, ImmutableArray<string> membersWithStateEnforcedByRequiredMembers, bool forcePropertyAnalysis)
             {
+#if DEBUG
+                var discardedUseSiteInfo = CompoundUseSiteInfo<AssemblySymbol>.Discarded;
+                Debug.Assert(AccessCheck.IsSymbolAccessible(member, within: constructor.ContainingType, ref discardedUseSiteInfo));
+#endif
                 var isStatic = !constructor.RequiresInstanceReceiver();
                 if (member.IsStatic != isStatic)
                 {
@@ -855,6 +861,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         foreach (var member in getMembersNeedingDefaultInitialState())
                         {
+#if DEBUG
+                            var discardedUseSiteInfo = CompoundUseSiteInfo<AssemblySymbol>.Discarded;
+                            Debug.Assert(AccessCheck.IsSymbolAccessible(member, within: method.ContainingType, ref discardedUseSiteInfo));
+#endif
                             if (member.IsStatic != method.IsStatic)
                             {
                                 continue;
@@ -863,7 +873,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                             var memberToInitialize = member;
                             switch (member)
                             {
-                                case PropertySymbol { IsRequired: true }:
+                                case PropertySymbol { IsRequired: true } requiredProperty when GetAccessibleBackingField(requiredProperty, method.ContainingType) is null:
+                                    // Visit a required property, unless it has a backing field which is accessible in the current context,
+                                    // in which case we expect the field to be visited in another iteration of this loop.
                                     break;
                                 case PropertySymbol:
                                     // skip any manually implemented non-required properties.
@@ -967,19 +979,20 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                             (includeAllMembers: false, includeCurrentTypeRequiredMembers: true, includeBaseRequiredMembers: false)
                                 => containingType.GetMembersUnordered().SelectManyAsArray(
-                                    predicate: SymbolExtensions.IsRequired,
-                                    selector: symbol => getAllMembersToBeDefaulted(symbol, filterOverridingProperties: true)),
+                                    predicate: static (symbol, _) => symbol.IsRequired(),
+                                    selector: static (symbol, containingType) => getAllMembersToBeDefaulted(containingType, symbol, filterOverridingProperties: true),
+                                    containingType),
 
                             (includeAllMembers: false, includeCurrentTypeRequiredMembers: true, includeBaseRequiredMembers: true)
-                                => containingType.AllRequiredMembers.SelectManyAsArray(static kvp => getAllMembersToBeDefaulted(kvp.Value, filterOverridingProperties: true)),
+                                => containingType.AllRequiredMembers.SelectManyAsArray(static (kvp, containingType) => getAllMembersToBeDefaulted(containingType, kvp.Value, filterOverridingProperties: true), arg: containingType),
 
                             (includeAllMembers: true, includeCurrentTypeRequiredMembers: _, includeBaseRequiredMembers: false)
                                 => containingType.GetMembersUnordered().SelectManyAsArray(
-                                    selector: symbol =>
+                                    selector: static (symbol, containingType) =>
                                     {
-                                        var symbolToInitialize = getFieldSymbolToBeInitialized(symbol);
+                                        var symbolToInitialize = getFieldSymbolToBeInitialized(containingType, symbol);
                                         var prop = symbolToInitialize as PropertySymbol ?? (symbolToInitialize as FieldSymbol)?.AssociatedSymbol as PropertySymbol;
-                                        if (prop is not null && isFilterableOverrideOfAbstractProperty(prop))
+                                        if (prop is not null && isFilterableOverrideOfAbstractProperty(containingType, prop))
                                         {
                                             return OneOrMany<Symbol>.Empty;
                                         }
@@ -987,7 +1000,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                                         {
                                             return OneOrMany.Create(symbolToInitialize);
                                         }
-                                    }),
+                                    },
+                                    arg: containingType),
 
                             (includeAllMembers: true, includeCurrentTypeRequiredMembers: true, includeBaseRequiredMembers: true)
                                 => getAllTypeAndRequiredMembers(containingType),
@@ -996,7 +1010,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 => throw ExceptionUtilities.Unreachable(),
                         };
 
-                        static ImmutableArray<Symbol> getAllTypeAndRequiredMembers(TypeSymbol containingType)
+                        static ImmutableArray<Symbol> getAllTypeAndRequiredMembers(NamedTypeSymbol containingType)
                         {
                             var members = containingType.GetMembersUnordered();
                             var baseRequiredMembers = containingType.BaseTypeNoUseSiteDiagnostics?.AllRequiredMembers ?? ImmutableSegmentedDictionary<string, Symbol>.Empty;
@@ -1018,19 +1032,19 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 if (requiredMember is PropertySymbol { IsAbstract: true } abstractProperty)
                                 {
                                     if (members.FirstOrDefault(static (thisMember, baseMember) => thisMember.IsOverride && (object)thisMember.GetOverriddenMember() == baseMember, requiredMember) is { } overridingMember
-                                        && isFilterableOverrideOfAbstractProperty((PropertySymbol)overridingMember))
+                                        && isFilterableOverrideOfAbstractProperty(containingType, (PropertySymbol)overridingMember))
                                     {
                                         continue;
                                     }
                                 }
 
-                                builder.AddRange(getAllMembersToBeDefaulted(requiredMember, filterOverridingProperties: false));
+                                builder.AddRange(getAllMembersToBeDefaulted(containingType, requiredMember, filterOverridingProperties: false));
                             }
 
                             return builder.ToImmutableAndFree();
                         }
 
-                        static OneOrMany<Symbol> getAllMembersToBeDefaulted(Symbol requiredMember, bool filterOverridingProperties)
+                        static OneOrMany<Symbol> getAllMembersToBeDefaulted(NamedTypeSymbol containingType, Symbol requiredMember, bool filterOverridingProperties)
                         {
                             Debug.Assert(requiredMember.IsRequired());
 
@@ -1042,19 +1056,23 @@ namespace Microsoft.CodeAnalysis.CSharp
                             {
                                 var property = (PropertySymbol)requiredMember;
 
-                                if (filterOverridingProperties && isFilterableOverrideOfAbstractProperty(property))
+                                if (filterOverridingProperties && isFilterableOverrideOfAbstractProperty(containingType, property))
                                 {
                                     return OneOrMany<Symbol>.Empty;
                                 }
 
-                                var @return = OneOrMany.Create(getFieldSymbolToBeInitialized(property));
+                                var @return = OneOrMany.Create(getFieldSymbolToBeInitialized(containingType, property));
 
                                 // If the set method is null (ie missing), that's an error, but we'll recover as best we can
+                                var discardedUseSiteInfo = CompoundUseSiteInfo<AssemblySymbol>.Discarded;
                                 foreach (var notNullMemberName in (property.SetMethod?.NotNullMembers ?? property.NotNullMembers))
                                 {
                                     foreach (var member in property.ContainingType.GetMembers(notNullMemberName))
                                     {
-                                        @return = @return.Add(getFieldSymbolToBeInitialized(member));
+                                        if (AccessCheck.IsSymbolAccessible(member, containingType, ref discardedUseSiteInfo))
+                                        {
+                                            @return = @return.Add(getFieldSymbolToBeInitialized(containingType, member));
+                                        }
                                     }
                                 }
 
@@ -1062,10 +1080,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                             }
                         }
 
-                        static Symbol getFieldSymbolToBeInitialized(Symbol requiredMember)
-                            => requiredMember is SourcePropertySymbolBase { BackingField: { } backingField } ? backingField : requiredMember;
+                        static Symbol getFieldSymbolToBeInitialized(NamedTypeSymbol containingType, Symbol requiredMember)
+                            => requiredMember is PropertySymbol property && GetAccessibleBackingField(property, containingType) is { } backingField ? backingField : requiredMember;
 
-                        static bool isFilterableOverrideOfAbstractProperty(PropertySymbol property)
+                        static bool isFilterableOverrideOfAbstractProperty(NamedTypeSymbol containingType, PropertySymbol property)
                         {
                             // If this is an override of an abstract property, and the overridden property has the same nullable
                             // annotation as us, we can skip default-initializing the property because the chained constructor
@@ -1075,8 +1093,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 return false;
                             }
 
-                            var symbolAnnotations = property is SourcePropertySymbolBase { UsesFieldKeyword: true, BackingField: { } field }
-                                ? field!.FlowAnalysisAnnotations
+                            var symbolAnnotations = GetAccessibleBackingField(property, containingType) is { } field
+                                ? field.FlowAnalysisAnnotations
                                 : property.GetFlowAnalysisAnnotations();
                             var symbolType = ApplyUnconditionalAnnotations(property.TypeWithAnnotations, symbolAnnotations);
                             if (!symbolType.NullableAnnotation.IsNotAnnotated())
@@ -1091,6 +1109,25 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// A property's backing field should only influence behavior of nullable analysis when the field is accessible.
+        /// For example, when the member being analyzed has the same containing type as the property.
+        ///
+        /// Note: this refers to accessibility only in the "accessibility modifier" sense.
+        /// This method may return a non-null symbol even if the field cannot be referenced by name in the current context.
+        /// <param name="containingType">Containing type of the member currently being analyzed.</param>
+        /// </summary>
+        private static SynthesizedBackingFieldSymbol? GetAccessibleBackingField(PropertySymbol property, NamedTypeSymbol containingType)
+        {
+            if (property is not SourcePropertySymbolBase { BackingField: { } backingField })
+                return null;
+
+            var discardedUseSiteInfo = CompoundUseSiteInfo<AssemblySymbol>.Discarded;
+            return AccessCheck.IsSymbolAccessible(backingField, within: containingType, ref discardedUseSiteInfo)
+                ? backingField
+                : null;
         }
 
         private void EnforceMemberNotNullOnMember(SyntaxNode? syntaxOpt, LocalState state, MethodSymbol method, string memberName)
@@ -2267,6 +2304,16 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (containingSlot > 0 && !IsSlotMember(containingSlot, symbol))
                 return -1;
 
+            (symbol, containingSlot) = GetOwningSymbolAndContainingSlot(symbol, containingSlot);
+            return base.GetOrCreateSlot(symbol, containingSlot, forceSlotEvenIfEmpty, createIfMissing);
+        }
+
+        /// <summary>
+        /// If the incoming symbol+containingSlot pair shares a slot,
+        /// returns the owning pair. Otherwise returns the arguments.
+        /// </summary>
+        private (Symbol symbol, int containingSlot) GetOwningSymbolAndContainingSlot(Symbol symbol, int containingSlot)
+        {
             // Primary constructor parameter and its backing field share the slot when
             // we are dealing with 'this' instance.
             if (symbol is ParameterSymbol { ContainingSymbol: SynthesizedPrimaryConstructor primaryConstructor } parameter &&
@@ -2291,6 +2338,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // Share a slot between backing field and associated property/event in the context of a constructor which owns initialization of that backing field.
+            // https://github.com/dotnet/roslyn/issues/84987: extend this sharing to more methods where the backing field is accessible
             if (this._symbol is MethodSymbol constructor
                 && constructor.IsConstructor()
                 && constructor.IsStatic == symbol.IsStatic)
@@ -2304,17 +2352,25 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // - property initializer on normal auto-property
                     // - property assignment on getter-only auto-property.
                     // Example test: NullableReferenceTypesTests.ConstructorUsesStateFromInitializers will fail without this.
-                    if (symbol is SynthesizedBackingFieldSymbol { AssociatedSymbol: SourcePropertySymbolBase { UsesFieldKeyword: false } property })
-                        symbol = property;
-                    // If symbol is a property that uses field keyword, then use field to determine initial state and to own the slot.
-                    else if (symbol is SourcePropertySymbolBase { UsesFieldKeyword: true, BackingField: { } backingField })
-                        symbol = backingField;
+                    if (symbol is SynthesizedBackingFieldSymbol { AssociatedProperty.UsesFieldKeyword: false } backingField)
+                    {
+                        symbol = backingField.AssociatedProperty;
+                    }
+                    // If symbol is a property that uses field keyword, and property is not null-resilient, then use field to determine initial state and to own the slot.
+                    else if (symbol is SourcePropertySymbolBase { UsesFieldKeyword: true } property
+                        && GetAccessibleBackingField(property, constructor.ContainingType) is { } accessibleBackingField
+                        && !IsAssociatedPropertyNullResilient(accessibleBackingField))
+                    {
+                        symbol = accessibleBackingField;
+                    }
                     else if (symbol is SourceEventFieldSymbol eventField)
+                    {
                         symbol = eventField.AssociatedSymbol;
+                    }
                 }
             }
 
-            return base.GetOrCreateSlot(symbol, containingSlot, forceSlotEvenIfEmpty, createIfMissing);
+            return (symbol, containingSlot);
         }
 
         private void VisitAndUnsplitAll<T>(ImmutableArray<T> nodes) where T : BoundNode
@@ -11289,6 +11345,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             return null;
+        }
+
+        private bool IsAssociatedPropertyNullResilient(SynthesizedBackingFieldSymbol backingField)
+        {
+            // Only possible to answer this question if a null resilience inference is not currently in progress.
+            Debug.Assert(_getterNullResilienceData is null);
+            return backingField.InfersNullableAnnotation && backingField.GetInferredNullableAnnotation() == NullableAnnotation.Annotated;
         }
 
         private bool IsPropertyOutputMoreStrictThanInput(PropertySymbol property)

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -1117,8 +1117,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         ///
         /// Note: this refers to accessibility only in the "accessibility modifier" sense.
         /// This method may return a non-null symbol even if the field cannot be referenced by name in the current context.
-        /// <param name="containingType">Containing type of the member currently being analyzed.</param>
         /// </summary>
+        /// <param name="containingType">Containing type of the member currently being analyzed.</param>
         private static SynthesizedBackingFieldSymbol? GetAccessibleBackingField(PropertySymbol property, NamedTypeSymbol containingType)
         {
             if (property is not SourcePropertySymbolBase { BackingField: { } backingField })

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedBackingFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedBackingFieldSymbol.cs
@@ -116,6 +116,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public override Symbol AssociatedSymbol
             => _property;
 
+        internal SourcePropertySymbolBase AssociatedProperty
+            => _property;
+
         public override ImmutableArray<Location> Locations
             => _property.Locations;
 

--- a/src/Compilers/CSharp/Test/Emit3/FieldKeywordTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/FieldKeywordTests.cs
@@ -11444,8 +11444,6 @@ class C<T>
         [InlineData("#pragma warning disable 8603 // Possible null reference return.")]
         public void Nullable_Resilient_ChainedConstructor_01(string directive)
         {
-            // Since the backing field is nullable, a chained constructor isn't expected to put it into non-null state.
-            // The property has maybe-null state in "caller" constructor since it shares a slot with the field.
             var source = $$"""
                 #nullable enable
 
@@ -11454,7 +11452,7 @@ class C<T>
                     public C(bool ignored) { Prop = "a"; }
                     public C() : this(false)
                     {
-                        Prop.ToString(); // 1
+                        Prop.ToString();
                     }
 
                     public string Prop
@@ -11466,10 +11464,7 @@ class C<T>
                 """;
 
             var comp = CreateCompilation(source);
-            comp.VerifyEmitDiagnostics(
-                // (8,9): warning CS8602: Dereference of a possibly null reference.
-                //         Prop.ToString(); // 1
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "Prop").WithLocation(8, 9));
+            comp.VerifyEmitDiagnostics();
 
             var prop = comp.GetMember<SourcePropertySymbol>("C.Prop");
             Assert.Equal(NullableAnnotation.Annotated, prop.BackingField.GetInferredNullableAnnotation());
@@ -11487,7 +11482,7 @@ class C<T>
                     public C(bool ignored) { Prop = "a"; }
                     public C() : this(false)
                     {
-                        Prop.ToString(); // 1
+                        Prop.ToString();
                     }
 
                     public string Prop
@@ -11498,10 +11493,7 @@ class C<T>
                 """;
 
             var comp = CreateCompilation(source);
-            comp.VerifyEmitDiagnostics(
-                // (8,9): warning CS8602: Dereference of a possibly null reference.
-                //         Prop.ToString(); // 1
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "Prop").WithLocation(8, 9));
+            comp.VerifyEmitDiagnostics();
 
             var prop = comp.GetMember<SourcePropertySymbol>("C.Prop");
             Assert.Equal(NullableAnnotation.Annotated, prop.BackingField.GetInferredNullableAnnotation());
@@ -12351,10 +12343,12 @@ class C<T>
                 Diagnostic(ErrorCode.ERR_AssgReadonlyProp, "Value1").WithArguments("S.Value1").WithLocation(23, 16));
         }
 
-        [Fact]
-        public void Nullable_Accessor_FieldStateAffectedByAssigningThis()
+        [Theory]
+        [InlineData("field")]
+        [InlineData(@"field ?? ""a""")]
+        public void Nullable_Accessor_FieldStateAffectedByAssigningThis(string getterReturnValue)
         {
-            var source = """
+            var source = $$"""
                 #nullable enable
 
                 public struct S
@@ -12366,7 +12360,7 @@ class C<T>
                             field = "a";
                             this = default;
                             field.ToString(); // 1
-                            return field;
+                            return {{getterReturnValue}};
                         }
                         set
                         {
@@ -12387,23 +12381,25 @@ class C<T>
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "field").WithLocation(18, 13));
         }
 
-        [Fact]
-        public void Nullable_Constructor_FieldStateAffectedByAssigningThis()
+        [Theory]
+        [InlineData("field")]
+        [InlineData(@"field ?? ""a""")]
+        public void Nullable_Constructor_FieldStateAffectedByAssigningThis(string getterReturnValue)
         {
-            var source = """
+            var source = $$"""
                 #nullable enable
 
                 public struct S
                 {
                     public string Prop
                     {
-                        get => field;
+                        get => {{getterReturnValue}};
                         set => field = value;
                     }
 
                     public static string StaticProp
                     {
-                        get => field;
+                        get => {{getterReturnValue}};
                         set => field = value;
                     } = "b";
 
@@ -12422,13 +12418,20 @@ class C<T>
                 }
                 """;
             var comp = CreateCompilation(source);
-            comp.VerifyEmitDiagnostics(
-                // (26,9): warning CS8602: Dereference of a possibly null reference.
-                //         Prop.ToString(); // 1
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "Prop").WithLocation(26, 9));
+            if (getterReturnValue == "field")
+            {
+                comp.VerifyEmitDiagnostics(
+                    // (26,9): warning CS8602: Dereference of a possibly null reference.
+                    //         Prop.ToString(); // 1
+                    Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "Prop").WithLocation(26, 9));
+            }
+            else
+            {
+                comp.VerifyEmitDiagnostics();
+            }
         }
 
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/77991")]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/84987")]
         public void Nullable_OrdinaryMethod_FieldStateAffectedByAssigningStruct()
         {
             var source = """
@@ -12447,12 +12450,16 @@ class C<T>
                         get => field;
                         set => field = value;
                     } = "b";
-                    
+
                     public void M(S s)
                     {
                         s.Prop.ToString();
                         StaticProp.ToString();
 
+                        s.Prop = null; // 1
+                        s.Prop.ToString(); // 2
+
+                        s.Prop = null; // 3
                         s = default;
                         s.Prop.ToString(); // expected warning is missing
                         StaticProp.ToString();
@@ -12460,10 +12467,19 @@ class C<T>
                 }
                 """;
             var comp = CreateCompilation(source);
-            comp.VerifyEmitDiagnostics();
+            comp.VerifyEmitDiagnostics(
+                // (22,18): warning CS8625: Cannot convert null literal to non-nullable reference type.
+                //         s.Prop = null; // 1
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(22, 18),
+                // (23,9): warning CS8602: Dereference of a possibly null reference.
+                //         s.Prop.ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "s.Prop").WithLocation(23, 9),
+                // (25,18): warning CS8625: Cannot convert null literal to non-nullable reference type.
+                //         s.Prop = null; // 3
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(25, 18));
         }
 
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/77991")]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/84987")]
         public void Nullable_Accessor_OtherPropStateAffectedByAssigningStruct()
         {
             var source = """
@@ -12500,7 +12516,7 @@ class C<T>
             comp.VerifyEmitDiagnostics();
         }
 
-        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/77991")]
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/84987")]
         public void Nullable_PropInitializer_PropStateAffectedByAssigningStruct()
         {
             var source = """
@@ -12549,27 +12565,27 @@ class C<T>
                 {
                     public S()
                     {
-                        Resilient.ToString(); // 3
+                        Resilient.ToString();
                         NonResilient.ToString(); // 4
                     }
 
                     public S(bool ignored) : this()
                     {
-                        Resilient.ToString(); // 5
+                        Resilient.ToString();
                         NonResilient.ToString();
                     }
 
                     public S((bool, bool) ignored2)
                     {
                         this = new();
-                        Resilient.ToString(); // 6
+                        Resilient.ToString();
                         NonResilient.ToString();
                     }
 
                     public S((bool, bool, bool) ignored3)
                     {
                         this = default;
-                        Resilient.ToString(); // 7
+                        Resilient.ToString();
                         NonResilient.ToString(); // 8
                     }
 
@@ -12591,21 +12607,9 @@ class C<T>
                 // (6,5): error CS0200: Property or indexer 'S.NonResilient' cannot be assigned to -- it is read only
                 //     NonResilient = "b" // 2
                 Diagnostic(ErrorCode.ERR_AssgReadonlyProp, "NonResilient").WithArguments("S.NonResilient").WithLocation(6, 5),
-                // (13,9): warning CS8602: Dereference of a possibly null reference.
-                //         Resilient.ToString(); // 3
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "Resilient").WithLocation(13, 9),
                 // (14,9): warning CS8602: Dereference of a possibly null reference.
                 //         NonResilient.ToString(); // 4
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "NonResilient").WithLocation(14, 9),
-                // (19,9): warning CS8602: Dereference of a possibly null reference.
-                //         Resilient.ToString(); // 5
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "Resilient").WithLocation(19, 9),
-                // (26,9): warning CS8602: Dereference of a possibly null reference.
-                //         Resilient.ToString(); // 6
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "Resilient").WithLocation(26, 9),
-                // (33,9): warning CS8602: Dereference of a possibly null reference.
-                //         Resilient.ToString(); // 7
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "Resilient").WithLocation(33, 9),
                 // (34,9): warning CS8602: Dereference of a possibly null reference.
                 //         NonResilient.ToString(); // 8
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "NonResilient").WithLocation(34, 9));
@@ -12729,39 +12733,612 @@ class C<T>
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/77991")]
-        public void Nullable_Resilient_InitialStateInConstructor()
+        public void Nullable_Resilient_InitialStateInConstructor_01()
         {
             var source = """
                 #nullable enable
 
+                // empty marker types to allow distinct constructor signatures
+                public class D1;
+                public class D2;
+                public class D3;
+                public class D4;
+                public class D5;
+                public class D6;
+
                 public class C
                 {
-                    public string Prop => field ??= "a";
+                    public string Prop1 => field ??= "a";
+                    public string Prop2 => field;
 
                     public C(bool ignored)
                     {
-                        Prop.ToString(); // unexpected warning
+                        Prop1.ToString();
+                        Prop2.ToString(); // 1
                     }
 
                     public C() : this(false)
                     {
-                        Prop.ToString(); // unexpected warning
+                        Prop1.ToString();
+                        Prop2.ToString();
+                    }
+
+                    public C(D1 d1) // 2
+                    {
+                    }
+
+                    public C(D2 d2) : this(false)
+                    {
+                    }
+
+                    public C(D3 d3) // 3
+                    {
+                        Prop1 = null;
+                        Prop2 = null; // 4
+                    }
+
+                    public C(D4 d4) : this(false) // 5
+                    {
+                        Prop1 = null;
+                        Prop2 = null; // 6
+                    }
+
+                    public C(D5 d5)
+                    {
+                        Prop1 = "a";
+                        Prop2 = "a";
+                    }
+
+                    public C(D6 d6) : this(false)
+                    {
+                        Prop1 = "a";
+                        Prop2 = "a";
                     }
 
                     public void M()
                     {
+                        Prop1.ToString();
+                        Prop2.ToString();
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (19,9): warning CS8602: Dereference of a possibly null reference.
+                //         Prop2.ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "Prop2").WithLocation(19, 9),
+                // (28,12): warning CS9264: Non-nullable property 'Prop2' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier, or declaring the property as nullable, or safely handling the case where 'field' is null in the 'get' accessor.
+                //     public C(D1 d1) // 2
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableBackingField, "C").WithArguments("property", "Prop2").WithLocation(28, 12),
+                // (36,12): warning CS9264: Non-nullable property 'Prop2' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier, or declaring the property as nullable, or safely handling the case where 'field' is null in the 'get' accessor.
+                //     public C(D3 d3) // 3
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableBackingField, "C").WithArguments("property", "Prop2").WithLocation(36, 12),
+                // (39,17): warning CS8625: Cannot convert null literal to non-nullable reference type.
+                //         Prop2 = null; // 4
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(39, 17),
+                // (42,12): warning CS9264: Non-nullable property 'Prop2' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier, or declaring the property as nullable, or safely handling the case where 'field' is null in the 'get' accessor.
+                //     public C(D4 d4) : this(false) // 5
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableBackingField, "C").WithArguments("property", "Prop2").WithLocation(42, 12),
+                // (45,17): warning CS8625: Cannot convert null literal to non-nullable reference type.
+                //         Prop2 = null; // 6
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(45, 17));
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/77991")]
+        public void Nullable_Resilient_InitialStateInConstructor_02()
+        {
+            // Test behaviors of AllowNull attribute on various null-resilient properties.
+            var source = """
+                #nullable enable
+                using System.Diagnostics.CodeAnalysis;
+
+                // empty marker types to allow distinct constructor signatures
+                public class D1;
+                public class D2;
+                public class D3;
+                public class D4;
+                public class D5;
+                public class D6;
+
+                public class C
+                {
+                    [AllowNull]
+                    public string Prop1 => field ??= "a";
+
+                    public string Prop2 { get => field ??= "a"; set; }
+
+                    [AllowNull]
+                    public string Prop3 { get => field ??= "a"; set; }
+
+                    public C(bool ignored)
+                    {
+                        Prop1.ToString();
+                        Prop2.ToString();
+                        Prop3.ToString();
+                    }
+
+                    public C() : this(false)
+                    {
+                        Prop1.ToString();
+                        Prop2.ToString();
+                        Prop3.ToString();
+                    }
+
+                    public C(D1 d1)
+                    {
+                    }
+
+                    public C(D2 d2) : this(false)
+                    {
+                    }
+
+                    public C(D3 d3)
+                    {
+                        Prop1 = null;
+                        Prop2 = null; // 1
+                        Prop3 = null;
+                    }
+
+                    public C(D4 d4) : this(false)
+                    {
+                        Prop1 = null;
+                        Prop2 = null; // 2
+                        Prop3 = null;
+                    }
+
+                    public C(D5 d5)
+                    {
+                        Prop1 = "a";
+                        Prop2 = "a";
+                        Prop3 = "a";
+                    }
+
+                    public C(D6 d6) : this(false)
+                    {
+                        Prop1 = "a";
+                        Prop2 = "a";
+                        Prop3 = "a";
+                    }
+
+                    public void M()
+                    {
+                        Prop1.ToString();
+                    }
+                }
+                """;
+            var comp = CreateCompilation([source, AllowNullAttributeDefinition]);
+            comp.VerifyEmitDiagnostics(
+                // (47,17): warning CS8625: Cannot convert null literal to non-nullable reference type.
+                //         Prop2 = null; // 1
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(47, 17),
+                // (54,17): warning CS8625: Cannot convert null literal to non-nullable reference type.
+                //         Prop2 = null; // 2
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(54, 17));
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/77991")]
+        public void Nullable_Resilient_InitialStateInConstructor_03()
+        {
+            // Test behaviors of MaybeNull attribute on a null-resilient property
+            var source = """
+                #nullable enable
+                using System.Diagnostics.CodeAnalysis;
+
+                // empty marker types to allow distinct constructor signatures
+                public class D1;
+                public class D2;
+                public class D3;
+                public class D4;
+                public class D5;
+                public class D6;
+
+                public class C
+                {
+                    [MaybeNull]
+                    public string Prop1 => field ??= "a";
+
+                    public C(bool ignored)
+                    {
+                        Prop1.ToString(); // 1
+                    }
+
+                    public C() : this(false)
+                    {
+                        Prop1.ToString(); // 2
+                    }
+
+                    public C(D1 d1)
+                    {
+                    }
+
+                    public C(D2 d2) : this(false)
+                    {
+                    }
+
+                    public C(D3 d3)
+                    {
+                        Prop1 = null;
+                    }
+
+                    public C(D4 d4) : this(false)
+                    {
+                        Prop1 = null;
+                    }
+
+                    public C(D5 d5)
+                    {
+                        Prop1 = "a";
+                    }
+
+                    public C(D6 d6) : this(false)
+                    {
+                        Prop1 = "a";
+                    }
+
+                    public void M()
+                    {
+                        Prop1.ToString(); // 3
+                    }
+                }
+                """;
+            var comp = CreateCompilation([source, MaybeNullAttributeDefinition]);
+            comp.VerifyEmitDiagnostics(
+                // (19,9): warning CS8602: Dereference of a possibly null reference.
+                //         Prop1.ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "Prop1").WithLocation(19, 9),
+                // (24,9): warning CS8602: Dereference of a possibly null reference.
+                //         Prop1.ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "Prop1").WithLocation(24, 9),
+                // (57,9): warning CS8602: Dereference of a possibly null reference.
+                //         Prop1.ToString(); // 3
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "Prop1").WithLocation(57, 9));
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/77991")]
+        public void Nullable_Resilient_InitialStateInConstructor_04()
+        {
+            // Test behaviors of a required null-resilient property
+            var source = """
+                #nullable enable
+
+                // empty marker types to allow distinct constructor signatures
+                public class D1;
+                public class D2;
+                public class D3;
+                public class D4;
+
+                public class C
+                {
+                    public required string Prop1 { get => field ??= "a"; set; }
+
+                    public C(bool ignored)
+                    {
+                        Prop1.ToString();
+                    }
+
+                    public C() : this(false)
+                    {
+                        Prop1.ToString();
+                    }
+
+                    public C(D1 d)
+                    {
+                    }
+
+                    public C(D2 d) : this(false)
+                    {
+                    }
+
+                    public C(D3 d)
+                    {
+                        Prop1 = "a";
+                    }
+
+                    public C(D4 d) : this(false)
+                    {
+                        Prop1 = "a";
+                    }
+
+                    public void M()
+                    {
+                        Prop1.ToString();
+                    }
+                }
+                """;
+            var comp = CreateCompilation([source, RequiredMemberAttribute, CompilerFeatureRequiredAttribute, SetsRequiredMembersAttribute]);
+            comp.VerifyEmitDiagnostics();
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/77991")]
+        public void Nullable_Resilient_InitialStateInConstructor_05()
+        {
+            // Test behaviors of a required null-resilient property with SetsRequiredMembers on constructors
+            var source = """
+                #nullable enable
+                using System.Diagnostics.CodeAnalysis;
+
+                // empty marker types to allow distinct constructor signatures
+                public class D1;
+                public class D2;
+                public class D3;
+                public class D4;
+                public class D5;
+                public class D6;
+                public class D7;
+                public class D8;
+
+                public class C
+                {
+                    public required string Prop1 { get => field ??= "a"; set; }
+
+                    [SetsRequiredMembers]
+                    public C(bool ignored)
+                    {
+                        Prop1.ToString();
+                    }
+
+                    public C(int ignored)
+                    {
+                        Prop1.ToString();
+                    }
+
+                    [SetsRequiredMembers]
+                    public C(D1 d) : this(false)
+                    {
+                        Prop1.ToString();
+                    }
+
+                    [SetsRequiredMembers]
+                    public C(D2 d) : this(0)
+                    {
+                        Prop1.ToString();
+                    }
+
+                    [SetsRequiredMembers]
+                    public C(D3 d)
+                    {
+                    }
+
+                    [SetsRequiredMembers]
+                    public C(D4 d) : this(false)
+                    {
+                    }
+
+                    [SetsRequiredMembers]
+                    public C(D5 d) : this(0)
+                    {
+                    }
+
+                    [SetsRequiredMembers]
+                    public C(D6 d)
+                    {
+                        Prop1 = "a";
+                    }
+
+                    [SetsRequiredMembers]
+                    public C(D7 d) : this(false)
+                    {
+                        Prop1 = "a";
+                    }
+
+                    [SetsRequiredMembers]
+                    public C(D8 d) : this(0)
+                    {
+                        Prop1 = "a";
+                    }
+
+                    public void M()
+                    {
+                        Prop1.ToString();
+                    }
+                }
+                """;
+            var comp = CreateCompilation([source, RequiredMemberAttribute, CompilerFeatureRequiredAttribute, SetsRequiredMembersAttribute]);
+            comp.VerifyEmitDiagnostics();
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/84957")]
+        public void Repro_84957()
+        {
+            var source = """
+                #nullable enable
+                internal class Goo {
+                    private Bar? _bang1;
+
+                    public Goo() {
+                        Wiz1 = Bang1;
+                        Wiz2 = Bang2;
+                        Wiz3 = Bang3;
+                        Wiz4 = Bang4;
+                        Wiz5 = Bang5;
+                    }
+
+                    public Bar Wiz1 { get; set; }
+                    public Bar Wiz2 { get; set; }
+                    public Bar Wiz3 { get; set; }
+                    public Bar Wiz4 { get; set; }
+                    public Bar Wiz5 { get; set; }
+
+                    public Bar Bang1 => _bang1 ??= new Bar();
+
+                    public Bar Bang2 => field ??= new Bar();
+
+                    public Bar Bang3 => (field ??= new Bar())!;
+
+                    public Bar Bang4 {
+                        get {
+                            field ??= new Bar();
+                            return field;
+                        }
+                    }
+
+                    public Bar Bang5 {
+                        get {
+                            field = new Bar();
+                            return field;
+                        }
+                    }
+                }
+
+                public class Bar { };
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics();
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/84987")]
+        public void Nullable_InheritedState_01()
+        {
+            var source = """
+                #nullable enable
+                struct S
+                {
+                    public string Prop { get => field; set; }
+                    public void M()
+                    {
+                        this = default;
+                        this.Prop.ToString(); // expected warning missing
+                    }
+
+                    public S()
+                    {
+                        this = default;
+                        Prop.ToString(); // 1
+                    }
+
+                    public S(bool ignored1)
+                    {
+                        S s1 = default;
+                        this = s1;
+                        Prop.ToString(); // 2
+                    }
+
+                    public S((bool, bool) ignored2)
+                    {
+                        S s1 = default;
+                        s1.Prop = "a";
+                        this = s1;
                         Prop.ToString();
                     }
                 }
                 """;
             var comp = CreateCompilation(source);
             comp.VerifyEmitDiagnostics(
-                // (9,9): warning CS8602: Dereference of a possibly null reference.
-                //         Prop.ToString(); // unexpected warning
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "Prop").WithLocation(9, 9),
                 // (14,9): warning CS8602: Dereference of a possibly null reference.
-                //         Prop.ToString(); // unexpected warning
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "Prop").WithLocation(14, 9));
+                //         Prop.ToString(); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "Prop").WithLocation(14, 9),
+                // (21,9): warning CS8602: Dereference of a possibly null reference.
+                //         Prop.ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "Prop").WithLocation(21, 9));
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/84987")]
+        public void Nullable_InheritedState_02()
+        {
+            // Slot is only shared between property and backing field of 'this' variable
+            var source = """
+                #nullable enable
+                struct S()
+                {
+                    public string Prop { get => field; set; } = "a";
+
+                    public class Inner
+                    {
+                        void M(S s)
+                        {
+                            s.Prop.ToString();
+                            s = default;
+                            s.Prop.ToString(); // expected warning missing
+                        }
+
+                        public Inner(S s)
+                        {
+                            s.Prop.ToString();
+                            s = default;
+                            s.Prop.ToString(); // expected warning missing
+                        }
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics();
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/84987")]
+        public void Nullable_InheritedState_03()
+        {
+            var source = """
+                #nullable enable
+                struct S<T>
+                {
+                    public T Prop { get => field; set; } = default!;
+                    public static void Use(T t) { }
+
+                    void M()
+                    {
+                        Use(this.Prop);
+                        this = default;
+                        Use(this.Prop); // expected warning missing
+                        Use(default(T)); // 1
+                    }
+
+                    public S()
+                    {
+                        Use(this.Prop);
+                        this = default;
+                        Use(default(T)); // 2
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (12,13): warning CS8604: Possible null reference argument for parameter 't' in 'void S<T>.Use(T t)'.
+                //         Use(default(T)); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "default(T)").WithArguments("t", "void S<T>.Use(T t)").WithLocation(12, 13),
+                // (19,13): warning CS8604: Possible null reference argument for parameter 't' in 'void S<T>.Use(T t)'.
+                //         Use(default(T)); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "default(T)").WithArguments("t", "void S<T>.Use(T t)").WithLocation(19, 13));
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/84987")]
+        public void Nullable_InheritedState_04()
+        {
+            var source = """
+                #nullable enable
+                struct S<T>()
+                {
+                    public T Prop { get => field; set; } = default!;
+
+                    public class Inner
+                    {
+                        public static void Use(T t) { }
+
+                        void M(S<T> s)
+                        {
+                            Use(s.Prop);
+                            s = default;
+                            Use(s.Prop); // expected warning missing
+                            Use(default(T)); // 1
+                        }
+
+                        public Inner(S<T> s)
+                        {
+                            Use(s.Prop);
+                            s = default;
+                            Use(s.Prop); // expected warning missing
+                            Use(default(T)); // 2
+                        }
+                    }
+                }
+                """;
+            var comp = CreateCompilation(source);
+            comp.VerifyEmitDiagnostics(
+                // (15,17): warning CS8604: Possible null reference argument for parameter 't' in 'void Inner.Use(T t)'.
+                //             Use(default(T)); // 1
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "default(T)").WithArguments("t", "void Inner.Use(T t)").WithLocation(15, 17),
+                // (23,17): warning CS8604: Possible null reference argument for parameter 't' in 'void Inner.Use(T t)'.
+                //             Use(default(T)); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceArgument, "default(T)").WithArguments("t", "void Inner.Use(T t)").WithLocation(23, 17));
         }
 
         [Theory, WorkItem("https://github.com/dotnet/roslyn/issues/78592")]
@@ -12993,9 +13570,8 @@ class C<T>
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/80504")]
         public void SetsRequiredMembersInSubtype()
         {
-            var source = """
+            var source1 = """
                 #nullable enable
-                using System.Diagnostics.CodeAnalysis;
 
                 public class Foo {
                     public required string Bar {
@@ -13005,20 +13581,39 @@ class C<T>
                         }
                     }
                 }
+                """;
+
+            var source2 = """
+                #nullable enable
+                using System.Diagnostics.CodeAnalysis;
 
                 public class FooDerivative : Foo {
-
                     [SetsRequiredMembers]
                     public FooDerivative() {
                     }
                 }
                 """;
 
-            var comp = CreateCompilation(source, targetFramework: TargetFramework.Net100);
+            var comp = CreateCompilation([source1, source2], targetFramework: TargetFramework.Net100);
             comp.VerifyEmitDiagnostics(
-                // (16,12): warning CS8618: Non-nullable property 'Bar' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
+                // (6,12): warning CS8618: Non-nullable property 'Bar' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
                 //     public FooDerivative() {
-                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "FooDerivative").WithArguments("property", "Bar").WithLocation(16, 12));
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "FooDerivative").WithArguments("property", "Bar").WithLocation(6, 12));
+
+            var comp1 = CreateCompilation(source1, targetFramework: TargetFramework.Net100);
+            comp1.VerifyEmitDiagnostics();
+
+            verify2(comp1.ToMetadataReference());
+            verify2(comp1.EmitToImageReference());
+
+            void verify2(MetadataReference reference)
+            {
+                var comp2 = CreateCompilation(source2, references: [reference], targetFramework: TargetFramework.Net100);
+                comp2.VerifyEmitDiagnostics(
+                    // (6,12): warning CS8618: Non-nullable property 'Bar' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
+                    //     public FooDerivative() {
+                    Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "FooDerivative").WithArguments("property", "Bar").WithLocation(6, 12));
+            }
         }
 
         private class TestAnalyzer1 : DiagnosticAnalyzer

--- a/src/Compilers/CSharp/Test/Emit3/FieldKeywordTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/FieldKeywordTests.cs
@@ -12775,24 +12775,42 @@ class C<T>
                     {
                         Prop1 = null;
                         Prop2 = null; // 4
+
+                        if (string.Empty == "")
+                        {
+                            Prop1.ToString(); // 5
+                            Prop2.ToString(); // 6
+                        }
                     }
 
-                    public C(D4 d4) : this(false) // 5
+                    public C(D4 d4) : this(false) // 7
                     {
                         Prop1 = null;
-                        Prop2 = null; // 6
+                        Prop2 = null; // 8
+
+                        if (string.Empty == "")
+                        {
+                            Prop1.ToString(); // 9
+                            Prop2.ToString(); // 10
+                        }
                     }
 
                     public C(D5 d5)
                     {
                         Prop1 = "a";
                         Prop2 = "a";
+
+                        Prop1.ToString();
+                        Prop2.ToString();
                     }
 
                     public C(D6 d6) : this(false)
                     {
                         Prop1 = "a";
                         Prop2 = "a";
+
+                        Prop1.ToString();
+                        Prop2.ToString();
                     }
 
                     public void M()
@@ -12816,12 +12834,24 @@ class C<T>
                 // (39,17): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         Prop2 = null; // 4
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(39, 17),
-                // (42,12): warning CS9264: Non-nullable property 'Prop2' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier, or declaring the property as nullable, or safely handling the case where 'field' is null in the 'get' accessor.
-                //     public C(D4 d4) : this(false) // 5
-                Diagnostic(ErrorCode.WRN_UninitializedNonNullableBackingField, "C").WithArguments("property", "Prop2").WithLocation(42, 12),
-                // (45,17): warning CS8625: Cannot convert null literal to non-nullable reference type.
-                //         Prop2 = null; // 6
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(45, 17));
+                // (43,13): warning CS8602: Dereference of a possibly null reference.
+                //             Prop1.ToString(); // 5
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "Prop1").WithLocation(43, 13),
+                // (44,13): warning CS8602: Dereference of a possibly null reference.
+                //             Prop2.ToString(); // 6
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "Prop2").WithLocation(44, 13),
+                // (48,12): warning CS9264: Non-nullable property 'Prop2' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier, or declaring the property as nullable, or safely handling the case where 'field' is null in the 'get' accessor.
+                //     public C(D4 d4) : this(false) // 7
+                Diagnostic(ErrorCode.WRN_UninitializedNonNullableBackingField, "C").WithArguments("property", "Prop2").WithLocation(48, 12),
+                // (51,17): warning CS8625: Cannot convert null literal to non-nullable reference type.
+                //         Prop2 = null; // 8
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(51, 17),
+                // (55,13): warning CS8602: Dereference of a possibly null reference.
+                //             Prop1.ToString(); // 9
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "Prop1").WithLocation(55, 13),
+                // (56,13): warning CS8602: Dereference of a possibly null reference.
+                //             Prop2.ToString(); // 10
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "Prop2").WithLocation(56, 13));
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/77991")]
@@ -12877,13 +12907,27 @@ class C<T>
                         Prop1 = null;
                         Prop2 = null; // 1
                         Prop3 = null;
+
+                        if (string.Empty == "")
+                        {
+                            Prop1.ToString();
+                            Prop2.ToString(); // 2
+                            Prop3.ToString();
+                        }
                     }
 
                     public C(D4 d4) : this(false)
                     {
                         Prop1 = null;
-                        Prop2 = null; // 2
+                        Prop2 = null; // 3
                         Prop3 = null;
+
+                        if (string.Empty == "")
+                        {
+                            Prop1.ToString();
+                            Prop2.ToString(); // 4
+                            Prop3.ToString();
+                        }
                     }
 
                     public C(D5 d5)
@@ -12891,6 +12935,10 @@ class C<T>
                         Prop1 = "a";
                         Prop2 = "a";
                         Prop3 = "a";
+
+                        Prop1.ToString();
+                        Prop2.ToString();
+                        Prop3.ToString();
                     }
 
                     public C(D6 d6) : this(false)
@@ -12898,6 +12946,10 @@ class C<T>
                         Prop1 = "a";
                         Prop2 = "a";
                         Prop3 = "a";
+
+                        Prop1.ToString();
+                        Prop2.ToString();
+                        Prop3.ToString();
                     }
 
                     public void M()
@@ -12911,9 +12963,15 @@ class C<T>
                 // (47,17): warning CS8625: Cannot convert null literal to non-nullable reference type.
                 //         Prop2 = null; // 1
                 Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(47, 17),
-                // (54,17): warning CS8625: Cannot convert null literal to non-nullable reference type.
-                //         Prop2 = null; // 2
-                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(54, 17));
+                // (53,13): warning CS8602: Dereference of a possibly null reference.
+                //             Prop2.ToString(); // 2
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "Prop2").WithLocation(53, 13),
+                // (61,17): warning CS8625: Cannot convert null literal to non-nullable reference type.
+                //         Prop2 = null; // 3
+                Diagnostic(ErrorCode.WRN_NullAsNonNullable, "null").WithLocation(61, 17),
+                // (67,13): warning CS8602: Dereference of a possibly null reference.
+                //             Prop2.ToString(); // 4
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "Prop2").WithLocation(67, 13));
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/77991")]
@@ -12958,21 +13016,31 @@ class C<T>
                     public C(D3 d3)
                     {
                         Prop1 = null;
+                        if (string.Empty == "")
+                        {
+                            Prop1.ToString(); // 3
+                        }
                     }
 
                     public C(D4 d4) : this(false)
                     {
                         Prop1 = null;
+                        if (string.Empty == "")
+                        {
+                            Prop1.ToString(); // 4
+                        }
                     }
 
                     public C(D5 d5)
                     {
                         Prop1 = "a";
+                        Prop1.ToString();
                     }
 
                     public C(D6 d6) : this(false)
                     {
                         Prop1 = "a";
+                        Prop1.ToString();
                     }
 
                     public void M()
@@ -12989,9 +13057,15 @@ class C<T>
                 // (24,9): warning CS8602: Dereference of a possibly null reference.
                 //         Prop1.ToString(); // 2
                 Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "Prop1").WithLocation(24, 9),
-                // (57,9): warning CS8602: Dereference of a possibly null reference.
+                // (40,13): warning CS8602: Dereference of a possibly null reference.
+                //             Prop1.ToString(); // 3
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "Prop1").WithLocation(40, 13),
+                // (49,13): warning CS8602: Dereference of a possibly null reference.
+                //             Prop1.ToString(); // 4
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "Prop1").WithLocation(49, 13),
+                // (67,9): warning CS8602: Dereference of a possibly null reference.
                 //         Prop1.ToString(); // 3
-                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "Prop1").WithLocation(57, 9));
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "Prop1").WithLocation(67, 9));
         }
 
         [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/77991")]
@@ -13032,11 +13106,21 @@ class C<T>
                     public C(D3 d)
                     {
                         Prop1 = "a";
+
+                        if (string.Empty == "")
+                        {
+                            Prop1.ToString();
+                        }
                     }
 
                     public C(D4 d) : this(false)
                     {
                         Prop1 = "a";
+
+                        if (string.Empty == "")
+                        {
+                            Prop1.ToString();
+                        }
                     }
 
                     public void M()

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/RequiredMembersTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/RequiredMembersTests.cs
@@ -4846,6 +4846,200 @@ class Derived : Base
     }
 
     [Fact, CompilerTrait(CompilerFeature.NullableReferenceTypes)]
+    [WorkItem(6754, "https://github.com/dotnet/csharplang/issues/6754")]
+    public void RequiredMemberSuppressesNullabilityWarnings_MemberNotNull_ChainedBaseConstructor_06()
+    {
+        // Base required property initializes a private field.
+        // Derived constructors have SetsRequiredMembers and demonstrate behavior with/without initializing base required property.
+        var @base = """
+using System.Diagnostics.CodeAnalysis;
+#nullable enable
+public class Base
+{
+    private string _field;
+    public string Field => _field;
+    public required string Property { get => _field; [MemberNotNull(nameof(_field))] set => _field = value; }
+
+    public Base() { }
+}
+""";
+
+        var derived = """
+using System;
+using System.Diagnostics.CodeAnalysis;
+#nullable enable
+
+var d = new Derived("property");
+Console.Write(d.Field);
+Console.Write(' ');
+
+d = new Derived();
+try
+{
+    d.Field.ToString();
+}
+catch (NullReferenceException)
+{
+    Console.Write("NullReferenceException");
+}
+
+class Derived : Base
+{
+    [SetsRequiredMembers]
+    public Derived()
+    {
+    }
+
+    [SetsRequiredMembers]
+    public Derived(string value)
+    {
+        Property = value;
+    }
+}
+""";
+
+        var comp = CreateCompilationWithRequiredMembers(new[] { @base, derived, MemberNotNullAttributeDefinition });
+        comp.VerifyDiagnostics(
+            // 1.cs(22,12): warning CS8618: Non-nullable property 'Property' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
+            //     public Derived()
+            Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "Derived").WithArguments("property", "Property").WithLocation(22, 12)
+            );
+        CompileAndVerify(comp, expectedOutput: "property NullReferenceException");
+
+        var baseComp = CreateCompilationWithRequiredMembers(new[] { @base, MemberNotNullAttributeDefinition });
+        comp = CreateCompilation(derived, new[] { baseComp.EmitToImageReference() });
+        comp.VerifyDiagnostics(
+            // 1.cs(22,12): warning CS8618: Non-nullable property 'Property' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
+            //     public Derived()
+            Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "Derived").WithArguments("property", "Property").WithLocation(22, 12)
+            );
+        CompileAndVerify(comp, expectedOutput: "property NullReferenceException");
+    }
+
+    [Fact, CompilerTrait(CompilerFeature.NullableReferenceTypes)]
+    [WorkItem(6754, "https://github.com/dotnet/csharplang/issues/6754")]
+    public void RequiredMemberSuppressesNullabilityWarnings_MemberNotNull_ChainedBaseConstructor_07()
+    {
+        // Base required property, with nullable type, initializes a private field.
+        // Derived constructors have SetsRequiredMembers and demonstrate behavior with/without initializing base required property.
+        // Note: this is a safety hole. However, the user has to go quite off into the weeds to fall into it.
+        var @base = """
+using System.Diagnostics.CodeAnalysis;
+#nullable enable
+public class Base
+{
+    private string _field;
+    public string Field => _field;
+    public required string? Property { get => _field; [MemberNotNull(nameof(_field))] set => _field = value ?? "property"; }
+
+    public Base() { }
+}
+""";
+
+        var derived = """
+using System;
+using System.Diagnostics.CodeAnalysis;
+#nullable enable
+
+var d = new Derived(null);
+Console.Write(d.Field);
+Console.Write(' ');
+
+d = new Derived();
+try
+{
+    d.Field.ToString();
+}
+catch (NullReferenceException)
+{
+    Console.Write("NullReferenceException");
+}
+
+class Derived : Base
+{
+    [SetsRequiredMembers]
+    public Derived()
+    {
+    }
+
+    [SetsRequiredMembers]
+    public Derived(string? value)
+    {
+        Property = value;
+    }
+}
+""";
+
+        var comp = CreateCompilationWithRequiredMembers(new[] { @base, derived, MemberNotNullAttributeDefinition });
+        comp.VerifyDiagnostics();
+        CompileAndVerify(comp, expectedOutput: "property NullReferenceException");
+
+        var baseComp = CreateCompilationWithRequiredMembers(new[] { @base, MemberNotNullAttributeDefinition });
+        comp = CreateCompilation(derived, new[] { baseComp.EmitToImageReference() });
+        comp.VerifyDiagnostics();
+        CompileAndVerify(comp, expectedOutput: "property NullReferenceException");
+    }
+
+    [Fact, CompilerTrait(CompilerFeature.NullableReferenceTypes)]
+    [WorkItem(6754, "https://github.com/dotnet/csharplang/issues/6754")]
+    public void RequiredMemberSuppressesNullabilityWarnings_MemberNotNull_ChainedBaseConstructor_08()
+    {
+        // Base required property initializes a private field.
+        // Derived is a nested type of the base and therefore can access the base private field.
+        // Derived constructors have SetsRequiredMembers and demonstrate behavior with/without initializing base required property.
+        var source = """
+using System;
+using System.Diagnostics.CodeAnalysis;
+#nullable enable
+
+var d = new Base.Derived("property");
+Console.Write(d.Field);
+Console.Write(' ');
+
+d = new Base.Derived();
+try
+{
+    d.Field.ToString();
+}
+catch (NullReferenceException)
+{
+    Console.Write("NullReferenceException");
+}
+
+public class Base
+{
+    private string _field;
+    public string Field => _field;
+    public required string Property { get => _field; [MemberNotNull(nameof(_field))] set => _field = value; }
+
+    public Base() { }
+
+    public class Derived : Base
+    {
+        [SetsRequiredMembers]
+        public Derived()
+        {
+        }
+
+        [SetsRequiredMembers]
+        public Derived(string value)
+        {
+            Property = value;
+        }
+    }
+}
+""";
+
+        var comp = CreateCompilationWithRequiredMembers(new[] { source, MemberNotNullAttributeDefinition });
+        comp.VerifyDiagnostics(
+            // 0.cs(30,16): warning CS8618: Non-nullable property 'Property' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the property as nullable.
+            //         public Derived()
+            Diagnostic(ErrorCode.WRN_UninitializedNonNullableField, "Derived").WithArguments("property", "Property").WithLocation(30, 16)
+            );
+        CompileAndVerify(comp, expectedOutput: "property NullReferenceException");
+    }
+
+    [Fact, CompilerTrait(CompilerFeature.NullableReferenceTypes)]
     public void RequiredMemberSuppressesNullabilityWarnings_ChainedConstructor_01()
     {
         var code = @"

--- a/src/Dependencies/Collections/Extensions/IEnumerableExtensions.cs
+++ b/src/Dependencies/Collections/Extensions/IEnumerableExtensions.cs
@@ -530,6 +530,19 @@ namespace Roslyn.Utilities
             return builder.ToImmutableAndFree();
         }
 
+        public static ImmutableArray<TResult> SelectManyAsArray<TItem, TArg, TResult>(this IReadOnlyCollection<TItem>? source, Func<TItem, TArg, OneOrMany<TResult>> selector, TArg arg)
+        {
+            if (source is null or { Count: 0 })
+                return [];
+
+            // Basic heuristic. Assume each element in the source adds one item to the result.
+            var builder = ArrayBuilder<TResult>.GetInstance(source.Count);
+            foreach (var item in source)
+                selector(item, arg).AddRangeTo(builder);
+
+            return builder.ToImmutableAndFree();
+        }
+
         public static ImmutableArray<TResult> SelectManyAsArray<TSource, TResult>(this IEnumerable<TSource>? source, Func<TSource, OneOrMany<TResult>> selector)
         {
             if (!TryGetBuilder<TSource, TResult>(source, useCountForBuilder: false, out var builder))

--- a/src/Dependencies/Collections/Extensions/ImmutableArrayExtensions.cs
+++ b/src/Dependencies/Collections/Extensions/ImmutableArrayExtensions.cs
@@ -305,6 +305,7 @@ namespace Microsoft.CodeAnalysis
         /// <param name="array">The array to transform</param>
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <returns>If the array's length is 0, this will return an empty immutable array.</returns>
+        public static ImmutableArray<TResult> SelectManyAsArray<TItem, TArg, TResult>(this ImmutableArray<TItem> array, Func<TItem, TArg, OneOrMany<TResult>> selector, TArg arg)
         {
             if (array.Length == 0)
                 return [];

--- a/src/Dependencies/Collections/Extensions/ImmutableArrayExtensions.cs
+++ b/src/Dependencies/Collections/Extensions/ImmutableArrayExtensions.cs
@@ -300,12 +300,11 @@ namespace Microsoft.CodeAnalysis
         /// Maps and flattens an immutable array to another immutable array.
         /// </summary>
         /// <typeparam name="TItem">Type of the source array items</typeparam>
-        /// <typeparam name="TArg">Type of the argument to pass to the predicate and selector</typeparam>
+        /// <typeparam name="TArg">Type of the argument to pass to the selector.</typeparam>
         /// <typeparam name="TResult">Type of the transformed array items</typeparam>
         /// <param name="array">The array to transform</param>
         /// <param name="selector">A transform function to apply to each element.</param>
-        /// <returns>If the items's length is 0, this will return an empty immutable array.</returns>
-        public static ImmutableArray<TResult> SelectManyAsArray<TItem, TArg, TResult>(this ImmutableArray<TItem> array, Func<TItem, TArg, OneOrMany<TResult>> selector, TArg arg)
+        /// <returns>If the array's length is 0, this will return an empty immutable array.</returns>
         {
             if (array.Length == 0)
                 return [];

--- a/src/Dependencies/Collections/Extensions/ImmutableArrayExtensions.cs
+++ b/src/Dependencies/Collections/Extensions/ImmutableArrayExtensions.cs
@@ -297,6 +297,29 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>
+        /// Maps and flattens an immutable array to another immutable array.
+        /// </summary>
+        /// <typeparam name="TItem">Type of the source array items</typeparam>
+        /// <typeparam name="TArg">Type of the argument to pass to the predicate and selector</typeparam>
+        /// <typeparam name="TResult">Type of the transformed array items</typeparam>
+        /// <param name="array">The array to transform</param>
+        /// <param name="selector">A transform function to apply to each element.</param>
+        /// <returns>If the items's length is 0, this will return an empty immutable array.</returns>
+        public static ImmutableArray<TResult> SelectManyAsArray<TItem, TArg, TResult>(this ImmutableArray<TItem> array, Func<TItem, TArg, OneOrMany<TResult>> selector, TArg arg)
+        {
+            if (array.Length == 0)
+                return [];
+
+            var builder = ArrayBuilder<TResult>.GetInstance();
+            foreach (var item in array)
+            {
+                selector(item, arg).AddRangeTo(builder);
+            }
+
+            return builder.ToImmutableAndFree();
+        }
+
+        /// <summary>
         /// Maps and flattens a subset of immutable array to another immutable array.
         /// </summary>
         /// <typeparam name="TItem">Type of the source array items</typeparam>


### PR DESCRIPTION
Closes #77991

2 principles in this change:
1) We **do not share a slot when the property is null-resilient**. This differs from the usual case where properties using `field` keyword use a shared slot in constructors. The reason is that there is no strong connection between their respective flow states in this situation. Our analysis decided that the field's value doesn't affect the nullability of the get accessor.
    - This allows us to use the property's type, instead of the field's type, etc. to get the property's initial state, in a fairly natural way. I tried some other approaches but this really made things fall out much better and seemed to stand to reason to me fairly well. Once I started doing this, a bunch of other changes I had became unnecessary.
2) Avoid using knowledge about a backing field in nullable analysis, when the field is not accessible in the method currently being analyzed. This mostly affects required properties+backing fields+inheritance, and, honestly, mostly affects corner cases. But, trying to stick to this principle helped iron some bugs out. For example, when encountering issues with different behaviors occurring when a type comes from source versus metadata.

This also adds verification, that when a slot *is* shared, that we only ever lookup the slot for a variable using the "owning" symbol. Otherwise we can get really painful bugs where we might have a slot for both "owning" and "non-owning" when we meant to share a single one, or, we can report no state is tracked because we forgot to use the "owning" symbol for the lookup.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84991)