### PR TITLE
Add `is` pattern benchmarks

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IsPatternOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IsPatternOperator.cs
@@ -13,8 +13,9 @@ namespace Microsoft.CodeAnalysis.CSharp
     internal sealed partial class LocalRewriter
     {
         /// <summary>
-        /// Benchmark results (<c>src/Tools/Benchmarks/IsPatternBenchmarks.cs</c>) show that short patterns can be more
-        /// efficient when emitted as comparisons. Larger patterns can benefit from switch dispatch.
+        /// Benchmarks in <c>src/Tools/Benchmarks/IsPatternBenchmarks.cs</c> show that short sparse patterns can be more
+        /// efficient as comparisons, while the sparse and dense four-value cases show that larger patterns can benefit
+        /// from general decision-DAG dispatch.
         /// </summary>
         private const int MaxTestsForInvertedLinearSequence = 3;
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IsPatternOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_IsPatternOperator.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     internal sealed partial class LocalRewriter
     {
         /// <summary>
-        /// Benchmark results (see https://github.com/dotnet/roslyn/pull/84961) show that short patterns can be more
+        /// Benchmark results (<c>src/Tools/Benchmarks/IsPatternBenchmarks.cs</c>) show that short patterns can be more
         /// efficient when emitted as comparisons. Larger patterns can benefit from switch dispatch.
         /// </summary>
         private const int MaxTestsForInvertedLinearSequence = 3;

--- a/src/Tools/Benchmarks/IsPatternBenchmarks.cs
+++ b/src/Tools/Benchmarks/IsPatternBenchmarks.cs
@@ -23,6 +23,10 @@ public enum IsPatternPathInput
     Other,
 }
 
+/// <summary>
+/// The pattern and comparison forms are expected to have equivalent performance when short patterns use linear
+/// lowering. This benchmark detects regressions in that equivalence.
+/// </summary>
 /// <seealso href="https://github.com/dotnet/roslyn/issues/80052"/>
 [EvaluateOverhead(false)]
 public class IsPatternLeadingSlashBenchmarks
@@ -70,6 +74,10 @@ public class IsPatternLeadingSlashBenchmarks
     }
 }
 
+/// <summary>
+/// The pattern and comparison forms are expected to have equivalent performance when short patterns use linear
+/// lowering. This benchmark detects regressions in that equivalence.
+/// </summary>
 /// <seealso href="https://github.com/dotnet/runtime/pull/132452"/>
 [EvaluateOverhead(false)]
 public class IsPatternJsonTerminatorBenchmarks : IsPatternByteInputBenchmarks
@@ -81,7 +89,7 @@ public class IsPatternJsonTerminatorBenchmarks : IsPatternByteInputBenchmarks
     public int Comparisons()
     {
         var value = Value;
-        return value != '.' && value != 'E' && value != 'e'
+        return value != (byte)'.' && value != (byte)'E' && value != (byte)'e'
             ? value + 1
             : value - 1;
     }
@@ -96,6 +104,9 @@ public class IsPatternJsonTerminatorBenchmarks : IsPatternByteInputBenchmarks
     }
 }
 
+/// <summary>
+/// Compares explicit linear tests with general decision-DAG dispatch for four sparse values.
+/// </summary>
 /// <seealso href="https://github.com/dotnet/roslyn/pull/84961"/>
 [EvaluateOverhead(false)]
 public class IsPatternSparseFourValueBenchmarks : IsPatternByteInputBenchmarks
@@ -104,12 +115,15 @@ public class IsPatternSparseFourValueBenchmarks : IsPatternByteInputBenchmarks
     protected override byte LastCase => (byte)'e';
 
     [Benchmark(Baseline = true)]
-    public bool Comparisons() => Guard && (Value == '+' || Value == '.' || Value == 'E' || Value == 'e');
+    public bool Comparisons() => Guard && (Value == (byte)'+' || Value == (byte)'.' || Value == (byte)'E' || Value == (byte)'e');
 
     [Benchmark]
     public bool Pattern() => Guard && Value is (byte)'+' or (byte)'.' or (byte)'E' or (byte)'e';
 }
 
+/// <summary>
+/// Compares explicit linear tests with general decision-DAG dispatch for four dense values.
+/// </summary>
 /// <seealso href="https://github.com/dotnet/roslyn/pull/84961"/>
 [EvaluateOverhead(false)]
 public class IsPatternDenseFourValueBenchmarks : IsPatternByteInputBenchmarks

