### PR TITLE
Handle blank lines when classifying reference spans

### DIFF
--- a/src/Features/Core/Portable/ClassifiedSpansAndHighlightSpanFactory.cs
+++ b/src/Features/Core/Portable/ClassifiedSpansAndHighlightSpanFactory.cs
@@ -44,7 +44,7 @@ internal static class ClassifiedSpansAndHighlightSpanFactory
     private static TextSpan GetLineSpanForReference(SourceText sourceText, TextSpan referenceSpan)
     {
         var sourceLine = sourceText.Lines.GetLineFromPosition(referenceSpan.Start);
-        var firstNonWhitespacePosition = sourceLine.GetFirstNonWhitespacePosition().Value;
+        var firstNonWhitespacePosition = sourceLine.GetFirstNonWhitespacePosition() ?? sourceLine.Start;
 
         // Get the span of the line from the first non-whitespace character to the end of it. Note: the reference
         // span might actually start in the leading whitespace of the line (nothing prevents any of our

--- a/src/Features/Test/Classification/ClassifiedSpansAndHighlightSpanFactoryTests.cs
+++ b/src/Features/Test/Classification/ClassifiedSpansAndHighlightSpanFactoryTests.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Classification;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.UnitTests.Classification;
+
+[UseExportProvider]
+public sealed class ClassifiedSpansAndHighlightSpanFactoryTests
+{
+    [Fact, WorkItem("https://github.com/dotnet/vscode-csharp/issues/8354")]
+    public async Task ClassifyAsync_ReferenceOnBlankLine()
+    {
+        using var workspace = TestWorkspace.CreateCSharp("\r\nclass C;");
+        var document = workspace.CurrentSolution.Projects.Single().Documents.Single();
+
+        var result = await ClassifiedSpansAndHighlightSpanFactory.ClassifyAsync(
+            new DocumentSpan(document, new TextSpan(0, 0)),
+            classifiedSpans: null,
+            ClassificationOptions.Default,
+            CancellationToken.None);
+
+        Assert.Empty(result.ClassifiedSpans);
+        Assert.Equal(default, result.HighlightSpan);
+    }
+}


### PR DESCRIPTION
## Summary

- handle reference spans reported on lines with no non-whitespace content
- use the source line start as the widened span fallback for blank lines
- add focused regression coverage for dotnet/vscode-csharp#8354

## Test plan

- `dotnet test .\src\Features\Test\Microsoft.CodeAnalysis.Features.UnitTests.csproj --filter "FullyQualifiedName=Microsoft.CodeAnalysis.UnitTests.Classification.ClassifiedSpansAndHighlightSpanFactoryTests.ClassifyAsync_ReferenceOnBlankLine" --no-restore --verbosity minimal`
- `dotnet build .\src\Features\Core\Portable\Microsoft.CodeAnalysis.Features.csproj --no-restore --verbosity minimal`

Fixes https://github.com/dotnet/vscode-csharp/issues/9482
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85031)