### PR TITLE
Fix extra newline after primary constructor parameter

### DIFF
--- a/src/LanguageServer/ProtocolUnitTests/Formatting/FormatDocumentOnTypeTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Formatting/FormatDocumentOnTypeTests.cs
@@ -99,6 +99,28 @@ public sealed class FormatDocumentOnTypeTests : AbstractLanguageServerProtocolTe
             """);
     }
 
+    [Theory, CombinatorialData, WorkItem("https://github.com/dotnet/vscode-csharp/issues/8939")]
+    public async Task TestFormatDocumentOnType_NewLineInPrimaryConstructorParameterList(bool mutatingLspWorkspace)
+    {
+        var markup =
+            """
+            class A(
+                int x,
+                int y,
+                {|type:|}
+            );
+            """;
+        await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace);
+        var locationTyped = testLspServer.GetLocations("type").Single();
+        await AssertFormatDocumentOnTypeAsync(testLspServer, "\n", locationTyped, """
+            class A(
+                int x,
+                int y,
+            /*indent*/
+            );
+            """.Replace("/*indent*/", "    "));
+    }
+
     [Theory, CombinatorialData, WorkItem("https://github.com/dotnet/vscode-csharp/issues/8429")]
     public async Task TestFormatDocumentOnType_NewLineBeforeMultilineComment(bool mutatingLspWorkspace)
     {

--- a/src/LanguageServer/ProtocolUnitTests/Formatting/FormatDocumentOnTypeTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Formatting/FormatDocumentOnTypeTests.cs
@@ -121,6 +121,38 @@ public sealed class FormatDocumentOnTypeTests : AbstractLanguageServerProtocolTe
             """.Replace("/*indent*/", "    "));
     }
 
