### PR TITLE
Release daemon mutex when idle shutdown commits

### DIFF
--- a/.github/memory/known-issues/ide.md
+++ b/.github/memory/known-issues/ide.md
@@ -16,3 +16,15 @@ unrelated-looking test failure rather than a clear composition error.
 **Workaround:** When IDE tests fail unexpectedly, check the export attributes
 first (`[ExportLanguageService]`/`[ExportWorkspaceService]`, `[Shared]`,
 `[ImportingConstructor]` + `[Obsolete(MefConstruction.ImportingConstructorMessage)]`).
+
+## The language-server daemon mutex tracks the accepting lifetime
+
+**Affected area:** `src/LanguageServer` daemon shutdown
+
+**Description:** The daemon server mutex signals that the daemon is accepting
+connections, not merely that its process is alive. On an initial-connection or
+idle timeout, `NamedPipeDaemonConnectionSource` disposes the pending listener,
+commits shutdown with no active connections, and then releases the mutex before
+the connection manager and `Program` finish their broader teardown. This order
+allows a replacement daemon to start without advertising it while the old
+listener can still accept clients.

--- a/src/LanguageServer/DaemonConnection/DaemonPipeName.cs
+++ b/src/LanguageServer/DaemonConnection/DaemonPipeName.cs
@@ -77,8 +77,8 @@ internal static class DaemonPipeName
     }
 
     /// <summary>
-    /// Name of the mutex held by the daemon for its entire lifetime; its existence means a daemon
-    /// is running for this pipe.
+    /// Name of the mutex held while the daemon is accepting connections; its existence means a daemon
+    /// is available for this pipe.
     /// </summary>
     public static string GetServerMutexName(string pipeName)
         => $"{GlobalMutexPrefix}{pipeName}.server";

--- a/src/LanguageServer/DaemonConnection/DaemonServerMutex.cs
+++ b/src/LanguageServer/DaemonConnection/DaemonServerMutex.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -8,8 +8,9 @@ using System.Threading;
 namespace Microsoft.CodeAnalysis.LanguageServer.Daemon;
 
 /// <summary>
-/// The "server" mutex that signals a language server daemon is running for a given pipe. The daemon holds it
-/// open for its lifetime; clients (and tests) check its existence to decide whether a daemon already exists.
+/// The "server" mutex that signals a language server daemon is accepting connections for a given pipe. The daemon
+/// holds it open until it commits shutdown; clients (and tests) check its existence to decide whether a daemon
+/// already exists.
 /// <para>
 /// The mutex is held unlocked (<c>initiallyOwned: false</c>): clients only check existence via
 /// <see cref="Mutex.TryOpenExisting(string, out Mutex)"/>, which is satisfied by an open handle. Holding it
@@ -22,7 +23,7 @@ internal static class DaemonServerMutex
     /// <summary>
     /// Attempts to become the daemon for <paramref name="pipeName"/> by opening the server mutex. Returns
     /// <see langword="true"/> and the held mutex if this process is the first; <see langword="false"/> if a
