### PR TITLE
Revert "Allow for better parallelization with brokered services"

### DIFF
--- a/src/Workspaces/Remote/Core/ServiceDescriptor.cs
+++ b/src/Workspaces/Remote/Core/ServiceDescriptor.cs
@@ -75,10 +75,6 @@ internal sealed class ServiceDescriptor : ServiceJsonRpcDescriptor
 
     protected override JsonRpcConnection CreateConnection(JsonRpc jsonRpc)
     {
-        // The default synchronization context set by the base type is NonConcurrentSynchronizationContext, which means that all incoming calls
-        // would be processed sequentially, at least up until their first await. We generally don't have services that expect ordering in that specific way, so
-        // disable that, especially since we want CPU-bound operations to happen in parallel.
-        jsonRpc.SynchronizationContext = null;
         jsonRpc.CancelLocallyInvokedMethodsWhenConnectionIsClosed = true;
         var connection = base.CreateConnection(jsonRpc);
         connection.LocalRpcTargetOptions = s_jsonRpcTargetOptions;


### PR DESCRIPTION
Reverts dotnet/roslyn#82733. This still [seemed to cause perf regressions](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/3044775), even though the runs from the PR validation were fine.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85014)