+    [Theory, CombinatorialData, WorkItem("https://github.com/dotnet/vscode-csharp/issues/8939")]
+    public async Task TestFormatDocumentOnType_NewLineInMethodParameterList(bool mutatingLspWorkspace)
+    {
+        var markup =
+            """
+            class A
+            {
+                void M(
+                    int x,
+                    int y,
+                    {|type:|}
+                )
+                {
+                }
+            }
+            """;
+        await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace);
+        var locationTyped = testLspServer.GetLocations("type").Single();
+        await AssertFormatDocumentOnTypeAsync(testLspServer, "\n", locationTyped, """
+            class A
+            {
+                void M(
+                    int x,
+                    int y,
+            /*indent*/
+                )
+                {
+                }
+            }
+            """.Replace("/*indent*/", "        "));
+    }
+
     [Theory, CombinatorialData, WorkItem("https://github.com/dotnet/vscode-csharp/issues/8429")]
     public async Task TestFormatDocumentOnType_NewLineBeforeMultilineComment(bool mutatingLspWorkspace)
     {

--- a/src/LanguageServer/ProtocolUnitTests/Formatting/FormatDocumentOnTypeTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Formatting/FormatDocumentOnTypeTests.cs
@@ -153,6 +153,40 @@ public sealed class FormatDocumentOnTypeTests : AbstractLanguageServerProtocolTe
             """.Replace("/*indent*/", "        "));
     }
 
+    [Theory, CombinatorialData, WorkItem("https://github.com/dotnet/vscode-csharp/issues/8939")]
+    public async Task TestFormatDocumentOnType_NewLineInArgumentList(bool mutatingLspWorkspace)
+    {
+        var markup =
+            """
+            class A
+            {
+                void M()
+                {
+                    M(
+                        1,
+                        2,
+                        {|type:|}
+                    );
+                }
+            }
+            """;
+        await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace);
+        var locationTyped = testLspServer.GetLocations("type").Single();
+        await AssertFormatDocumentOnTypeAsync(testLspServer, "\n", locationTyped, """
+            class A
+            {
+                void M()
+                {
+                    M(
+                        1,
+                        2,
+            /*indent*/
+                    );
+                }
+            }
+            """.Replace("/*indent*/", "            "));
+    }
+
     [Theory, CombinatorialData, WorkItem("https://github.com/dotnet/vscode-csharp/issues/8429")]
     public async Task TestFormatDocumentOnType_NewLineBeforeMultilineComment(bool mutatingLspWorkspace)
     {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Indentation/CSharpSmartTokenFormatter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Indentation/CSharpSmartTokenFormatter.cs
@@ -47,6 +47,17 @@ internal sealed class CSharpSmartTokenFormatter : ISmartTokenFormatter
         Contract.ThrowIfTrue(startToken.Kind() is SyntaxKind.None or SyntaxKind.EndOfFileToken);
         Contract.ThrowIfTrue(endToken.Kind() is SyntaxKind.None or SyntaxKind.EndOfFileToken);
 
+        var previousToken = endToken.GetPreviousToken(includeZeroWidth: true);
+        // A trailing comma produces a missing parameter. Formatting through an already-separated close paren
+        // duplicates the trivia before it, so stop at the last visible token in the incomplete parameter list.
+        if (endToken.IsKind(SyntaxKind.CloseParenToken) &&
+            endToken.Parent is BaseParameterListSyntax &&
+            previousToken.IsMissing &&
+            !_text.AreOnSameLine(previousToken, endToken))
+        {
+            endToken = previousToken.GetPreviousToken();
+        }
+
         var smartTokenformattingRules = _formattingRules;
         var common = startToken.GetCommonRoot(endToken);
         RoslynDebug.AssertNotNull(common);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Indentation/CSharpSmartTokenFormatter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Indentation/CSharpSmartTokenFormatter.cs
@@ -47,20 +47,6 @@ internal sealed class CSharpSmartTokenFormatter : ISmartTokenFormatter
         Contract.ThrowIfTrue(startToken.Kind() is SyntaxKind.None or SyntaxKind.EndOfFileToken);
         Contract.ThrowIfTrue(endToken.Kind() is SyntaxKind.None or SyntaxKind.EndOfFileToken);
 
-        if (endToken.IsKind(SyntaxKind.CloseParenToken) &&
-            endToken.Parent is BaseParameterListSyntax)
-        {
-            var previousToken = endToken.GetPreviousToken(includeZeroWidth: true);
-
-            // A trailing comma produces a missing parameter. Formatting through an already-separated close paren
-            // duplicates the trivia before it, so stop at the last visible token in the incomplete parameter list.
-            if (previousToken.IsMissing &&
-                !_text.AreOnSameLine(previousToken, endToken))
-            {
-                endToken = previousToken.GetPreviousToken();
-            }
-        }
-
         var smartTokenformattingRules = _formattingRules;
         var common = startToken.GetCommonRoot(endToken);
         RoslynDebug.AssertNotNull(common);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Indentation/CSharpSmartTokenFormatter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Indentation/CSharpSmartTokenFormatter.cs
@@ -47,15 +47,18 @@ internal sealed class CSharpSmartTokenFormatter : ISmartTokenFormatter
         Contract.ThrowIfTrue(startToken.Kind() is SyntaxKind.None or SyntaxKind.EndOfFileToken);
         Contract.ThrowIfTrue(endToken.Kind() is SyntaxKind.None or SyntaxKind.EndOfFileToken);
 
-        var previousToken = endToken.GetPreviousToken(includeZeroWidth: true);
-        // A trailing comma produces a missing parameter. Formatting through an already-separated close paren
-        // duplicates the trivia before it, so stop at the last visible token in the incomplete parameter list.
         if (endToken.IsKind(SyntaxKind.CloseParenToken) &&
-            endToken.Parent is BaseParameterListSyntax &&
-            previousToken.IsMissing &&
-            !_text.AreOnSameLine(previousToken, endToken))
+            endToken.Parent is BaseParameterListSyntax)
         {
-            endToken = previousToken.GetPreviousToken();
+            var previousToken = endToken.GetPreviousToken(includeZeroWidth: true);
+
+            // A trailing comma produces a missing parameter. Formatting through an already-separated close paren
+            // duplicates the trivia before it, so stop at the last visible token in the incomplete parameter list.
+            if (previousToken.IsMissing &&
+                !_text.AreOnSameLine(previousToken, endToken))
+            {
+                endToken = previousToken.GetPreviousToken();
+            }
         }
 
         var smartTokenformattingRules = _formattingRules;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Utilities/FormattingRangeHelper.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Utilities/FormattingRangeHelper.cs
@@ -21,7 +21,20 @@ internal static class FormattingRangeHelper
     {
         Contract.ThrowIfTrue(endToken.Kind() == SyntaxKind.None);
 
-        return FixupOpenBrace(FindAppropriateRangeWorker(endToken, useDefaultRange));
+        var tokenRange = FixupOpenBrace(FindAppropriateRangeWorker(endToken, useDefaultRange));
+        if (!tokenRange.HasValue || tokenRange.Value.Item2 == endToken)
+            return tokenRange;
+
+        var previousToken = tokenRange.Value.Item2.GetPreviousToken(includeZeroWidth: true);
+        if (!previousToken.IsMissing ||
+            AreTwoTokensOnSameLine(previousToken, tokenRange.Value.Item2))
+        {
+            return tokenRange;
+        }
+
+        // Since this range was expanded past the token that triggered formatting, that token provides a preceding
+        // non-missing token in the same syntax tree.
+        return ValueTuple.Create(tokenRange.Value.Item1, previousToken.GetPreviousToken());
     }
 
     private static ValueTuple<SyntaxToken, SyntaxToken>? FixupOpenBrace(ValueTuple<SyntaxToken, SyntaxToken>? tokenRange)


### PR DESCRIPTION
Fixes dotnet/vscode-csharp#8939.

When on-type formatting runs after a trailing comma and newline in an incomplete syntax list, the parser synthesizes a missing list element before the existing closing token. Range formatting included that already-newline-separated closer, duplicating its leading trivia and returning extra newlines.

This change trims an expanded formatting range to the last visible token when it ends after a line-separated missing token. It adds LSP on-type formatting regression tests for primary-constructor parameter lists, method parameter lists, and argument lists, covering both mutating and non-mutating workspace modes.

Validation:
- All three incomplete-list regressions pass on `net10.0` and `net472` (6/6 each)
- `FormatDocumentOnTypeTests` passes on `net10.0` and `net472` (16/16 each)
- Related editor formatting and automatic line-ender tests pass (524/524)
- `Microsoft.CodeAnalysis.CSharp.Workspaces.csproj` builds successfully

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85030)