-    /// daemon already owns it. The returned mutex must be disposed when the daemon shuts down.
+    /// daemon already owns it. The returned mutex must be disposed when the daemon stops accepting connections.
     /// </summary>
     public static bool TryAcquire(string pipeName, [NotNullWhen(true)] out Mutex? mutex)
     {

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Daemon/LanguageServerDaemonTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Daemon/LanguageServerDaemonTests.cs
@@ -6,6 +6,7 @@ using System.IO.Pipes;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.LanguageServer.Daemon;
 using Microsoft.CodeAnalysis.LanguageServer.HostWorkspace;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.LanguageServer.Protocol;
@@ -28,6 +29,107 @@ public sealed class LanguageServerDaemonTests(ITestOutputHelper testOutputHelper
         Assert.False(NamedPipeDaemonConnectionSource.TryCreate(
             daemon.PipeName, Timeout.InfiniteTimeSpan, LoggerFactory.CreateLogger("Daemon2"), out var secondSource));
         Assert.Null(secondSource);
+    }
+
+    [Fact]
+    public async Task Daemon_InitialConnectionTimeout_ReleasesServerMutexBeforeSourceDisposal()
+    {
+        var pipeName = "roslyn-daemon-test." + Guid.NewGuid().ToString("N");
+        Assert.True(NamedPipeDaemonConnectionSource.TryCreate(
+            pipeName,
+            Timeout.InfiniteTimeSpan,
+            LoggerFactory.CreateLogger("Daemon"),
+            out var source,
+            initialConnectionTimeout: Timeout.InfiniteTimeSpan));
+        Assert.NotNull(source);
+
+        using var mutexReleased = new ManualResetEventSlim();
+        using var allowShutdownCompletion = new ManualResetEventSlim();
+        var sourceAccessor = source.GetTestAccessor();
+        sourceAccessor.OnServerMutexReleased = () =>
+        {
+            mutexReleased.Set();
+            allowShutdownCompletion.Wait();
+        };
+        var enumerator = source.AcceptConnectionsAsync(CancellationToken.None).GetAsyncEnumerator();
+
+        try
+        {
+            var acceptTask = enumerator.MoveNextAsync().AsTask();
+
+            sourceAccessor.TriggerTimeout();
+
+            Assert.True(mutexReleased.Wait(TimeSpan.FromSeconds(10)));
+            Assert.False(acceptTask.IsCompleted);
+            Assert.False(DaemonServerMutex.IsRunning(pipeName));
+            await AssertReplacementDaemonAcceptsConnectionAsync(pipeName);
+
+            allowShutdownCompletion.Set();
+            Assert.False(await acceptTask.WaitAsync(TimeSpan.FromSeconds(10)));
+        }
+        finally
+        {
+            sourceAccessor.OnServerMutexReleased = null;
+            allowShutdownCompletion.Set();
+            await enumerator.DisposeAsync();
+            source.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task Daemon_KeepaliveTimeout_ReleasesServerMutexBeforeSourceDisposal()
+    {
+        var pipeName = "roslyn-daemon-test." + Guid.NewGuid().ToString("N");
+        Assert.True(NamedPipeDaemonConnectionSource.TryCreate(
+            pipeName,
+            Timeout.InfiniteTimeSpan,
+            LoggerFactory.CreateLogger("Daemon"),
+            out var source,
+            initialConnectionTimeout: Timeout.InfiniteTimeSpan));
+        Assert.NotNull(source);
+
+        using var mutexReleased = new ManualResetEventSlim();
+        using var allowShutdownCompletion = new ManualResetEventSlim();
+        var sourceAccessor = source.GetTestAccessor();
+        sourceAccessor.OnServerMutexReleased = () =>
+        {
+            mutexReleased.Set();
+            allowShutdownCompletion.Wait();
+        };
+        var enumerator = source.AcceptConnectionsAsync(CancellationToken.None).GetAsyncEnumerator();
+
+        try
+        {
+            using var client = NamedPipeUtil.CreateClient(
+                serverName: ".",
+                pipeName,
+                PipeDirection.InOut,
+                PipeOptions.Asynchronous);
+
+            var acceptTask = enumerator.MoveNextAsync().AsTask();
+            await client.ConnectAsync(timeout: 30_000);
+            Assert.True(await acceptTask.WaitAsync(TimeSpan.FromSeconds(10)));
+            Assert.NotNull(enumerator.Current.Resource);
+            enumerator.Current.Resource.Dispose();
+
+            var timeoutTask = enumerator.MoveNextAsync().AsTask();
+            sourceAccessor.TriggerTimeout();
+
+            Assert.True(mutexReleased.Wait(TimeSpan.FromSeconds(10)));
+            Assert.False(timeoutTask.IsCompleted);
+            Assert.False(DaemonServerMutex.IsRunning(pipeName));
+            await AssertReplacementDaemonAcceptsConnectionAsync(pipeName);
+
+            allowShutdownCompletion.Set();
+            Assert.False(await timeoutTask.WaitAsync(TimeSpan.FromSeconds(10)));
+        }
+        finally
+        {
+            sourceAccessor.OnServerMutexReleased = null;
+            allowShutdownCompletion.Set();
+            await enumerator.DisposeAsync();
+            source.Dispose();
+        }
     }
 
     [Fact]
@@ -414,6 +516,33 @@ public sealed class LanguageServerDaemonTests(ITestOutputHelper testOutputHelper
                 .AddMetadataReferences(references)
                 .Solution,
             WorkspaceChangeKind.ProjectAdded);
+
+    private async Task AssertReplacementDaemonAcceptsConnectionAsync(string pipeName)
+    {
+        Assert.True(NamedPipeDaemonConnectionSource.TryCreate(
+            pipeName, Timeout.InfiniteTimeSpan, LoggerFactory.CreateLogger("ReplacementDaemon"), out var replacementSource));
+        Assert.NotNull(replacementSource);
+
+        try
+        {
+            await using var enumerator = replacementSource.AcceptConnectionsAsync(CancellationToken.None).GetAsyncEnumerator();
+            using var client = NamedPipeUtil.CreateClient(
+                serverName: ".",
+                pipeName,
+                PipeDirection.InOut,
+                PipeOptions.Asynchronous);
+
+            var acceptTask = enumerator.MoveNextAsync().AsTask();
+            await client.ConnectAsync(timeout: 30_000);
+            Assert.True(await acceptTask.WaitAsync(TimeSpan.FromSeconds(10)));
+            Assert.NotNull(enumerator.Current.Resource);
+            enumerator.Current.Resource.Dispose();
+        }
+        finally
+        {
+            replacementSource.Dispose();
+        }
+    }
 
     private static DocumentUri LoadProjectWithDocument(LanguageServerWorkspaceFactory workspaceFactory, string typeName)
     {

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServer/NamedPipeDaemonConnectionSource.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/LanguageServer/NamedPipeDaemonConnectionSource.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -21,8 +21,8 @@ using NamedPipeUtil = MSBuildWorkspaces::Microsoft.CodeAnalysis.NamedPipeUtil;
 namespace Microsoft.CodeAnalysis.LanguageServer;
 
 /// <summary>
-/// A connection source for daemon mode: owns the server mutex (which signals "a daemon is running" for
-/// this pipe) and accepts client connections on a named pipe, handing each a dedicated, independent
+/// A connection source for daemon mode: owns the server mutex (which signals that a daemon is accepting
+/// connections for this pipe) and accepts clients on a named pipe, handing each a dedicated, independent
 /// <see cref="System.IO.Pipes.NamedPipeServerStream"/>.
 /// </summary>
 internal sealed class NamedPipeDaemonConnectionSource : ILanguageServerConnectionSource, IDisposable
@@ -31,10 +31,11 @@ internal sealed class NamedPipeDaemonConnectionSource : ILanguageServerConnectio
 
     private readonly string _pipeName;
     private readonly ILogger _logger;
-    private readonly Mutex _serverMutex;
     private readonly ConnectionIdleTimeout _idleTimeout;
 
+    private Mutex? _serverMutex;
     private Action? _onConnectionAccepted;
+    private Action? _onServerMutexReleased;
 
     private NamedPipeDaemonConnectionSource(
         string pipeName,
@@ -101,7 +102,16 @@ internal sealed class NamedPipeDaemonConnectionSource : ILanguageServerConnectio
             catch (OperationCanceledException) when (timeoutToken.IsCancellationRequested)
             {
                 await pipeStream.DisposeAsync().ConfigureAwait(false);
-                _idleTimeout.CommitTimeout();
+                try
+                {
+                    _idleTimeout.CommitTimeout();
+                }
+                finally
+                {
+                    ReleaseServerMutex();
+                    _onServerMutexReleased?.Invoke();
+                }
+
                 yield break;
             }
             catch (Exception ex)
@@ -138,6 +148,11 @@ internal sealed class NamedPipeDaemonConnectionSource : ILanguageServerConnectio
         {
             set => _instance._onConnectionAccepted = value;
         }
+
+        internal Action? OnServerMutexReleased
+        {
+            set => _instance._onServerMutexReleased = value;
+        }
     }
 
     private sealed class ConnectionResource(IDisposable resource, NamedPipeDaemonConnectionSource source) : IDisposable
@@ -164,6 +179,9 @@ internal sealed class NamedPipeDaemonConnectionSource : ILanguageServerConnectio
     public void Dispose()
     {
         _idleTimeout.Dispose();
-        _serverMutex.Dispose();
+        ReleaseServerMutex();
     }
+
+    private void ReleaseServerMutex()
+        => Interlocked.Exchange(ref _serverMutex, null)?.Dispose();
 }

--- a/src/LanguageServer/roslyn-language-server/DaemonBootstrap.cs
+++ b/src/LanguageServer/roslyn-language-server/DaemonBootstrap.cs
@@ -115,8 +115,8 @@ internal static class DaemonBootstrap
             if (daemonProcess.HasExited)
                 return DaemonReadinessResult.Exited(daemonProcess.ExitCode);
 
-            // The daemon holds its server mutex for its whole lifetime once it is ready to accept clients, so its
-            // existence is our readiness signal.
+            // The daemon holds its server mutex while it is ready to accept clients, so its existence is our
+            // readiness signal.
             if (DaemonServerMutex.IsRunning(pipeName))
                 return DaemonReadinessResult.Ready;
 


### PR DESCRIPTION
## Summary
- release the daemon server mutex when an idle or initial-connection timeout commits shutdown
- preserve source disposal as an idempotent fallback through interlocked mutex ownership
- verify a replacement daemon can bind and accept before the original connection-manager/program teardown completes

## Shutdown ordering
1. Dispose the pending listener pipe.
2. Commit the timeout, which guarantees there are no active connections.
3. Release the server mutex.
4. Complete the connection-source enumeration and broader teardown.

## Validation
- `dotnet test src\LanguageServer\Microsoft.CodeAnalysis.LanguageServer.UnitTests\Microsoft.CodeAnalysis.LanguageServer.UnitTests.csproj --filter "FullyQualifiedName~LanguageServerDaemonTests" --no-restore --nologo --verbosity minimal` (15 passed)
- new initial/idle timeout tests repeated 5 times (10 passed)
- `dotnet build src\LanguageServer\Microsoft.CodeAnalysis.LanguageServer.UnitTests\Microsoft.CodeAnalysis.LanguageServer.UnitTests.csproj --no-restore --nologo --verbosity minimal`
- `dotnet format whitespace --folder . --include <changed C# files>`
- `git diff --check`

The build reports only the repository's existing NuGet vulnerability warnings.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85012)