### PR TITLE
Fail when test results cannot be published

### DIFF
--- a/eng/pipelines/publish-logs.yml
+++ b/eng/pipelines/publish-logs.yml
@@ -48,6 +48,7 @@ steps:
         testResultsFiles: '$(Build.SourcesDirectory)/artifacts/TestResults/${{ parameters.configuration }}/*.xml'
         mergeTestResults: true
         failTaskOnFailureToPublishResults: true
+        failTaskOnMissingResultsFile: true
         testRunTitle: ${{ parameters.testRunName }}
     condition: and(always(), ne('${{ parameters.testRunName }}', ''))
 

--- a/eng/pipelines/publish-logs.yml
+++ b/eng/pipelines/publish-logs.yml
@@ -47,6 +47,7 @@ steps:
         testRunner: XUnit
         testResultsFiles: '$(Build.SourcesDirectory)/artifacts/TestResults/${{ parameters.configuration }}/*.xml'
         mergeTestResults: true
+        failTaskOnFailureToPublishResults: true
         testRunTitle: ${{ parameters.testRunName }}
     condition: and(always(), ne('${{ parameters.testRunName }}', ''))
 


### PR DESCRIPTION
## Summary
- fail the shared xUnit publishing task when Azure Pipelines cannot publish all test results
- fail the task when no test result files are produced
- surface incomplete test reporting as a task failure instead of a warning

This prevents runs such as [20260825.36](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1567319&view=results) from showing only the test script failure when the test-results service rejects part of the upload. Log and dump publication remains unaffected because those steps use `condition: always()`.

## Validation
- verified `PublishTestResults@2` supports both failure options
- ran `git diff --check`