### PR TITLE
Make obsolete completion sort test order-independent

### DIFF
--- a/src/LanguageServer/ProtocolUnitTests/Completion/CompletionFeaturesTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Completion/CompletionFeaturesTests.cs
@@ -544,8 +544,9 @@ public sealed class CompletionFeaturesTests : AbstractLanguageServerProtocolTest
         Assert.NotNull(completionResult.ItemDefaults.CommitCharacters);
 
         var actualItem = completionResult.Items.First(i => i.Label == "ObsoleteType");
+        var expectedSortText = $"{Array.IndexOf(completionResult.Items, actualItem):D4}";
         Assert.Null(actualItem.LabelDetails);
-        Assert.Equal("0000", actualItem.SortText);
+        Assert.Equal(expectedSortText, actualItem.SortText);
         Assert.Equal(CompletionItemKind.Class, actualItem.Kind);
         Assert.Equal([CompletionItemTag.Deprecated], actualItem.Tags);
         Assert.Null(actualItem.FilterText);
@@ -562,7 +563,7 @@ public sealed class CompletionFeaturesTests : AbstractLanguageServerProtocolTest
 
         var resolvedItem = await testLspServer.ExecuteRequestAsync<LSP.CompletionItem, LSP.CompletionItem>(LSP.Methods.TextDocumentCompletionResolveName, actualItem, CancellationToken.None).ConfigureAwait(false);
         Assert.Null(resolvedItem.LabelDetails);
-        Assert.Equal("0000", actualItem.SortText);
+        Assert.Equal(expectedSortText, resolvedItem.SortText);
         Assert.Equal(CompletionItemKind.Class, resolvedItem.Kind);
         Assert.Equal([CompletionItemTag.Deprecated], resolvedItem.Tags);
 


### PR DESCRIPTION
## Summary
- validate the obsolete completion item's sort prefix against its actual list position
- verify the resolved item preserves that sort text
- avoid assuming unrelated completion ordering places the item first

## Test plan
- [x] Run `TestCompletionForObsoleteSymbol` for both workspace modes on .NET 10 Release
- [x] Verify the test fails before the change and passes afterward
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/84993)