### PR TITLE
Better align Razor with Roslyn's misc file Uri handling

### DIFF
--- a/.github/instructions/Razor.instructions.md
+++ b/.github/instructions/Razor.instructions.md
@@ -38,6 +38,10 @@ their original sub-tree layout
   `GetUnusedDirectives()`) rather than storing computed results as fields.
 - **Razor documents in Roslyn**: Stored as additional documents. Resolve via
   `solution.GetDocumentIdsWithFilePath(filePath)` then `solution.GetAdditionalDocument(documentId)`.
+- **Razor documents with virtual URIs**: Remote Razor document classification preserves the full
+  additional-document `FilePath` for identity. For parseable absolute URI file paths, inspect the
+  URI's local path when checking the `.razor` or `.cshtml` extension; do not strip the query from
+  the stored file path.
 - **Remote services**: Place the public stub method (calling `RunServiceAsync`) directly
   above its private implementation method.
 - **Formatting options across OOP**: Cohost endpoints must resolve

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/Extensions.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/Extensions.cs
@@ -15,7 +15,27 @@ internal static class Extensions
     public static bool IsRazorDocument(this TextDocument document)
         => document is AdditionalDocument &&
            document.FilePath is string filePath &&
-           filePath.IsRazorFilePath();
+           IsRazorDocumentFilePath(filePath);
+
+    private static bool IsRazorDocumentFilePath(string filePath)
+    {
+        // Most file paths and virtual URIs can be classified from their extension directly.
+        if (filePath.IsRazorFilePath())
+        {
+            return true;
+        }
+
+        // Roslyn preserves non-file document URIs as the additional document's file path, so a query
+        // or fragment can obscure an otherwise trailing Razor extension.
+        if (!filePath.Contains('?') && !filePath.Contains('#'))
+        {
+            return false;
+        }
+
+        // Match Roslyn's language classification by checking the local path of an absolute URI.
+        return new DocumentUri(filePath).ParsedUri is { IsAbsoluteUri: true } uri &&
+            uri.LocalPath.IsRazorFilePath();
+    }
 
     public static bool ContainsRazorDocuments(this Project project)
         => project.AdditionalDocuments.Any(static d => d.IsRazorDocument());

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.UnitTests/RemoteWorkspaceProviderTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.UnitTests/RemoteWorkspaceProviderTest.cs
@@ -5,12 +5,36 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Remote.Razor;
+using Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Text;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Razor.Remote;
 
 public class RemoteWorkspaceProviderTest
 {
+    [Theory]
+    [InlineData("cline-diff:Index.cshtml?SGVsbG8=", true)]
+    [InlineData("custom://workspace/Component.razor?SGVsbG8=", true)]
+    [InlineData("cline-diff:Program.cs?SGVsbG8=", false)]
+    [InlineData("custom://workspace/README.md?SGVsbG8=", false)]
+    [InlineData("Index.cshtml", true)]
+    [InlineData("Program.cs", false)]
+    [InlineData(@"C:\Project\Index.cshtml", true)]
+    [InlineData("/Project/Component.razor", true)]
+    [InlineData(@"C:\Project\Program.cs", false)]
+    [InlineData("/Project/README.md", false)]
+    public void IsRazorDocument(string filePath, bool expected)
+    {
+        using var workspace = new AdhocWorkspace();
+        var project = workspace.AddProject("Test", LanguageNames.CSharp);
+        var document = project.AddAdditionalDocument(filePath, SourceText.From(""), filePath: filePath);
+
+        Assert.Equal(filePath, document.FilePath);
+        Assert.Equal(expected, document.IsRazorDocument());
+        Assert.Equal(expected, document.Project.ContainsRazorDocuments());
+    }
+
     [Fact]
     public async Task InitializeRemoteExportProviderBuilderAsync_OnlyInitializesOnce()
     {

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.UnitTests/RemoteWorkspaceProviderTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.UnitTests/RemoteWorkspaceProviderTest.cs
@@ -18,6 +18,8 @@ public class RemoteWorkspaceProviderTest
     [InlineData("custom://workspace/Component.razor?SGVsbG8=", true)]
     [InlineData("cline-diff:Program.cs?SGVsbG8=", false)]
     [InlineData("custom://workspace/README.md?SGVsbG8=", false)]
+    [InlineData("custom://workspace/Component.razor#fragment", true)]
+    [InlineData("custom://workspace/README.md#fragment", false)]
     [InlineData("Index.cshtml", true)]
     [InlineData("Program.cs", false)]
     [InlineData(@"C:\Project\Index.cshtml", true)]


### PR DESCRIPTION
Fixes https://github.com/dotnet/vscode-csharp/issues/9353
Fixes https://github.com/dotnet/vscode-csharp/issues/9464
Fixes https://github.com/dotnet/vscode-csharp/issues/9678

This check assumed that a document file path is just a file path, but for some odd Uris Roslyn will set the document file path to the raw Uri from the incoming request, which failed.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85019)