--- a/src/Tools/Benchmarks/IsPatternBenchmarks.cs
+++ b/src/Tools/Benchmarks/IsPatternBenchmarks.cs
@@ -1,0 +1,150 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+
+namespace Benchmarks;
+
+public enum IsPatternInputPosition
+{
+    FirstHit,
+    LastHit,
+    Miss,
+}
+
+public enum IsPatternPathInput
+{
+    Empty,
+    Slash,
+    Backslash,
+    Other,
+}
+
+/// <seealso href="https://github.com/dotnet/roslyn/issues/80052"/>
+[EvaluateOverhead(false)]
+public class IsPatternLeadingSlashBenchmarks
+{
+    private string _path = null!;
+
+    [Params(IsPatternPathInput.Empty, IsPatternPathInput.Slash, IsPatternPathInput.Backslash, IsPatternPathInput.Other)]
+    public IsPatternPathInput Input { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _path = Input switch
+        {
+            IsPatternPathInput.Empty => "",
+            IsPatternPathInput.Slash => "/path",
+            IsPatternPathInput.Backslash => "\\path",
+            IsPatternPathInput.Other => "path",
+            _ => throw new InvalidOperationException(),
+        };
+    }
+
+    [Benchmark(Baseline = true)]
+    public bool Comparisons() => HasLeadingSlashWithComparisons(_path);
+
+    [Benchmark]
+    public bool Pattern() => HasLeadingSlashWithPattern(_path);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool HasLeadingSlashWithComparisons(ReadOnlySpan<char> path)
+    {
+        if (path.Length > 0 && (path[0] == '/' || path[0] == '\\'))
+            return true;
+
+        return false;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool HasLeadingSlashWithPattern(ReadOnlySpan<char> path)
+    {
+        if (path.Length > 0 && path[0] is '/' or '\\')
+            return true;
+
+        return false;
+    }
+}
+
+/// <seealso href="https://github.com/dotnet/runtime/pull/132452"/>
+[EvaluateOverhead(false)]
+public class IsPatternJsonTerminatorBenchmarks : IsPatternByteInputBenchmarks
+{
+    protected override byte FirstCase => (byte)'.';
+    protected override byte LastCase => (byte)'e';
+
+    [Benchmark(Baseline = true)]
+    public int Comparisons()
+    {
+        var value = Value;
+        return value != '.' && value != 'E' && value != 'e'
+            ? value + 1
+            : value - 1;
+    }
+
+    [Benchmark]
+    public int Pattern()
+    {
+        var value = Value;
+        return value is not ((byte)'.' or (byte)'E' or (byte)'e')
+            ? value + 1
+            : value - 1;
+    }
+}
+
+/// <seealso href="https://github.com/dotnet/roslyn/pull/84961"/>
+[EvaluateOverhead(false)]
+public class IsPatternSparseFourValueBenchmarks : IsPatternByteInputBenchmarks
+{
+    protected override byte FirstCase => (byte)'+';
+    protected override byte LastCase => (byte)'e';
+
+    [Benchmark(Baseline = true)]
+    public bool Comparisons() => Guard && (Value == '+' || Value == '.' || Value == 'E' || Value == 'e');
+
+    [Benchmark]
+    public bool Pattern() => Guard && Value is (byte)'+' or (byte)'.' or (byte)'E' or (byte)'e';
+}
+
+/// <seealso href="https://github.com/dotnet/roslyn/pull/84961"/>
+[EvaluateOverhead(false)]
+public class IsPatternDenseFourValueBenchmarks : IsPatternByteInputBenchmarks
+{
+    protected override byte FirstCase => 1;
+    protected override byte LastCase => 4;
+
+    [Benchmark(Baseline = true)]
+    public bool Comparisons() => Guard && (Value == 1 || Value == 2 || Value == 3 || Value == 4);
+
+    [Benchmark]
+    public bool Pattern() => Guard && Value is 1 or 2 or 3 or 4;
+}
+
+public abstract class IsPatternByteInputBenchmarks
+{
+    [Params(IsPatternInputPosition.FirstHit, IsPatternInputPosition.LastHit, IsPatternInputPosition.Miss)]
+    public IsPatternInputPosition Input { get; set; }
+
+    protected bool Guard;
+    protected byte Value;
+
+    protected abstract byte FirstCase { get; }
+    protected abstract byte LastCase { get; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        Guard = true;
+        Value = Input switch
+        {
+            IsPatternInputPosition.FirstHit => FirstCase,
+            IsPatternInputPosition.LastHit => LastCase,
+            IsPatternInputPosition.Miss => byte.MaxValue,
+            _ => throw new InvalidOperationException(),
+        };
+    }
+}


### PR DESCRIPTION
Follow up on https://github.com/dotnet/roslyn/pull/84961#discussion_r3846574703.

<details>

<summary>Results of <code>IsPatternLeadingSlashBenchmarks</code></summary>

```

BenchmarkDotNet v0.16.0-preview.1, Windows 11 (10.0.26100.9106/24H2/2024Update/HudsonValley) (Hyper-V)
Intel Xeon Platinum 8370C CPU 2.80GHz (Max: 2.79GHz), 1 CPU, 16 logical and 8 physical cores
Memory: 63.95 GB Total, 16.03 GB Available
.NET SDK 11.0.100-preview.7.26381.103
  [Host]   : .NET 10.0.11 (10.0.11, 10.0.1126.37416), X64 RyuJIT x86-64-v4
  ShortRun : .NET 10.0.11 (10.0.11, 10.0.1126.37416), X64 RyuJIT x86-64-v4

Job=ShortRun  EvaluateOverhead=False  IterationCount=3  
LaunchCount=1  WarmupCount=3  

```
| Method      | Input     | Mean     | Error     | StdDev    | Ratio | RatioSD |
|------------ |---------- |---------:|----------:|----------:|------:|--------:|
| **Comparisons** | **Empty**     | **4.081 ns** | **6.2051 ns** | **0.3401 ns** |  **1.00** |    **0.00** |
| Pattern     | Empty     | 3.537 ns | 0.9690 ns | 0.0531 ns |  0.87 |    0.07 |
|             |           |          |           |           |       |         |
| **Comparisons** | **Slash**     | **4.010 ns** | **1.4465 ns** | **0.0793 ns** |  **1.00** |    **0.00** |
| Pattern     | Slash     | 4.241 ns | 0.7739 ns | 0.0424 ns |  1.06 |    0.02 |
|             |           |          |           |           |       |         |
| **Comparisons** | **Backslash** | **3.593 ns** | **2.5362 ns** | **0.1390 ns** |  **1.00** |    **0.00** |
| Pattern     | Backslash | 4.629 ns | 0.6133 ns | 0.0336 ns |  1.29 |    0.04 |
|             |           |          |           |           |       |         |
| **Comparisons** | **Other**     | **4.184 ns** | **3.6089 ns** | **0.1978 ns** |  **1.00** |    **0.00** |
| Pattern     | Other     | 4.678 ns | 3.8583 ns | 0.2115 ns |  1.12 |    0.06 |

</details>


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85027)