### PR TITLE
Stabilize stale daemon lifecycle test

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.ProcessHost.UnitTests/Lifecycle/DaemonServerLifecycleTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.ProcessHost.UnitTests/Lifecycle/DaemonServerLifecycleTests.cs
@@ -199,6 +199,11 @@ public sealed class DaemonServerLifecycleTests(ITestOutputHelper testOutputHelpe
         await firstDaemonProcess.WaitForExitAsync();
         Assert.True(firstDaemonProcess.HasExited);
 
+        // Wait for the first thin client to observe the lost daemon and release its connection. Otherwise, the next
+        // client can briefly observe and connect to the dying daemon before its pipe and server mutex disappear.
+        Assert.NotEqual(0, await WaitForThinClientExitAsync(first));
+        Assert.False(daemon.IsRunning);
+
         // With the stale daemon gone, the next client launches a brand-new daemon (a different process).
         await using var second = await daemon.CreateClientAsync(useNamedPipe: true);
         Assert.NotEqual(firstDaemonProcessId, await daemon.GetDaemonProcessIdAsync(second));


### PR DESCRIPTION
## Summary

- wait for the killed daemon's thin client to observe the disconnect before starting the replacement client
- verify the stale daemon mutex is gone before asserting that a fresh daemon launches

This removes a race seen in [roslyn-CI build 1564354](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1564354), where the next client could briefly connect to the dying daemon and lose JSON-RPC during initialization.

Related to #84828.

## Validation

- `StaleDaemon_NextClientLaunchesFreshDaemon` passed once with a Release build
- the same test passed 10 additional Release runs with `--no-build`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85011)