### PR TITLE
Suppress speculative T completion after lowercase t

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SpeculativeTCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SpeculativeTCompletionProviderTests.cs
@@ -738,6 +738,20 @@ public sealed class SpeculativeTCompletionProviderTests : AbstractCSharpCompleti
             }
             """, "T");
 
+    [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+    [WorkItem("https://github.com/dotnet/vscode-csharp/issues/8050")]
+    public Task NotAfterLowercaseTInMethod()
+        => VerifyItemIsAbsentAsync("""
+            class Main
+            {
+                static void Main()
+                {
+                    var t = 1;
+                    t$$
+                }
+            }
+            """, "T");
+
     [Fact(Skip = "https://github.com/dotnet/roslyn/issues/14525")]
     [CompilerTrait(CompilerFeature.LocalFunctions)]
     public Task LocalFunctionAfterAyncTask()

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/SpeculativeTCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/SpeculativeTCompletionProvider.cs
@@ -69,6 +69,13 @@ internal sealed class SpeculativeTCompletionProvider : LSPCompletionProvider
             return false;
         }
 
+        // Case-insensitive clients may otherwise rank the synthetic `T` first when the user types lowercase `t`.
+        if (completionContext.CompletionListSpan is { Length: > 0 } completionListSpan &&
+            syntaxTree.GetText(cancellationToken)[completionListSpan.Start] == 't')
+        {
+            return false;
+        }
+
         var context = await completionContext.GetSyntaxContextWithExistingSpeculativeModelAsync(document, cancellationToken).ConfigureAwait(false);
 
         if (context.IsTaskLikeTypeContext)


### PR DESCRIPTION
## Summary

Fixes dotnet/vscode-csharp#8050 by suppressing Roslyn's synthetic speculative type-parameter `T` completion item when the active completion span begins with lowercase `t`.

The synthetic item remains available in valid empty and uppercase speculative type-parameter contexts, and real symbols are unaffected.

## Test-first regression evidence

Before changing product code, the new focused regression test failed with:

```
Unexpected item found among existing items: T
Existing items: T
```

After the fix:

- Focused regression test: 1 passed
- `SpeculativeTCompletionProviderTests`: 68 passed, 2 pre-existing skipped
- `Microsoft.CodeAnalysis.CSharp.EditorFeatures.UnitTests.csproj` build: succeeded

The build reports the existing NU1903 warning for `SQLitePCLRaw.lib.e_sqlite3` 2.1.6.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85032)