### PR TITLE
[ProjectData] Refresh shared generator and build evidence sources

### DIFF
--- a/Roslyn.slnx
+++ b/Roslyn.slnx
@@ -428,6 +428,7 @@
   <Project Path="src/Deployment/RoslynDeployment.csproj" />
   <Folder Name="/LanguageServer/ProjectData/">
     <Project Path="src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Generators/Microsoft.NET.ProjectData.Generators.csproj" />
+    <Project Path="src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Generators.Tests/Microsoft.NET.ProjectData.Generators.Tests.csproj" />
     <Project Path="src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Tests/Microsoft.NET.ProjectData.Tests.csproj" />
     <Project Path="src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/Microsoft.NET.ProjectData.csproj" />
   </Folder>

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Generators.Tests/DataModelSchemaGeneratorTests.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Generators.Tests/DataModelSchemaGeneratorTests.cs
@@ -1,5 +1,8 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
+using System.Text.Json.Nodes;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Text;
@@ -9,8 +12,341 @@ namespace Microsoft.NET.ProjectData.Generators.Tests;
 
 public sealed class DataModelSchemaGeneratorTests
 {
+	private const string SchemaPath = "/repo/project-data-schema.json";
+
 	[Fact]
-	public void DataModelSchemaGenerator_EmitsSha256SourceHashes()
+	public void DataModelSchemaGenerator_ValidSchema_EmitsSha256SourceHashes()
+	{
+		GeneratorRunResult result = RunGenerator(new TestAdditionalText(SchemaPath, ValidSchema));
+
+		Assert.Empty(result.Diagnostics);
+		Assert.Equal(4, result.GeneratedSources.Length);
+		Assert.All(result.GeneratedSources, static source => Assert.Equal(SourceHashAlgorithm.Sha256, source.SourceText.ChecksumAlgorithm));
+		Assert.All(result.GeneratedSources, static source =>
+		{
+			// Generated sources must use only the current platform's newline sequence.
+			string textWithoutPlatformNewLines = source.SourceText.ToString().Replace(Environment.NewLine, "");
+			Assert.DoesNotContain('\r', textWithoutPlatformNewLines);
+			Assert.DoesNotContain('\n', textWithoutPlatformNewLines);
+		});
+	}
+
+	[Fact]
+	public void DataModelSchemaGenerator_AbsentOptionalFields_UsesSemanticDefaults()
+	{
+		JsonObject schema = ParseValidSchema();
+		JsonObject property = schema["properties"]!["required"]!.AsArray()[0]!.AsObject();
+		property.Remove("description");
+		JsonObject item = schema["items"]!["Compile"]!.AsObject();
+		item.Remove("description");
+		item.Remove("required");
+		item.Remove("metadata");
+		JsonObject section = schema["cacheFormat"]!["sections"]!.AsArray()[0]!.AsObject();
+		section.Remove("description");
+		section.Remove("itemType");
+
+		GeneratorRunResult result = RunGenerator(new TestAdditionalText(SchemaPath, schema.ToJsonString()));
+
+		Assert.Empty(result.Diagnostics);
+		string projectItems = Assert.Single(result.GeneratedSources, static source => source.HintName == "ProjectItems.g.cs").SourceText.ToString();
+		Assert.Contains("public const string Compile = \"Compile\";", projectItems);
+		Assert.Contains("RequiredItemTypes = [];", projectItems);
+	}
+
+	[Fact]
+	public void DataModelSchemaGenerator_DynamicValues_AreEscapedForGeneratedCSharpAndXml()
+	{
+		JsonObject schema = ParseValidSchema();
+		schema["properties"]!["required"]!.AsArray()[0]!["description"] = """Quotes "stay"; slash / and backslash \ stay; A & B < C > D.""";
+		schema["cacheFormat"]!["hashHeaderPrefix"] = "hash=\"C:\\cache\"";
+		schema["cacheFormat"]!["sections"]!.AsArray()[0]!["description"] = "Section & <value>.";
+
+		GeneratorRunResult result = RunGenerator(new TestAdditionalText(SchemaPath, schema.ToJsonString()));
+
+		Assert.Empty(result.Diagnostics);
+		string projectProperties = Assert.Single(result.GeneratedSources, static source => source.HintName == "ProjectProperties.g.cs").SourceText.ToString();
+		Assert.Contains("""/// <summary>Quotes "stay"; slash / and backslash \ stay; A &amp; B &lt; C &gt; D.</summary>""", projectProperties);
+
+		string cacheFormat = Assert.Single(result.GeneratedSources, static source => source.HintName == "CacheFormat.g.cs").SourceText.ToString();
+		Assert.Contains("""public const string HashHeaderPrefix = "hash=\"C:\\cache\"";""", cacheFormat);
+		Assert.Contains("/// <summary>Section &amp; &lt;value&gt;.</summary>", cacheFormat);
+		Assert.DoesNotContain(
+			CSharpSyntaxTree.ParseText(cacheFormat, cancellationToken: CancellationToken.None).GetDiagnostics(CancellationToken.None),
+			static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+	}
+
+	[Fact]
+	public void DataModelSchemaGenerator_ControlCharacterInDynamicValue_ReportsDiagnostic()
+	{
+		JsonObject schema = ParseValidSchema();
+		schema["cacheFormat"]!["hashHeaderPrefix"] = "hash=\t";
+
+		AssertInvalid(schema.ToJsonString(), "Field 'cacheFormat.hashHeaderPrefix' cannot contain control characters or Unicode line separators.");
+	}
+
+	[Theory]
+	[InlineData("properties")]
+	[InlineData("items")]
+	[InlineData("cacheFormat")]
+	[InlineData("pathSentinels")]
+	public void DataModelSchemaGenerator_MissingRequiredTopLevelSection_ReportsDiagnostic(string section)
+	{
+		JsonObject schema = ParseValidSchema();
+		Assert.True(schema.Remove(section));
+
+		AssertInvalid(schema.ToJsonString(), $"Required field '{section}' is missing.");
+	}
+
+	[Fact]
+	public void DataModelSchemaGenerator_MissingPropertyName_ReportsDiagnostic()
+	{
+		JsonObject schema = ParseValidSchema();
+		Assert.True(schema["properties"]!["required"]!.AsArray()[0]!.AsObject().Remove("name"));
+
+		AssertInvalid(schema.ToJsonString(), "Required field 'properties.required[0].name' is missing.");
+	}
+
+	[Fact]
+	public void DataModelSchemaGenerator_MissingSectionName_ReportsDiagnostic()
+	{
+		JsonObject schema = ParseValidSchema();
+		Assert.True(schema["cacheFormat"]!["sections"]!.AsArray()[0]!.AsObject().Remove("name"));
+
+		AssertInvalid(schema.ToJsonString(), "Required field 'cacheFormat.sections[0].name' is missing.");
+	}
+
+	[Fact]
+	public void DataModelSchemaGenerator_MissingWireFormatToken_ReportsDiagnostic()
+	{
+		JsonObject schema = ParseValidSchema();
+		Assert.True(schema["cacheFormat"]!.AsObject().Remove("versionHeader"));
+
+		AssertInvalid(schema.ToJsonString(), "Required field 'cacheFormat.versionHeader' is missing.");
+	}
+
+	[Fact]
+	public void DataModelSchemaGenerator_EmptyPathSentinelToken_ReportsDiagnostic()
+	{
+		JsonObject schema = ParseValidSchema();
+		schema["pathSentinels"]!["path"] = "";
+
+		AssertInvalid(schema.ToJsonString(), "Field 'pathSentinels.path' must be a non-empty string.");
+	}
+
+	[Theory]
+	[InlineData("properties", "Field 'properties' must be a JSON object, but found array.")]
+	[InlineData("propertyList", "Field 'properties.required' must be a JSON array, but found object.")]
+	[InlineData("itemRequired", "Field 'items.Compile.required' must be a JSON boolean, but found string.")]
+	[InlineData("itemMetadata", "Field 'items.Compile.metadata' must be a JSON array, but found string.")]
+	[InlineData("description", "Field 'properties.required[0].description' must be a JSON string, but found null.")]
+	[InlineData("propertyValue", "Field 'properties.required[0].value' must be a JSON string, but found number.")]
+	[InlineData("sentinel", "Field 'pathSentinels.path' must be a JSON string, but found number.")]
+	public void DataModelSchemaGenerator_WrongJsonKind_ReportsDiagnostic(string mutation, string expectedDetail)
+	{
+		JsonObject schema = ParseValidSchema();
+		switch (mutation)
+		{
+			case "properties":
+				schema["properties"] = new JsonArray();
+				break;
+			case "propertyList":
+				schema["properties"]!["required"] = new JsonObject();
+				break;
+			case "itemRequired":
+				schema["items"]!["Compile"]!["required"] = "true";
+				break;
+			case "itemMetadata":
+				schema["items"]!["Compile"]!["metadata"] = "fullPath";
+				break;
+			case "description":
+				schema["properties"]!["required"]!.AsArray()[0]!["description"] = null;
+				break;
+			case "propertyValue":
+				schema["properties"]!["required"]!.AsArray()[0]!["value"] = 42;
+				break;
+			case "sentinel":
+				schema["pathSentinels"]!["path"] = 42;
+				break;
+			default:
+				throw new InvalidOperationException($"Unknown mutation '{mutation}'.");
+		}
+
+		AssertInvalid(schema.ToJsonString(), expectedDetail);
+	}
+
+	[Fact]
+	public void DataModelSchemaGenerator_DuplicatePropertyName_ReportsDiagnostic()
+	{
+		JsonObject schema = ParseValidSchema();
+		schema["properties"]!["optional"]!.AsArray()[0]!["name"] = "ProjectPath";
+
+		AssertInvalid(
+			schema.ToJsonString(),
+			"Property name 'ProjectPath' is duplicated across 'properties.required' and 'properties.optional'.");
+	}
+
+	[Theory]
+	[InlineData("ProjectProperties")]
+	[InlineData("TypedProperties")]
+	[InlineData("inner")]
+	public void DataModelSchemaGenerator_PropertyNameCollidingWithGeneratedMember_ReportsDiagnostic(string name)
+	{
+		JsonObject schema = ParseValidSchema();
+		schema["properties"]!["required"]!.AsArray()[0]!["name"] = name;
+
+		AssertInvalid(
+			schema.ToJsonString(),
+			$"Field 'properties.required[0].name' cannot be '{name}' because that name is reserved by the generated ProjectProperties or TypedProperties type.");
+	}
+
+	[Fact]
+	public void DataModelSchemaGenerator_ItemNameCollidingWithGeneratedType_ReportsDiagnostic()
+	{
+		JsonObject schema = ParseValidSchema();
+		JsonNode item = schema["items"]!["Compile"]!.DeepClone();
+		schema["items"]!.AsObject().Remove("Compile");
+		schema["items"]!["ProjectItems"] = item;
+
+		AssertInvalid(
+			schema.ToJsonString(),
+			"Item name 'ProjectItems' is reserved by the generated ProjectItems type.");
+	}
+
+	[Fact]
+	public void DataModelSchemaGenerator_MetadataNameCollidingWithContainingItem_ReportsDiagnostic()
+	{
+		JsonObject schema = ParseValidSchema();
+		schema["items"]!["Compile"]!["metadata"] = new JsonArray("compile");
+
+		AssertInvalid(
+			schema.ToJsonString(),
+			"Field 'items.Compile.metadata[0]' produces duplicate generated member name 'Compile'.");
+	}
+
+	[Theory]
+	[InlineData("sections", "Sections")]
+	[InlineData("metadataBySection", "MetadataBySection")]
+	public void DataModelSchemaGenerator_SectionNameCollidingWithGeneratedMember_ReportsDiagnostic(string name, string generatedName)
+	{
+		JsonObject schema = ParseValidSchema();
+		schema["cacheFormat"]!["sections"]!.AsArray()[0]!["name"] = name;
+
+		AssertInvalid(
+			schema.ToJsonString(),
+			$"Field 'cacheFormat.sections[0].name' produces duplicate generated member name '{generatedName}'.");
+	}
+
+	[Fact]
+	public void DataModelSchemaGenerator_PathSentinelNameCollidingWithGeneratedType_ReportsDiagnostic()
+	{
+		JsonObject schema = ParseValidSchema();
+		schema["pathSentinels"]!["pathSentinels"] = "<COLLISION>";
+
+		AssertInvalid(
+			schema.ToJsonString(),
+			"Path sentinel name 'pathSentinels' produces duplicate generated member name 'PathSentinels'.");
+	}
+
+	[Fact]
+	public void DataModelSchemaGenerator_DuplicateJsonField_ReportsDiagnostic()
+	{
+		string schema = ValidSchema.Replace(
+			"\"versionHeader\": \"version=2\",",
+			"\"versionHeader\": \"version=2\", \"versionHeader\": \"version=3\",",
+			StringComparison.Ordinal);
+
+		AssertInvalid(schema, "'cacheFormat' contains duplicate field 'versionHeader'.");
+	}
+
+	[Fact]
+	public void DataModelSchemaGenerator_UnknownSectionItemType_ReportsDiagnostic()
+	{
+		JsonObject schema = ParseValidSchema();
+		schema["cacheFormat"]!["sections"]!.AsArray()[0]!["itemType"] = "Unknown";
+
+		AssertInvalid(
+			schema.ToJsonString(),
+			"Field 'cacheFormat.sections[0].itemType' references unknown item type 'Unknown'.");
+	}
+
+	[Fact]
+	public void DataModelSchemaGenerator_MalformedVersionHeader_ReportsDiagnostic()
+	{
+		JsonObject schema = ParseValidSchema();
+		schema["cacheFormat"]!["versionHeader"] = "version=2.x";
+
+		AssertInvalid(
+			schema.ToJsonString(),
+			"Field 'cacheFormat.versionHeader' must have the form 'version=<major>[.<minor>]' using non-negative integers.");
+	}
+
+	[Theory]
+	[InlineData(0x2028)]
+	[InlineData(0x2029)]
+	public void DataModelSchemaGenerator_UnicodeLineSeparatorInWireToken_ReportsDiagnostic(int codePoint)
+	{
+		JsonObject schema = ParseValidSchema();
+		schema["cacheFormat"]!["primaryMarker"] = "primary" + char.ConvertFromUtf32(codePoint);
+
+		AssertInvalid(
+			schema.ToJsonString(),
+			"Field 'cacheFormat.primaryMarker' cannot contain control characters or Unicode line separators.");
+	}
+
+	[Fact]
+	public void DataModelSchemaGenerator_UnicodeLineSeparatorInDescription_ReportsDiagnostic()
+	{
+		JsonObject schema = ParseValidSchema();
+		schema["properties"]!["required"]!.AsArray()[0]!["description"] = "Project" + char.ConvertFromUtf32(0x2028) + "path.";
+
+		AssertInvalid(
+			schema.ToJsonString(),
+			"Field 'properties.required[0].description' cannot contain control characters or Unicode line separators.");
+	}
+
+	[Fact]
+	public void DataModelSchemaGenerator_InvalidJson_ReportsDiagnostic()
+	{
+		AssertInvalid(
+			"{",
+			"the file does not contain valid JSON (line 1, byte 2).");
+	}
+
+	[Fact]
+	public void DataModelSchemaGenerator_UnreadableSchema_ReportsDiagnostic()
+	{
+		GeneratorRunResult result = RunGenerator(new ThrowingAdditionalText(SchemaPath, new IOException("read failed")));
+
+		AssertInvalid(result, "the schema file could not be read: read failed", hasLocation: false);
+	}
+
+	[Fact]
+	public void DataModelSchemaGenerator_UnexpectedReadFailure_IsNotHiddenAsSchemaDiagnostic()
+	{
+		GeneratorRunResult result = RunGenerator(new ThrowingAdditionalText(SchemaPath, new InvalidOperationException("programming error")));
+
+		Assert.IsType<InvalidOperationException>(result.Exception);
+		Assert.DoesNotContain(result.Diagnostics, static diagnostic => diagnostic.Id == "PDG001");
+		Assert.Empty(result.GeneratedSources);
+	}
+
+	private static void AssertInvalid(string schema, string expectedDetail)
+		=> AssertInvalid(RunGenerator(new TestAdditionalText(SchemaPath, schema)), expectedDetail, hasLocation: true);
+
+	private static void AssertInvalid(GeneratorRunResult result, string expectedDetail, bool hasLocation)
+	{
+		Assert.Empty(result.GeneratedSources);
+		Diagnostic diagnostic = Assert.Single(result.Diagnostics);
+		Assert.Equal("PDG001", diagnostic.Id);
+		Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+		Assert.Equal($"ProjectData schema '{SchemaPath}' is invalid: {expectedDetail}", diagnostic.GetMessage());
+		if (hasLocation)
+			Assert.Equal(SchemaPath, diagnostic.Location.GetLineSpan().Path);
+		else
+			Assert.Equal(Location.None, diagnostic.Location);
+	}
+
+	private static GeneratorRunResult RunGenerator(AdditionalText schema)
 	{
 		CSharpCompilation compilation = CSharpCompilation.Create(
 			"Microsoft.NET.ProjectData.Tasks",
@@ -19,51 +355,14 @@ public sealed class DataModelSchemaGeneratorTests
 
 		DataModelSchemaGenerator generator = new();
 		GeneratorDriver driver = CSharpGeneratorDriver.Create(generator)
-			.AddAdditionalTexts([new TestAdditionalText("project-data-schema.json", """
-				{
-				  "properties": {
-				    "required": [
-				      { "name": "ProjectPath", "description": "Project path." }
-				    ],
-				    "optional": [
-				      { "name": "TargetFramework", "description": "Target framework." }
-				    ]
-				  },
-				  "items": {
-				    "Compile": {
-				      "description": "Compile items.",
-				      "required": true,
-				      "metadata": [ "fullPath" ]
-				    }
-				  },
-				  "cacheFormat": {
-				    "versionHeader": "version=2",
-				    "hashHeaderPrefix": "hash=",
-				    "sliceSeparator": "---",
-				    "sectionOpen": "[",
-				    "sectionClose": "]",
-				    "commentChar": "#",
-				    "projectHeaderPrefix": "project=",
-				    "languagePrefix": "language=",
-				    "primaryMarker": "primary",
-				    "lastDtbSucceededMarker": "lastDtbSucceeded",
-				    "sections": [
-				      { "name": "project", "description": "Project header." }
-				    ]
-				  },
-				  "pathSentinels": {
-				    "path": "<PATH>"
-				  }
-				}
-				""")]);
+			.AddAdditionalTexts([schema])
+			.RunGenerators(compilation, CancellationToken.None);
 
-		// Roslyn is still on xunit v2, so must CancellationToken.None instead of the TestContext's CancellationToken
-		driver = driver.RunGenerators(compilation, CancellationToken.None);
-		GeneratorRunResult result = Assert.Single(driver.GetRunResult().Results);
-
-		Assert.NotEmpty(result.GeneratedSources);
-		Assert.All(result.GeneratedSources, static source => Assert.Equal(SourceHashAlgorithm.Sha256, source.SourceText.ChecksumAlgorithm));
+		return Assert.Single(driver.GetRunResult().Results);
 	}
+
+	private static JsonObject ParseValidSchema()
+		=> JsonNode.Parse(ValidSchema)!.AsObject();
 
 	private static IEnumerable<MetadataReference> GetReferences()
 	{
@@ -81,4 +380,50 @@ public sealed class DataModelSchemaGeneratorTests
 		public override SourceText GetText(CancellationToken cancellationToken = default)
 			=> SourceText.From(text);
 	}
+
+	private sealed class ThrowingAdditionalText(string path, Exception exception) : AdditionalText
+	{
+		public override string Path { get; } = path;
+
+		public override SourceText GetText(CancellationToken cancellationToken = default)
+			=> throw exception;
+	}
+
+	private const string ValidSchema = """
+		{
+		  "properties": {
+		    "required": [
+		      { "name": "ProjectPath", "description": "Project path." }
+		    ],
+		    "optional": [
+		      { "name": "TargetFramework", "description": "Target framework." }
+		    ]
+		  },
+		  "items": {
+		    "Compile": {
+		      "description": "Compile items.",
+		      "required": true,
+		      "metadata": [ "fullPath" ]
+		    }
+		  },
+		  "cacheFormat": {
+		    "versionHeader": "version=2",
+		    "hashHeaderPrefix": "hash=",
+		    "sliceSeparator": "---",
+		    "sectionOpen": "[",
+		    "sectionClose": "]",
+		    "commentChar": "#",
+		    "projectHeaderPrefix": "project=",
+		    "languagePrefix": "language=",
+		    "primaryMarker": "primary",
+		    "lastDtbSucceededMarker": "lastDtbSucceeded",
+		    "sections": [
+		      { "name": "project", "description": "Project header.", "itemType": "Compile" }
+		    ]
+		  },
+		  "pathSentinels": {
+		    "path": "<PATH>"
+		  }
+		}
+		""";
 }

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Generators/DataModelSchemaGenerator.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Generators/DataModelSchemaGenerator.cs
@@ -3,9 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
+using System.Globalization;
 using System.Text;
 using System.Text.Json;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.NET.ProjectData.Generators;
 
@@ -17,6 +19,14 @@ namespace Microsoft.NET.ProjectData.Generators;
 public sealed class DataModelSchemaGenerator : IIncrementalGenerator
 {
 	private const string SchemaFileName = "project-data-schema.json";
+
+	private static readonly DiagnosticDescriptor InvalidSchema = new(
+		"PDG001",
+		"Invalid ProjectData schema",
+		"ProjectData schema '{0}' is invalid: {1}",
+		"ProjectData",
+		DiagnosticSeverity.Error,
+		isEnabledByDefault: true);
 
 	public void Initialize(IncrementalGeneratorInitializationContext context)
 	{
@@ -33,207 +43,570 @@ public sealed class DataModelSchemaGenerator : IIncrementalGenerator
 			{
 				if (Path.GetFileName(file.Path).Equals(SchemaFileName, StringComparison.OrdinalIgnoreCase))
 				{
+					if (schemaFile is not null)
+					{
+						ReportInvalidSchema(ctx, file.Path, sourceText: null, $"multiple additional files named '{SchemaFileName}' were provided.");
+						return;
+					}
+
 					schemaFile = file;
-					break;
 				}
 			}
 
 			if (schemaFile is null)
+			{
+				ReportInvalidSchema(ctx, SchemaFileName, sourceText: null, "the required schema additional file was not provided.");
 				return;
+			}
 
-			string? text = schemaFile.GetText(ctx.CancellationToken)?.ToString();
-			if (text is null)
+			SourceText? sourceText;
+			try
+			{
+				sourceText = schemaFile.GetText(ctx.CancellationToken);
+			}
+			catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+			{
+				ReportInvalidSchema(ctx, schemaFile.Path, sourceText: null, $"the schema file could not be read: {ex.Message}");
 				return;
+			}
 
-			Schema? schema = ParseSchema(text);
-			if (schema is null)
+			if (sourceText is null)
+			{
+				ReportInvalidSchema(ctx, schemaFile.Path, sourceText: null, "the schema file could not be read.");
 				return;
+			}
+
+			Schema schema;
+			try
+			{
+				schema = ParseSchema(sourceText.ToString());
+			}
+			catch (JsonException ex)
+			{
+				ReportInvalidSchema(
+					ctx,
+					schemaFile.Path,
+					sourceText,
+					$"the file does not contain valid JSON (line {ex.LineNumber.GetValueOrDefault() + 1}, byte {ex.BytePositionInLine.GetValueOrDefault() + 1}).");
+				return;
+			}
+			catch (SchemaValidationException ex)
+			{
+				ReportInvalidSchema(ctx, schemaFile.Path, sourceText, ex.Message);
+				return;
+			}
 
 			// Derive namespace from the consuming project's assembly name.
 			// CSDevKit → CSDevKit.Contracts.DataModel (its existing brokered DTO convention)
 			// ProjectData reader/tasks → their root namespace
 			string assemblyName = compilation.AssemblyName ?? "";
-			string ns = assemblyName switch
+			string namespaceName = assemblyName switch
 			{
 				"CSDevKit" => "CSDevKit.Contracts.DataModel",
 				_ => assemblyName,
 			};
 
-			ctx.AddSource("ProjectProperties.g.cs", GeneratorSourceText.From(GenerateProjectProperties(schema, ns)));
-			ctx.AddSource("ProjectItems.g.cs", GeneratorSourceText.From(GenerateProjectItems(schema, ns)));
+			ctx.AddSource("ProjectProperties.g.cs", GeneratorSourceText.From(GenerateProjectProperties(schema, namespaceName)));
+			ctx.AddSource("ProjectItems.g.cs", GeneratorSourceText.From(GenerateProjectItems(schema, namespaceName)));
 
 			// Wire-format constants for the on-disk .lscache file. Emitted into the same
 			// namespace as the other generated constants so the writer and reader can
 			// reference a single source of truth and a rename cannot silently drop a
 			// section.
-			ctx.AddSource("CacheFormat.g.cs", GeneratorSourceText.From(GenerateCacheFormat(schema, ns)));
-			ctx.AddSource("PathSentinels.g.cs", GeneratorSourceText.From(GeneratePathSentinels(schema.PathSentinels, ns)));
+			ctx.AddSource("CacheFormat.g.cs", GeneratorSourceText.From(GenerateCacheFormat(schema, namespaceName)));
+			ctx.AddSource("PathSentinels.g.cs", GeneratorSourceText.From(GeneratePathSentinels(schema.PathSentinels, namespaceName)));
 
 			// Only emit TypedProperties when the consuming project has KeyValueCollection;
 			// the generated accessors cannot compile without the immutable model types.
 			bool hasKeyValueCollection = compilation.GetTypeByMetadataName(
-				$"{ns}.KeyValueCollection") is not null;
+				$"{namespaceName}.KeyValueCollection") is not null;
 			if (hasKeyValueCollection)
 			{
-				ctx.AddSource("TypedProperties.g.cs", GeneratorSourceText.From(GenerateTypedProperties(schema, ns)));
+				ctx.AddSource("TypedProperties.g.cs", GeneratorSourceText.From(GenerateTypedProperties(schema, namespaceName)));
 			}
 		});
 	}
 
-	private static PropertyDef ParseProperty(JsonElement p)
+	private static void ReportInvalidSchema(SourceProductionContext context, string path, SourceText? sourceText, string detail)
 	{
-		string name = p.GetProperty("name").GetString()!;
-		string description = p.TryGetProperty("description", out JsonElement d) ? d.GetString() ?? "" : "";
-		return new(name, description);
+		Location location = sourceText is null
+			? Location.None
+			: Location.Create(
+				path,
+				new TextSpan(0, 0),
+				new LinePositionSpan(new LinePosition(0, 0), new LinePosition(0, 0)));
+		context.ReportDiagnostic(Diagnostic.Create(InvalidSchema, location, path, detail));
 	}
 
-	private static Schema? ParseSchema(string json)
+	private static Schema ParseSchema(string json)
 	{
-		try
+		using JsonDocument document = JsonDocument.Parse(json);
+		JsonElement schemaRoot = RequireKind(document.RootElement, JsonValueKind.Object, "the schema root");
+		ValidateNoDuplicateFields(schemaRoot, "the schema root");
+
+		JsonElement propertiesElement = RequireProperty(schemaRoot, "properties", JsonValueKind.Object);
+		ValidateNoDuplicateFields(propertiesElement, "'properties'");
+		JsonElement requiredPropertiesElement = RequireProperty(propertiesElement, "required", JsonValueKind.Array, "properties");
+		JsonElement optionalPropertiesElement = RequireProperty(propertiesElement, "optional", JsonValueKind.Array, "properties");
+
+		HashSet<string> propertyNames = new(StringComparer.OrdinalIgnoreCase);
+		List<PropertyDef> requiredProperties = ParseProperties(requiredPropertiesElement, "properties.required", propertyNames);
+		List<PropertyDef> optionalProperties = ParseProperties(optionalPropertiesElement, "properties.optional", propertyNames);
+		if (requiredProperties.Count == 0 && optionalProperties.Count == 0)
+			throw Invalid("Field 'properties' must define at least one property.");
+
+		JsonElement itemsElement = RequireProperty(schemaRoot, "items", JsonValueKind.Object);
+		ValidateNoDuplicateFields(itemsElement, "'items'");
+		List<ItemDef> items = ParseItems(itemsElement);
+		HashSet<string> itemNames = new(items.Select(static item => item.Name), StringComparer.Ordinal);
+
+		JsonElement cacheFormatElement = RequireProperty(schemaRoot, "cacheFormat", JsonValueKind.Object);
+		ValidateNoDuplicateFields(cacheFormatElement, "'cacheFormat'");
+		CacheFormatDef cacheFormat = ParseCacheFormat(cacheFormatElement, itemNames);
+
+		JsonElement pathSentinelsElement = RequireProperty(schemaRoot, "pathSentinels", JsonValueKind.Object);
+		ValidateNoDuplicateFields(pathSentinelsElement, "'pathSentinels'");
+		PathSentinelsDef pathSentinels = ParsePathSentinels(pathSentinelsElement);
+
+		return new(requiredProperties, optionalProperties, items, cacheFormat, pathSentinels);
+	}
+
+	private static List<PropertyDef> ParseProperties(JsonElement properties, string path, HashSet<string> propertyNames)
+	{
+		List<PropertyDef> result = [];
+		int index = 0;
+		foreach (JsonElement property in properties.EnumerateArray())
 		{
-			using JsonDocument doc = JsonDocument.Parse(json);
-			JsonElement root = doc.RootElement;
+			string propertyPath = $"{path}[{index}]";
+			RequireKind(property, JsonValueKind.Object, $"field '{propertyPath}'");
+			ValidateNoDuplicateFields(property, $"field '{propertyPath}'");
 
-			List<PropertyDef> required = [];
-			List<PropertyDef> optional = [];
+			string name = RequireIdentifier(property, "name", propertyPath);
+			if (name is "ProjectProperties" or "Required" or "All" or "TypedProperties" or "inner")
+				throw Invalid($"Field '{propertyPath}.name' cannot be '{name}' because that name is reserved by the generated ProjectProperties or TypedProperties type.");
+			if (!propertyNames.Add(name))
+				throw Invalid($"Property name '{name}' is duplicated across 'properties.required' and 'properties.optional'.");
 
-			if (root.TryGetProperty("properties", out JsonElement propsEl))
-			{
-				if (propsEl.TryGetProperty("required", out JsonElement reqEl))
-					foreach (JsonElement p in reqEl.EnumerateArray())
-						required.Add(ParseProperty(p));
-				if (propsEl.TryGetProperty("optional", out JsonElement optEl))
-					foreach (JsonElement p in optEl.EnumerateArray())
-						optional.Add(ParseProperty(p));
-			}
-
-			List<ItemDef> items = [];
-			if (root.TryGetProperty("items", out JsonElement itemsEl))
-			{
-				foreach (JsonProperty item in itemsEl.EnumerateObject())
-				{
-					string desc = item.Value.TryGetProperty("description", out JsonElement descEl) ? descEl.GetString() ?? "" : "";
-					bool isRequired = item.Value.TryGetProperty("required", out JsonElement reqEl) && reqEl.GetBoolean();
-					List<string> metadata = [];
-					if (item.Value.TryGetProperty("metadata", out JsonElement metaEl))
-						foreach (JsonElement m in metaEl.EnumerateArray())
-							metadata.Add(m.GetString()!);
-					items.Add(new(item.Name, desc, isRequired, metadata));
-				}
-			}
-
-			CacheFormatDef? cacheFormat = null;
-			if (root.TryGetProperty("cacheFormat", out JsonElement cacheFormatEl))
-			{
-				List<SectionDef> sections = [];
-				if (cacheFormatEl.TryGetProperty("sections", out JsonElement sectionsEl))
-				{
-					foreach (JsonElement section in sectionsEl.EnumerateArray())
-					{
-						sections.Add(new(
-							section.GetProperty("name").GetString()!,
-							section.TryGetProperty("description", out JsonElement secDescEl) ? secDescEl.GetString() ?? "" : "",
-							section.TryGetProperty("itemType", out JsonElement secItemEl) ? secItemEl.GetString() : null));
-					}
-				}
-
-				cacheFormat = new(
-					VersionHeader: GetStringOrEmpty(cacheFormatEl, "versionHeader"),
-					HashHeaderPrefix: GetStringOrEmpty(cacheFormatEl, "hashHeaderPrefix"),
-					SliceSeparator: GetStringOrEmpty(cacheFormatEl, "sliceSeparator"),
-					SectionOpen: GetStringOrEmpty(cacheFormatEl, "sectionOpen"),
-					SectionClose: GetStringOrEmpty(cacheFormatEl, "sectionClose"),
-					CommentChar: GetStringOrEmpty(cacheFormatEl, "commentChar"),
-					ProjectHeaderPrefix: GetStringOrEmpty(cacheFormatEl, "projectHeaderPrefix"),
-					LanguagePrefix: GetStringOrEmpty(cacheFormatEl, "languagePrefix"),
-					PrimaryMarker: GetStringOrEmpty(cacheFormatEl, "primaryMarker"),
-					LastDtbSucceededMarker: GetStringOrEmpty(cacheFormatEl, "lastDtbSucceededMarker"),
-					Sections: sections);
-			}
-
-			PathSentinelsDef? pathSentinels = null;
-			if (root.TryGetProperty("pathSentinels", out JsonElement sentinelsEl))
-			{
-				List<(string Name, string Value)> entries = [];
-				foreach (JsonProperty entry in sentinelsEl.EnumerateObject())
-				{
-					if (entry.Name.StartsWith("$", StringComparison.Ordinal))
-						continue;
-					if (entry.Value.ValueKind != JsonValueKind.String)
-						continue;
-					entries.Add((entry.Name, entry.Value.GetString()!));
-				}
-				pathSentinels = new(entries);
-			}
-
-			return new(required, optional, items,
-				cacheFormat ?? throw new InvalidOperationException("Schema is missing required 'cacheFormat' block."),
-				pathSentinels ?? throw new InvalidOperationException("Schema is missing required 'pathSentinels' block."));
+			_ = GetOptionalNonEmptyString(property, "value", propertyPath);
+			result.Add(new(name, GetOptionalDescription(property, propertyPath)));
+			index++;
 		}
-		catch
+
+		return result;
+	}
+
+	private static List<ItemDef> ParseItems(JsonElement itemsElement)
+	{
+		List<ItemDef> items = [];
+		HashSet<string> generatedNames = new(StringComparer.OrdinalIgnoreCase);
+		foreach (JsonProperty item in itemsElement.EnumerateObject())
 		{
+			string itemPath = $"items.{item.Name}";
+			ValidateIdentifier(item.Name, "Item name");
+			if (item.Name is "ProjectItems" or "AllItemTypes" or "RequiredItemTypes" or "AllMetadata" or "MetadataByItemType")
+				throw Invalid($"Item name '{item.Name}' is reserved by the generated ProjectItems type.");
+			if (!generatedNames.Add(item.Name))
+				throw Invalid($"Item name '{item.Name}' is duplicated.");
+
+			RequireKind(item.Value, JsonValueKind.Object, $"field '{itemPath}'");
+			ValidateNoDuplicateFields(item.Value, $"field '{itemPath}'");
+
+			bool isRequired = GetOptionalBoolean(item.Value, "required", itemPath);
+			List<string> metadata = GetOptionalMetadata(item.Value, itemPath, item.Name);
+			items.Add(new(item.Name, GetOptionalDescription(item.Value, itemPath), isRequired, metadata));
+		}
+
+		if (items.Count == 0)
+			throw Invalid("Field 'items' must define at least one item.");
+
+		return items;
+	}
+
+	private static List<string> GetOptionalMetadata(JsonElement item, string itemPath, string itemName)
+	{
+		if (!item.TryGetProperty("metadata", out JsonElement metadataElement))
+			return [];
+
+		RequireKind(metadataElement, JsonValueKind.Array, $"field '{itemPath}.metadata'");
+		List<string> metadata = [];
+		HashSet<string> metadataNames = new(StringComparer.OrdinalIgnoreCase);
+		HashSet<string> generatedNames = new(StringComparer.Ordinal) { "ItemType", itemName };
+		int index = 0;
+		foreach (JsonElement value in metadataElement.EnumerateArray())
+		{
+			string path = $"{itemPath}.metadata[{index}]";
+			string name = RequireNonEmptyString(value, path);
+			if (!metadataNames.Add(name))
+				throw Invalid($"Metadata name '{name}' is duplicated in field '{itemPath}.metadata'.");
+
+			string generatedName = PascalCase(name);
+			ValidateIdentifier(generatedName, $"Field '{path}'");
+			if (!generatedNames.Add(generatedName))
+				throw Invalid($"Field '{path}' produces duplicate generated member name '{generatedName}'.");
+
+			metadata.Add(name);
+			index++;
+		}
+
+		return metadata;
+	}
+
+	private static CacheFormatDef ParseCacheFormat(JsonElement cacheFormat, HashSet<string> itemNames)
+	{
+		string versionHeader = RequireToken(cacheFormat, "versionHeader", "cacheFormat");
+		if (!IsValidVersionHeader(versionHeader))
+			throw Invalid("Field 'cacheFormat.versionHeader' must have the form 'version=<major>[.<minor>]' using non-negative integers.");
+
+		string hashHeaderPrefix = RequireToken(cacheFormat, "hashHeaderPrefix", "cacheFormat");
+		string sliceSeparator = RequireToken(cacheFormat, "sliceSeparator", "cacheFormat");
+		string sectionOpen = RequireToken(cacheFormat, "sectionOpen", "cacheFormat");
+		string sectionClose = RequireToken(cacheFormat, "sectionClose", "cacheFormat");
+		string commentChar = RequireToken(cacheFormat, "commentChar", "cacheFormat");
+		if (commentChar.Length != 1)
+			throw Invalid("Field 'cacheFormat.commentChar' must contain exactly one character.");
+
+		string projectHeaderPrefix = RequireToken(cacheFormat, "projectHeaderPrefix", "cacheFormat");
+		string languagePrefix = RequireToken(cacheFormat, "languagePrefix", "cacheFormat");
+		string primaryMarker = RequireToken(cacheFormat, "primaryMarker", "cacheFormat");
+		string lastDtbSucceededMarker = RequireToken(cacheFormat, "lastDtbSucceededMarker", "cacheFormat");
+
+		if (sectionOpen == sectionClose)
+			throw Invalid("Fields 'cacheFormat.sectionOpen' and 'cacheFormat.sectionClose' must be different.");
+		if (projectHeaderPrefix == languagePrefix)
+			throw Invalid("Fields 'cacheFormat.projectHeaderPrefix' and 'cacheFormat.languagePrefix' must be different.");
+		if (primaryMarker == lastDtbSucceededMarker)
+			throw Invalid("Fields 'cacheFormat.primaryMarker' and 'cacheFormat.lastDtbSucceededMarker' must be different.");
+
+		JsonElement sectionsElement = RequireProperty(cacheFormat, "sections", JsonValueKind.Array, "cacheFormat");
+		List<SectionDef> sections = [];
+		HashSet<string> sectionNames = new(StringComparer.Ordinal);
+		HashSet<string> generatedNames = new(StringComparer.Ordinal) { "Sections", "All", "MetadataBySection" };
+		int index = 0;
+		foreach (JsonElement section in sectionsElement.EnumerateArray())
+		{
+			string sectionPath = $"cacheFormat.sections[{index}]";
+			RequireKind(section, JsonValueKind.Object, $"field '{sectionPath}'");
+			ValidateNoDuplicateFields(section, $"field '{sectionPath}'");
+
+			string name = RequireToken(section, "name", sectionPath);
+			ValidateIdentifier(PascalCase(name), $"Field '{sectionPath}.name'");
+			if (!sectionNames.Add(name))
+				throw Invalid($"Section name '{name}' is duplicated in field 'cacheFormat.sections'.");
+
+			string generatedName = PascalCase(name);
+			if (!generatedNames.Add(generatedName))
+				throw Invalid($"Field '{sectionPath}.name' produces duplicate generated member name '{generatedName}'.");
+
+			string? itemType = GetOptionalNonEmptyString(section, "itemType", sectionPath);
+			if (itemType is not null && !itemNames.Contains(itemType))
+				throw Invalid($"Field '{sectionPath}.itemType' references unknown item type '{itemType}'.");
+
+			sections.Add(new(name, GetOptionalDescription(section, sectionPath), itemType));
+			index++;
+		}
+
+		if (sections.Count == 0)
+			throw Invalid("Field 'cacheFormat.sections' must define at least one section.");
+
+		return new(
+			versionHeader,
+			hashHeaderPrefix,
+			sliceSeparator,
+			sectionOpen,
+			sectionClose,
+			commentChar,
+			projectHeaderPrefix,
+			languagePrefix,
+			primaryMarker,
+			lastDtbSucceededMarker,
+			sections);
+	}
+
+	private static PathSentinelsDef ParsePathSentinels(JsonElement pathSentinels)
+	{
+		List<(string Name, string Value)> entries = [];
+		HashSet<string> generatedNames = new(StringComparer.Ordinal) { "PathSentinels" };
+		HashSet<string> values = new(StringComparer.Ordinal);
+		foreach (JsonProperty entry in pathSentinels.EnumerateObject())
+		{
+			if (entry.Name.StartsWith("$", StringComparison.Ordinal))
+				continue;
+
+			ValidateIdentifier(PascalCase(entry.Name), "Path sentinel name");
+			string generatedName = PascalCase(entry.Name);
+			if (!generatedNames.Add(generatedName))
+				throw Invalid($"Path sentinel name '{entry.Name}' produces duplicate generated member name '{generatedName}'.");
+
+			string value = RequireNonEmptyString(entry.Value, $"pathSentinels.{entry.Name}");
+			ValidateToken(value, $"Field 'pathSentinels.{entry.Name}'");
+			if (!values.Add(value))
+				throw Invalid($"Path sentinel value '{value}' is duplicated.");
+
+			entries.Add((entry.Name, value));
+		}
+
+		if (entries.Count == 0)
+			throw Invalid("Field 'pathSentinels' must define at least one sentinel.");
+
+		return new(entries);
+	}
+
+	private static JsonElement RequireProperty(JsonElement parent, string name, JsonValueKind kind, string? parentPath = null)
+	{
+		string path = string.IsNullOrEmpty(parentPath) ? name : $"{parentPath}.{name}";
+		if (!parent.TryGetProperty(name, out JsonElement value))
+			throw Invalid($"Required field '{path}' is missing.");
+
+		return RequireKind(value, kind, $"field '{path}'");
+	}
+
+	private static JsonElement RequireKind(JsonElement value, JsonValueKind kind, string subject)
+	{
+		if (value.ValueKind != kind)
+			throw Invalid($"{char.ToUpperInvariant(subject[0]) + subject.Substring(1)} must be a JSON {GetJsonKindName(kind)}, but found {GetJsonKindName(value.ValueKind)}.");
+		return value;
+	}
+
+	private static string RequireIdentifier(JsonElement parent, string name, string parentPath)
+	{
+		string path = $"{parentPath}.{name}";
+		string value = RequireToken(parent, name, parentPath);
+		ValidateIdentifier(value, $"Field '{path}'");
+		return value;
+	}
+
+	private static string RequireToken(JsonElement parent, string name, string parentPath)
+	{
+		string path = $"{parentPath}.{name}";
+		JsonElement value = RequireProperty(parent, name, JsonValueKind.String, parentPath);
+		string result = RequireNonEmptyString(value, path);
+		ValidateToken(result, $"Field '{path}'");
+		return result;
+	}
+
+	private static string RequireNonEmptyString(JsonElement value, string path)
+	{
+		RequireKind(value, JsonValueKind.String, $"field '{path}'");
+		string? result = value.GetString();
+		if (string.IsNullOrWhiteSpace(result))
+			throw Invalid($"Field '{path}' must be a non-empty string.");
+		return result!;
+	}
+
+	private static string? GetOptionalNonEmptyString(JsonElement parent, string name, string parentPath)
+	{
+		if (!parent.TryGetProperty(name, out JsonElement value))
 			return null;
+
+		string path = $"{parentPath}.{name}";
+		string result = RequireNonEmptyString(value, path);
+		ValidateToken(result, $"Field '{path}'");
+		return result;
+	}
+
+	private static string GetOptionalDescription(JsonElement parent, string parentPath)
+	{
+		if (!parent.TryGetProperty("description", out JsonElement value))
+			return "";
+
+		string path = $"{parentPath}.description";
+		RequireKind(value, JsonValueKind.String, $"field '{path}'");
+		string description = value.GetString()!;
+		if (description.IndexOf('\r') >= 0 || description.IndexOf('\n') >= 0)
+			throw Invalid($"Field '{path}' cannot contain line breaks.");
+		ValidateToken(description, $"Field '{path}'");
+		return description;
+	}
+
+	private static bool GetOptionalBoolean(JsonElement parent, string name, string parentPath)
+	{
+		if (!parent.TryGetProperty(name, out JsonElement value))
+			return false;
+
+		string path = $"{parentPath}.{name}";
+		RequireKind(value, JsonValueKind.True, $"field '{path}'", JsonValueKind.False);
+		return value.GetBoolean();
+	}
+
+	private static JsonElement RequireKind(JsonElement value, JsonValueKind firstKind, string subject, JsonValueKind secondKind)
+	{
+		if (value.ValueKind != firstKind && value.ValueKind != secondKind)
+			throw Invalid($"{char.ToUpperInvariant(subject[0]) + subject.Substring(1)} must be a JSON boolean, but found {GetJsonKindName(value.ValueKind)}.");
+		return value;
+	}
+
+	private static void ValidateNoDuplicateFields(JsonElement element, string subject)
+	{
+		HashSet<string> names = new(StringComparer.Ordinal);
+		foreach (JsonProperty property in element.EnumerateObject())
+		{
+			if (!names.Add(property.Name))
+				throw Invalid($"{char.ToUpperInvariant(subject[0]) + subject.Substring(1)} contains duplicate field '{property.Name}'.");
 		}
 	}
 
-	private static string GenerateProjectProperties(Schema schema, string ns)
+	private static void ValidateIdentifier(string value, string subject)
+	{
+		if (string.IsNullOrWhiteSpace(value)
+			|| !IsIdentifierStart(value[0])
+			|| value.Skip(1).Any(static c => !IsIdentifierPart(c))
+			|| IsReservedKeyword(value))
+			throw Invalid($"{subject} must be a valid, non-keyword C# identifier, but found '{value}'.");
+	}
+
+	private static bool IsIdentifierStart(char value)
+		=> value == '_' || char.GetUnicodeCategory(value) is
+			UnicodeCategory.UppercaseLetter or
+			UnicodeCategory.LowercaseLetter or
+			UnicodeCategory.TitlecaseLetter or
+			UnicodeCategory.ModifierLetter or
+			UnicodeCategory.OtherLetter or
+			UnicodeCategory.LetterNumber;
+
+	private static bool IsIdentifierPart(char value)
+		=> IsIdentifierStart(value) || char.GetUnicodeCategory(value) is
+			UnicodeCategory.DecimalDigitNumber or
+			UnicodeCategory.ConnectorPunctuation or
+			UnicodeCategory.SpacingCombiningMark or
+			UnicodeCategory.NonSpacingMark or
+			UnicodeCategory.Format;
+
+	private static bool IsReservedKeyword(string value)
+		=> value is
+			"abstract" or "as" or "base" or "bool" or "break" or "byte" or
+			"case" or "catch" or "char" or "checked" or "class" or "const" or "continue" or
+			"decimal" or "default" or "delegate" or "do" or "double" or
+			"else" or "enum" or "event" or "explicit" or "extern" or
+			"false" or "finally" or "fixed" or "float" or "for" or "foreach" or
+			"goto" or "if" or "implicit" or "in" or "int" or "interface" or "internal" or "is" or
+			"lock" or "long" or "namespace" or "new" or "null" or "object" or "operator" or "out" or "override" or
+			"params" or "private" or "protected" or "public" or "readonly" or "ref" or "return" or
+			"sbyte" or "sealed" or "short" or "sizeof" or "stackalloc" or "static" or "string" or "struct" or "switch" or
+			"this" or "throw" or "true" or "try" or "typeof" or "uint" or "ulong" or "unchecked" or "unsafe" or "ushort" or "using" or
+			"virtual" or "void" or "volatile" or "while";
+
+	private static void ValidateToken(string value, string subject)
+	{
+		foreach (char c in value)
+		{
+			if (char.IsControl(c) || c is '\u2028' or '\u2029')
+				throw Invalid($"{subject} cannot contain control characters or Unicode line separators.");
+		}
+	}
+
+	private static bool IsValidVersionHeader(string value)
+	{
+		const string Prefix = "version=";
+		if (!value.StartsWith(Prefix, StringComparison.Ordinal))
+			return false;
+
+		ReadOnlySpan<char> version = value.AsSpan(Prefix.Length);
+		int separator = version.IndexOf('.');
+		if (separator < 0)
+			return TryParseNonNegativeInteger(version);
+		if (separator == 0 || separator == version.Length - 1 || version.Slice(separator + 1).IndexOf('.') >= 0)
+			return false;
+		return TryParseNonNegativeInteger(version.Slice(0, separator))
+			&& TryParseNonNegativeInteger(version.Slice(separator + 1));
+	}
+
+	private static bool TryParseNonNegativeInteger(ReadOnlySpan<char> value)
+	{
+		if (value.Length == 0)
+			return false;
+		foreach (char c in value)
+		{
+			if (c is < '0' or > '9')
+				return false;
+		}
+		return int.TryParse(value.ToString(), NumberStyles.None, CultureInfo.InvariantCulture, out _);
+	}
+
+	private static string GetJsonKindName(JsonValueKind kind)
+		=> kind switch
+		{
+			JsonValueKind.Object => "object",
+			JsonValueKind.Array => "array",
+			JsonValueKind.String => "string",
+			JsonValueKind.Number => "number",
+			JsonValueKind.True or JsonValueKind.False => "boolean",
+			JsonValueKind.Null => "null",
+			JsonValueKind.Undefined => "undefined value",
+			_ => kind.ToString(),
+		};
+
+	private static SchemaValidationException Invalid(string message) => new(message);
+
+	private static string GenerateProjectProperties(Schema schema, string namespaceName)
 	{
 		StringBuilder sb = new();
-		sb.AppendLine("// <auto-generated/>");
-		sb.AppendLine("// Generated from project-data-schema.json by DataModelSchemaGenerator.");
-		sb.AppendLine();
-		sb.AppendLine($"namespace {ns};");
-		sb.AppendLine();
-		sb.AppendLine("/// <summary>Strongly-typed constants for all Data Model property names.</summary>");
-		sb.AppendLine("internal static class ProjectProperties");
-		sb.AppendLine("{");
+		AppendLines(
+			sb,
+			$$"""
+			// <auto-generated/>
+			// Generated from project-data-schema.json by DataModelSchemaGenerator.
 
-		foreach (PropertyDef p in schema.Required)
+			namespace {{namespaceName}};
+
+			/// <summary>Strongly-typed constants for all Data Model property names.</summary>
+			internal static class ProjectProperties
+			{
+			""");
+
+		foreach (PropertyDef property in schema.Required)
 		{
-			sb.AppendLine($"\t/// <summary>{EscapeXml(p.Description)}</summary>");
-			sb.AppendLine($"\tpublic const string {p.Name} = \"{p.Name}\";");
+			sb.AppendLine($"\t/// <summary>{EscapeXml(property.Description)}</summary>");
+			sb.AppendLine($"\tpublic const string {property.Name} = \"{property.Name}\";");
 		}
 		sb.AppendLine();
-		foreach (PropertyDef p in schema.Optional)
+		foreach (PropertyDef property in schema.Optional)
 		{
-			sb.AppendLine($"\t/// <summary>{EscapeXml(p.Description)}</summary>");
-			sb.AppendLine($"\tpublic const string {p.Name} = \"{p.Name}\";");
+			sb.AppendLine($"\t/// <summary>{EscapeXml(property.Description)}</summary>");
+			sb.AppendLine($"\tpublic const string {property.Name} = \"{property.Name}\";");
 		}
 
 		sb.AppendLine();
 		sb.Append("\tpublic static readonly string[] Required = [");
-		sb.Append(string.Join(", ", schema.Required.Select(p => $"\"{p.Name}\"")));
+		sb.Append(string.Join(", ", schema.Required.Select(static property => $"\"{property.Name}\"")));
 		sb.AppendLine("];");
 
 		sb.AppendLine();
-		sb.AppendLine("\t/// <summary>");
-		sb.AppendLine("\t/// All Data Model property names. Every property is exported into the cache file's");
-		sb.AppendLine("\t/// <c>[properties]</c> section by the writer (the generated <c>_ProjectDataProperties</c>");
-		sb.AppendLine("\t/// MSBuild allow-list is the same set). This is also the forward-compatibility");
-		sb.AppendLine("\t/// \"known [properties] key\" set: a key NOT listed here is treated as data authored by a");
-		sb.AppendLine("\t/// newer writer and preserved losslessly rather than dropped.");
-		sb.AppendLine("\t/// </summary>");
+		AppendLines(
+			sb,
+			"""
+				/// <summary>
+				/// All Data Model property names. Every property is exported into the cache file's
+				/// <c>[properties]</c> section by the writer (the generated <c>_ProjectDataProperties</c>
+				/// MSBuild allow-list is the same set). This is also the forward-compatibility
+				/// "known [properties] key" set: a key NOT listed here is treated as data authored by a
+				/// newer writer and preserved losslessly rather than dropped.
+				/// </summary>
+			""");
 		sb.Append("\tpublic static readonly string[] All = [");
-		sb.Append(string.Join(", ", schema.Required.Concat(schema.Optional).Select(p => $"\"{p.Name}\"")));
+		sb.Append(string.Join(", ", schema.Required.Concat(schema.Optional).Select(static property => $"\"{property.Name}\"")));
 		sb.AppendLine("];");
 
 		sb.AppendLine("}");
 		return sb.ToString();
 	}
 
-	private static string GenerateProjectItems(Schema schema, string ns)
+	private static string GenerateProjectItems(Schema schema, string namespaceName)
 	{
 		StringBuilder sb = new();
-		sb.AppendLine("// <auto-generated/>");
-		sb.AppendLine("// Generated from project-data-schema.json by DataModelSchemaGenerator.");
-		sb.AppendLine();
-		sb.AppendLine("using System.Collections.Generic;");
-		sb.AppendLine();
-		sb.AppendLine($"namespace {ns};");
-		sb.AppendLine();
-		sb.AppendLine("/// <summary>Strongly-typed constants for Data Model item types and metadata.</summary>");
-		sb.AppendLine("internal static class ProjectItems");
-		sb.AppendLine("{");
+		AppendLines(
+			sb,
+			$$"""
+			// <auto-generated/>
+			// Generated from project-data-schema.json by DataModelSchemaGenerator.
+
+			using System.Collections.Generic;
+
+			namespace {{namespaceName}};
+
+			/// <summary>Strongly-typed constants for Data Model item types and metadata.</summary>
+			internal static class ProjectItems
+			{
+			""");
 
 		foreach (ItemDef item in schema.Items)
 		{
@@ -245,49 +618,57 @@ public sealed class DataModelSchemaGenerator : IIncrementalGenerator
 				sb.AppendLine($"\tpublic static class {item.Name}");
 				sb.AppendLine("\t{");
 				sb.AppendLine($"\t\tpublic const string ItemType = \"{item.Name}\";");
-				foreach (string meta in item.Metadata)
-					sb.AppendLine($"\t\tpublic const string {char.ToUpperInvariant(meta[0]) + meta.Substring(1)} = \"{meta}\";");
+				foreach (string metadataName in item.Metadata)
+					sb.AppendLine($"\t\tpublic const string {char.ToUpperInvariant(metadataName[0]) + metadataName.Substring(1)} = \"{metadataName}\";");
 				sb.AppendLine("\t}");
 			}
 			sb.AppendLine();
 		}
 
 		sb.Append("\tpublic static readonly string[] AllItemTypes = [");
-		sb.Append(string.Join(", ", schema.Items.Select(i => $"\"{i.Name}\"")));
+		sb.Append(string.Join(", ", schema.Items.Select(static item => $"\"{item.Name}\"")));
 		sb.AppendLine("];");
 
 		sb.AppendLine();
 		sb.AppendLine("\t/// <summary>Item types that must be present (even if empty) in every valid snapshot.</summary>");
 		sb.Append("\tpublic static readonly string[] RequiredItemTypes = [");
-		sb.Append(string.Join(", ", schema.Items.Where(i => i.IsRequired).Select(i => $"\"{i.Name}\"")));
+		sb.Append(string.Join(", ", schema.Items.Where(static item => item.IsRequired).Select(static item => $"\"{item.Name}\"")));
 		sb.AppendLine("];");
 
 		sb.AppendLine();
-		sb.AppendLine("\t/// <summary>");
-		sb.AppendLine("\t/// Every metadata key the writer can emit on any item (the union across all item");
-		sb.AppendLine("\t/// types). Used by forward-compatibility preservation to tell a known <c>@metadata</c>");
-		sb.AppendLine("\t/// line from one written by a newer version that must be carried through losslessly.");
-		sb.AppendLine("\t/// </summary>");
+		AppendLines(
+			sb,
+			"""
+				/// <summary>
+				/// Every metadata key the writer can emit on any item (the union across all item
+				/// types). Used by forward-compatibility preservation to tell a known <c>@metadata</c>
+				/// line from one written by a newer version that must be carried through losslessly.
+				/// </summary>
+			""");
 		sb.Append("\tpublic static readonly string[] AllMetadata = [");
 		sb.Append(string.Join(", ", schema.Items
-			.SelectMany(i => i.Metadata)
+			.SelectMany(static item => item.Metadata)
 			.Distinct(StringComparer.Ordinal)
-			.Select(m => $"\"{m}\"")));
+			.Select(static metadataName => $"\"{metadataName}\"")));
 		sb.AppendLine("];");
 
 		sb.AppendLine();
-		sb.AppendLine("\t/// <summary>");
-		sb.AppendLine("\t/// Metadata keys the writer can emit, grouped by the item type that carries them (NOT a");
-		sb.AppendLine("\t/// flattened union). Forward-compatibility preservation uses this to decide what is");
-		sb.AppendLine("\t/// \"known\" <em>per item type</em>, so a newer version that reuses an existing metadata");
-		sb.AppendLine("\t/// name on a different item type is still treated as unknown and carried through losslessly.");
-		sb.AppendLine("\t/// </summary>");
-		sb.AppendLine("\tpublic static readonly Dictionary<string, string[]> MetadataByItemType = new(System.StringComparer.Ordinal)");
-		sb.AppendLine("\t{");
-		foreach (ItemDef item in schema.Items.Where(i => i.Metadata.Count > 0))
+		AppendLines(
+			sb,
+			"""
+				/// <summary>
+				/// Metadata keys the writer can emit, grouped by the item type that carries them (NOT a
+				/// flattened union). Forward-compatibility preservation uses this to decide what is
+				/// "known" <em>per item type</em>, so a newer version that reuses an existing metadata
+				/// name on a different item type is still treated as unknown and carried through losslessly.
+				/// </summary>
+				public static readonly Dictionary<string, string[]> MetadataByItemType = new(System.StringComparer.Ordinal)
+				{
+			""");
+		foreach (ItemDef item in schema.Items.Where(static item => item.Metadata.Count > 0))
 		{
-			string metas = string.Join(", ", item.Metadata.Select(m => $"\"{m}\""));
-			sb.AppendLine($"\t\t[\"{item.Name}\"] = [{metas}],");
+			string metadataValues = string.Join(", ", item.Metadata.Select(static metadataName => $"\"{metadataName}\""));
+			sb.AppendLine($"\t\t[\"{item.Name}\"] = [{metadataValues}],");
 		}
 
 		sb.AppendLine("\t};");
@@ -296,52 +677,65 @@ public sealed class DataModelSchemaGenerator : IIncrementalGenerator
 		return sb.ToString();
 	}
 
-	private static string GenerateTypedProperties(Schema schema, string ns)
+	private static string GenerateTypedProperties(Schema schema, string namespaceName)
 	{
 		StringBuilder sb = new();
-		sb.AppendLine("// <auto-generated/>");
-		sb.AppendLine("#nullable enable");
-		sb.AppendLine("// Generated from project-data-schema.json by DataModelSchemaGenerator.");
-		sb.AppendLine();
-		sb.AppendLine("using System;");
-		sb.AppendLine();
-		sb.AppendLine($"namespace {ns};");
-		sb.AppendLine();
-		sb.AppendLine("/// <summary>Strongly-typed accessor over <see cref=\"KeyValueCollection\"/>.</summary>");
-		sb.AppendLine("internal readonly ref struct TypedProperties");
-		sb.AppendLine("{");
-		sb.AppendLine("\tprivate readonly KeyValueCollection inner;");
-		sb.AppendLine("\tpublic TypedProperties(KeyValueCollection inner) => this.inner = inner;");
-		sb.AppendLine();
+		AppendLines(
+			sb,
+			$$"""
+			// <auto-generated/>
+			#nullable enable
+			// Generated from project-data-schema.json by DataModelSchemaGenerator.
 
-		foreach (PropertyDef p in schema.Required)
+			using System;
+
+			namespace {{namespaceName}};
+
+			/// <summary>Strongly-typed accessor over <see cref="KeyValueCollection"/>.</summary>
+			internal readonly ref struct TypedProperties
+			{
+				private readonly KeyValueCollection inner;
+				public TypedProperties(KeyValueCollection inner) => this.inner = inner;
+
+			""");
+
+		foreach (PropertyDef property in schema.Required)
 		{
-			sb.AppendLine($"\t/// <summary>{EscapeXml(p.Description)}</summary>");
-			sb.AppendLine($"\tpublic string {p.Name} => this.inner[ProjectProperties.{p.Name}] ?? throw new InvalidOperationException(\"Required Data Model property '\" + ProjectProperties.{p.Name} + \"' is missing. The .lscache file may be incomplete or the property merge failed.\");");
+			sb.AppendLine($"\t/// <summary>{EscapeXml(property.Description)}</summary>");
+			sb.AppendLine($"\tpublic string {property.Name} => this.inner[ProjectProperties.{property.Name}] ?? throw new InvalidOperationException(\"Required Data Model property '\" + ProjectProperties.{property.Name} + \"' is missing. The .lscache file may be incomplete or the property merge failed.\");");
 		}
 		sb.AppendLine();
-		foreach (PropertyDef p in schema.Optional)
+		foreach (PropertyDef property in schema.Optional)
 		{
-			sb.AppendLine($"\t/// <summary>{EscapeXml(p.Description)}</summary>");
-			sb.AppendLine($"\tpublic string? {p.Name} => this.inner[ProjectProperties.{p.Name}];");
+			sb.AppendLine($"\t/// <summary>{EscapeXml(property.Description)}</summary>");
+			sb.AppendLine($"\tpublic string? {property.Name} => this.inner[ProjectProperties.{property.Name}];");
 		}
 
-		sb.AppendLine("}");
-		sb.AppendLine();
-		sb.AppendLine("internal static class TypedPropertiesExtensions");
-		sb.AppendLine("{");
-		sb.AppendLine("\tpublic static TypedProperties Typed(this ProjectDataSnapshot snapshot) => new(snapshot.Properties);");
-		sb.AppendLine("}");
+		AppendLines(
+			sb,
+			"""
+			}
+
+			internal static class TypedPropertiesExtensions
+			{
+				public static TypedProperties Typed(this ProjectDataSnapshot snapshot) => new(snapshot.Properties);
+			}
+			""");
 		return sb.ToString();
 	}
 
 	private static string EscapeXml(string text) => text.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;");
 
-	private static string GetStringOrEmpty(JsonElement el, string name)
-		=> el.TryGetProperty(name, out JsonElement v) && v.ValueKind == JsonValueKind.String ? v.GetString() ?? "" : "";
-
 	private static string EscapeForCSharpString(string value)
 		=> value.Replace("\\", "\\\\").Replace("\"", "\\\"");
+
+	private static string EscapeForCSharpChar(string value)
+		=> value switch
+		{
+			"'" => "\\'",
+			"\\" => "\\\\",
+			_ => value,
+		};
 
 	private static string PascalCase(string name)
 	{
@@ -350,39 +744,46 @@ public sealed class DataModelSchemaGenerator : IIncrementalGenerator
 		return char.ToUpperInvariant(name[0]) + name.Substring(1);
 	}
 
-	private static string GenerateCacheFormat(Schema schema, string ns)
+	private static string GenerateCacheFormat(Schema schema, string namespaceName)
 	{
 		CacheFormatDef cacheFormat = schema.CacheFormat;
 		StringBuilder sb = new();
-		sb.AppendLine("// <auto-generated/>");
-		sb.AppendLine("// Generated from project-data-schema.json by DataModelSchemaGenerator.");
-		sb.AppendLine();
-		sb.AppendLine("using System.Collections.Generic;");
-		sb.AppendLine();
-		sb.AppendLine($"namespace {ns};");
-		sb.AppendLine();
-		sb.AppendLine("/// <summary>");
-		sb.AppendLine("/// Wire-format tokens for the on-disk <c>.lscache</c> file. Shared by the writer");
-		sb.AppendLine("/// (<c>Microsoft.NET.ProjectData.Tasks</c>) and the reader");
-		sb.AppendLine("/// (<c>Microsoft.NET.ProjectData</c>) so renames cannot silently drop a section.");
-		sb.AppendLine("/// </summary>");
-		sb.AppendLine("internal static class CacheFormat");
-		sb.AppendLine("{");
+		AppendLines(
+			sb,
+			$$"""
+			// <auto-generated/>
+			// Generated from project-data-schema.json by DataModelSchemaGenerator.
+
+			using System.Collections.Generic;
+
+			namespace {{namespaceName}};
+
+			/// <summary>
+			/// Wire-format tokens for the on-disk <c>.lscache</c> file. Shared by the writer
+			/// (<c>Microsoft.NET.ProjectData.Tasks</c>) and the reader
+			/// (<c>Microsoft.NET.ProjectData</c>) so renames cannot silently drop a section.
+			/// </summary>
+			internal static class CacheFormat
+			{
+			""");
 		sb.AppendLine($"\tpublic const string VersionHeader = \"{EscapeForCSharpString(cacheFormat.VersionHeader)}\";");
 		sb.AppendLine($"\tpublic const string HashHeaderPrefix = \"{EscapeForCSharpString(cacheFormat.HashHeaderPrefix)}\";");
 		sb.AppendLine($"\tpublic const string SliceSeparator = \"{EscapeForCSharpString(cacheFormat.SliceSeparator)}\";");
 		sb.AppendLine($"\tpublic const string SectionOpen = \"{EscapeForCSharpString(cacheFormat.SectionOpen)}\";");
 		sb.AppendLine($"\tpublic const string SectionClose = \"{EscapeForCSharpString(cacheFormat.SectionClose)}\";");
-		if (cacheFormat.CommentChar.Length == 1)
-			sb.AppendLine($"\tpublic const char CommentChar = '{EscapeForCSharpString(cacheFormat.CommentChar)}';");
+		sb.AppendLine($"\tpublic const char CommentChar = '{EscapeForCSharpChar(cacheFormat.CommentChar)}';");
 		sb.AppendLine($"\tpublic const string ProjectHeaderPrefix = \"{EscapeForCSharpString(cacheFormat.ProjectHeaderPrefix)}\";");
 		sb.AppendLine($"\tpublic const string LanguagePrefix = \"{EscapeForCSharpString(cacheFormat.LanguagePrefix)}\";");
 		sb.AppendLine($"\tpublic const string PrimaryMarker = \"{EscapeForCSharpString(cacheFormat.PrimaryMarker)}\";");
 		sb.AppendLine($"\tpublic const string LastDtbSucceededMarker = \"{EscapeForCSharpString(cacheFormat.LastDtbSucceededMarker)}\";");
 		sb.AppendLine();
-		sb.AppendLine("\t/// <summary>Section names emitted as <c>[name]</c> by the writer and matched without brackets by the reader.</summary>");
-		sb.AppendLine("\tpublic static class Sections");
-		sb.AppendLine("\t{");
+		AppendLines(
+			sb,
+			"""
+				/// <summary>Section names emitted as <c>[name]</c> by the writer and matched without brackets by the reader.</summary>
+				public static class Sections
+				{
+			""");
 		foreach (SectionDef section in cacheFormat.Sections)
 		{
 			if (!string.IsNullOrEmpty(section.Description))
@@ -391,60 +792,81 @@ public sealed class DataModelSchemaGenerator : IIncrementalGenerator
 		}
 		sb.AppendLine();
 		sb.Append("\t\tpublic static readonly string[] All = [");
-		sb.Append(string.Join(", ", cacheFormat.Sections.Select(s => $"\"{EscapeForCSharpString(s.Name)}\"")));
+		sb.Append(string.Join(", ", cacheFormat.Sections.Select(static section => $"\"{EscapeForCSharpString(section.Name)}\"")));
 		sb.AppendLine("];");
 		sb.AppendLine();
-		sb.AppendLine("\t\t/// <summary>");
-		sb.AppendLine("\t\t/// Item <c>@metadata</c> keys the writer can emit, keyed by the WIRE section that carries");
-		sb.AppendLine("\t\t/// them (resolved through the section's <c>itemType</c> link in the schema). Used by");
-		sb.AppendLine("\t\t/// forward-compatibility preservation to judge \"known\" metadata <em>per section</em>, so a");
-		sb.AppendLine("\t\t/// newer writer that reuses an existing metadata name on a different item type is still");
-		sb.AppendLine("\t\t/// preserved rather than mistaken for regenerable data. Only sections whose item type");
-		sb.AppendLine("\t\t/// emits metadata appear here; a section absent from the map emits no metadata.");
-		sb.AppendLine("\t\t/// </summary>");
-		sb.AppendLine("\t\tpublic static readonly Dictionary<string, string[]> MetadataBySection = new(System.StringComparer.Ordinal)");
-		sb.AppendLine("\t\t{");
+		AppendLines(
+			sb,
+			"""
+					/// <summary>
+					/// Item <c>@metadata</c> keys the writer can emit, keyed by the WIRE section that carries
+					/// them (resolved through the section's <c>itemType</c> link in the schema). Used by
+					/// forward-compatibility preservation to judge "known" metadata <em>per section</em>, so a
+					/// newer writer that reuses an existing metadata name on a different item type is still
+					/// preserved rather than mistaken for regenerable data. Only sections whose item type
+					/// emits metadata appear here; a section absent from the map emits no metadata.
+					/// </summary>
+					public static readonly Dictionary<string, string[]> MetadataBySection = new(System.StringComparer.Ordinal)
+					{
+			""");
 		foreach (SectionDef section in cacheFormat.Sections)
 		{
 			if (section.ItemType is null)
 				continue;
-			ItemDef? item = schema.Items.FirstOrDefault(i => i.Name == section.ItemType);
+			ItemDef? item = schema.Items.FirstOrDefault(item => item.Name == section.ItemType);
 			if (item is null || item.Metadata.Count == 0)
 				continue;
-			string metas = string.Join(", ", item.Metadata.Select(m => $"\"{EscapeForCSharpString(m)}\""));
-			sb.AppendLine($"\t\t\t[\"{EscapeForCSharpString(section.Name)}\"] = [{metas}],");
+			string metadataValues = string.Join(", ", item.Metadata.Select(static metadataName => $"\"{EscapeForCSharpString(metadataName)}\""));
+			sb.AppendLine($"\t\t\t[\"{EscapeForCSharpString(section.Name)}\"] = [{metadataValues}],");
 		}
-		sb.AppendLine("\t\t};");
-		sb.AppendLine("\t}");
-		sb.AppendLine();
-		sb.AppendLine("\t/// <summary>Returns <paramref name=\"name\"/> wrapped in section delimiters, e.g. <c>[sourceFiles]</c>.</summary>");
-		sb.AppendLine("\tpublic static string SectionHeader(string name) => SectionOpen + name + SectionClose;");
+		AppendLines(
+			sb,
+			"""
+					};
+				}
+
+				/// <summary>Returns <paramref name="name"/> wrapped in section delimiters, e.g. <c>[sourceFiles]</c>.</summary>
+				public static string SectionHeader(string name) => SectionOpen + name + SectionClose;
+			}
+			""");
+		return sb.ToString();
+	}
+
+	private static string GeneratePathSentinels(PathSentinelsDef pathSentinels, string namespaceName)
+	{
+		StringBuilder sb = new();
+		AppendLines(
+			sb,
+			$$"""
+			// <auto-generated/>
+			// Generated from project-data-schema.json by DataModelSchemaGenerator.
+
+			namespace {{namespaceName}};
+
+			/// <summary>
+			/// Sentinel prefixes embedded in encoded paths in the <c>.lscache</c> file.
+			/// The writer rewrites version-specific or location-specific paths to these sentinels
+			/// so the cache is portable across machines and SDK upgrades; the reader resolves them
+			/// via <c>CachePathResolver</c>.
+			/// </summary>
+			internal static class PathSentinels
+			{
+			""");
+		foreach ((string name, string value) in pathSentinels.Entries)
+		{
+			AppendLines(
+				sb,$"\tpublic const string {PascalCase(name)} = \"{EscapeForCSharpString(value)}\";");
+		}
 		sb.AppendLine("}");
 		return sb.ToString();
 	}
 
-	private static string GeneratePathSentinels(PathSentinelsDef pathSentinels, string ns)
+	private static void AppendLines(StringBuilder sb, string lines)
 	{
-		StringBuilder sb = new();
-		sb.AppendLine("// <auto-generated/>");
-		sb.AppendLine("// Generated from project-data-schema.json by DataModelSchemaGenerator.");
-		sb.AppendLine();
-		sb.AppendLine($"namespace {ns};");
-		sb.AppendLine();
-		sb.AppendLine("/// <summary>");
-		sb.AppendLine("/// Sentinel prefixes embedded in encoded paths in the <c>.lscache</c> file.");
-		sb.AppendLine("/// The writer rewrites version-specific or location-specific paths to these sentinels");
-		sb.AppendLine("/// so the cache is portable across machines and SDK upgrades; the reader resolves them");
-		sb.AppendLine("/// via <c>CachePathResolver</c>.");
-		sb.AppendLine("/// </summary>");
-		sb.AppendLine("internal static class PathSentinels");
-		sb.AppendLine("{");
-		foreach ((string name, string value) in pathSentinels.Entries)
+		foreach (string line in lines.Replace("\r\n", "\n").Replace('\r', '\n').Split('\n'))
 		{
-			sb.AppendLine($"\tpublic const string {PascalCase(name)} = \"{EscapeForCSharpString(value)}\";");
+			sb.AppendLine(line);
 		}
-		sb.AppendLine("}");
-		return sb.ToString();
 	}
 
 	private sealed record PropertyDef(string Name, string Description);
@@ -469,4 +891,5 @@ public sealed class DataModelSchemaGenerator : IIncrementalGenerator
 		List<ItemDef> Items,
 		CacheFormatDef CacheFormat,
 		PathSentinelsDef PathSentinels);
+	private sealed class SchemaValidationException(string message) : Exception(message);
 }

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/ProjectDataBuildAttemptManifest.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/ProjectDataBuildAttemptManifest.cs
@@ -1,0 +1,305 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json;
+
+namespace Microsoft.NET.ProjectData;
+
+/// <summary>
+/// Structured, bounded evidence emitted by the central ProjectDataBuild MSBuild logger.
+/// </summary>
+public sealed class ProjectDataBuildAttemptManifest
+{
+	public const int SchemaVersion = 1;
+	public const string FileName = "attempt.manifest.json";
+
+	public int Version { get; set; } = SchemaVersion;
+	public string AttemptId { get; set; } = string.Empty;
+	public bool BuildFinished { get; set; }
+	public bool BuildSucceeded { get; set; }
+	public bool BuildCancelled { get; set; }
+	public bool ProjectDataBuildSubmissionObserved { get; set; }
+	public string CompletedUtc { get; set; } = string.Empty;
+	public int TruncatedDiagnosticCount { get; set; }
+	public int TruncatedSubmissionCount { get; set; }
+	public int TruncatedContextCount { get; set; }
+	public ProjectDataBuildSubmissionRecord[] Submissions { get; set; } = [];
+	public ProjectDataBuildContextRecord[] Contexts { get; set; } = [];
+	public ProjectDataBuildDiagnosticRecord[] Diagnostics { get; set; } = [];
+
+	public static string GetManifestFilePath(string receiptDirectory)
+	{
+		ThrowIfNullOrWhiteSpace(receiptDirectory, nameof(receiptDirectory));
+		return Path.Combine(receiptDirectory, FileName);
+	}
+
+	public static bool TryRead(string receiptDirectory, string attemptId, out ProjectDataBuildAttemptManifest manifest)
+	{
+		manifest = new ProjectDataBuildAttemptManifest();
+		try
+		{
+			ThrowIfNullOrWhiteSpace(receiptDirectory, nameof(receiptDirectory));
+			ThrowIfNullOrWhiteSpace(attemptId, nameof(attemptId));
+
+			string path = GetManifestFilePath(receiptDirectory);
+			if (!File.Exists(path))
+			{
+				return false;
+			}
+
+			using JsonDocument document = JsonDocument.Parse(File.ReadAllText(path));
+			JsonElement root = document.RootElement;
+			if (root.ValueKind != JsonValueKind.Object ||
+				!TryGetInt32(root, "version", out int version) ||
+				version != SchemaVersion ||
+				!TryGetString(root, "attemptId", out string manifestAttemptId) ||
+				!string.Equals(manifestAttemptId, attemptId, StringComparison.Ordinal))
+			{
+				return false;
+			}
+
+			manifest = new ProjectDataBuildAttemptManifest
+			{
+				Version = version,
+				AttemptId = manifestAttemptId,
+				BuildFinished = GetBoolean(root, "buildFinished"),
+				BuildSucceeded = GetBoolean(root, "buildSucceeded"),
+				BuildCancelled = GetBoolean(root, "buildCancelled"),
+				ProjectDataBuildSubmissionObserved = GetBoolean(root, "projectDataBuildSubmissionObserved"),
+				CompletedUtc = GetString(root, "completedUtc"),
+				TruncatedDiagnosticCount = GetInt32(root, "truncatedDiagnosticCount"),
+				TruncatedSubmissionCount = GetInt32(root, "truncatedSubmissionCount"),
+				TruncatedContextCount = GetInt32(root, "truncatedContextCount"),
+				Submissions = ReadSubmissions(root),
+				Contexts = ReadContexts(root),
+				Diagnostics = ReadDiagnostics(root),
+			};
+			return true;
+		}
+		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException or FormatException or ArgumentException or NotSupportedException)
+		{
+			System.Diagnostics.Trace.TraceWarning(
+				"[ProjectDataBuildAttemptManifest] Failed to read manifest for attempt {0}: {1}",
+				attemptId,
+				ex.Message);
+			return false;
+		}
+	}
+
+	private static ProjectDataBuildSubmissionRecord[] ReadSubmissions(JsonElement root)
+	{
+		if (!root.TryGetProperty("submissions", out JsonElement submissions) || submissions.ValueKind != JsonValueKind.Array)
+		{
+			return [];
+		}
+
+		List<ProjectDataBuildSubmissionRecord> result = [];
+		foreach (JsonElement element in submissions.EnumerateArray())
+		{
+			if (element.ValueKind != JsonValueKind.Object)
+			{
+				continue;
+			}
+
+			result.Add(new ProjectDataBuildSubmissionRecord
+			{
+				SubmissionId = GetInt32(element, "submissionId"),
+				Phase = GetString(element, "phase"),
+				MSBuildIsRestoring = GetBoolean(element, "msBuildIsRestoring"),
+				EntryProjects = ReadStringArray(element, "entryProjects"),
+				TargetNames = ReadStringArray(element, "targetNames"),
+				Context = ReadContext(element, "context"),
+			});
+		}
+
+		return [.. result];
+	}
+
+	private static ProjectDataBuildContextRecord[] ReadContexts(JsonElement root)
+	{
+		if (!root.TryGetProperty("contexts", out JsonElement contexts) || contexts.ValueKind != JsonValueKind.Array)
+		{
+			return [];
+		}
+
+		List<ProjectDataBuildContextRecord> result = [];
+		foreach (JsonElement element in contexts.EnumerateArray())
+		{
+			if (element.ValueKind != JsonValueKind.Object)
+			{
+				continue;
+			}
+
+			result.Add(new ProjectDataBuildContextRecord
+			{
+				Kind = GetString(element, "kind"),
+				ProjectFilePath = GetString(element, "projectFilePath"),
+				Context = ReadContext(element, "context"),
+				ParentContext = ReadContext(element, "parentContext"),
+			});
+		}
+
+		return [.. result];
+	}
+
+	private static ProjectDataBuildDiagnosticRecord[] ReadDiagnostics(JsonElement root)
+	{
+		if (!root.TryGetProperty("diagnostics", out JsonElement diagnostics) || diagnostics.ValueKind != JsonValueKind.Array)
+		{
+			return [];
+		}
+
+		List<ProjectDataBuildDiagnosticRecord> result = [];
+		foreach (JsonElement element in diagnostics.EnumerateArray())
+		{
+			if (element.ValueKind != JsonValueKind.Object)
+			{
+				continue;
+			}
+
+			result.Add(new ProjectDataBuildDiagnosticRecord
+			{
+				Severity = GetString(element, "severity"),
+				Phase = GetString(element, "phase"),
+				ProjectFilePath = GetString(element, "projectFilePath"),
+				ProjectFilePathSource = GetString(element, "projectFilePathSource"),
+				FilePath = GetString(element, "filePath"),
+				Code = GetString(element, "code"),
+				Message = GetString(element, "message"),
+				Line = GetInt32(element, "line"),
+				Column = GetInt32(element, "column"),
+				Context = ReadContext(element, "context"),
+			});
+		}
+
+		return [.. result];
+	}
+
+	private static ProjectDataBuildEventContextRecord? ReadContext(JsonElement owner, string propertyName)
+	{
+		if (!owner.TryGetProperty(propertyName, out JsonElement element) || element.ValueKind != JsonValueKind.Object)
+		{
+			return null;
+		}
+
+		return new ProjectDataBuildEventContextRecord
+		{
+			NodeId = GetInt32(element, "nodeId"),
+			ProjectContextId = GetInt32(element, "projectContextId"),
+			ProjectInstanceId = GetInt32(element, "projectInstanceId"),
+			TargetId = GetInt32(element, "targetId"),
+			TaskId = GetInt32(element, "taskId"),
+			SubmissionId = GetInt32(element, "submissionId"),
+			EvaluationId = GetInt32(element, "evaluationId"),
+			BuildRequestId = GetInt64(element, "buildRequestId"),
+		};
+	}
+
+	private static string[] ReadStringArray(JsonElement owner, string propertyName)
+	{
+		if (!owner.TryGetProperty(propertyName, out JsonElement element) || element.ValueKind != JsonValueKind.Array)
+		{
+			return [];
+		}
+
+		return [.. element.EnumerateArray()
+			.Where(static value => value.ValueKind == JsonValueKind.String)
+			.Select(static value => value.GetString() ?? string.Empty)];
+	}
+
+	private static bool TryGetString(JsonElement owner, string propertyName, out string value)
+	{
+		value = string.Empty;
+		if (!owner.TryGetProperty(propertyName, out JsonElement element) || element.ValueKind != JsonValueKind.String)
+		{
+			return false;
+		}
+
+		value = element.GetString() ?? string.Empty;
+		return true;
+	}
+
+	private static bool TryGetInt32(JsonElement owner, string propertyName, out int value)
+	{
+		value = 0;
+		return owner.TryGetProperty(propertyName, out JsonElement element) &&
+			element.ValueKind == JsonValueKind.Number &&
+			element.TryGetInt32(out value);
+	}
+
+	private static string GetString(JsonElement owner, string propertyName)
+		=> TryGetString(owner, propertyName, out string value) ? value : string.Empty;
+
+	private static int GetInt32(JsonElement owner, string propertyName)
+		=> TryGetInt32(owner, propertyName, out int value) ? value : 0;
+
+	private static long GetInt64(JsonElement owner, string propertyName)
+		=> owner.TryGetProperty(propertyName, out JsonElement element) &&
+			element.ValueKind == JsonValueKind.Number &&
+			element.TryGetInt64(out long value)
+				? value
+				: 0;
+
+	private static bool GetBoolean(JsonElement owner, string propertyName)
+		=> owner.TryGetProperty(propertyName, out JsonElement element) &&
+			element.ValueKind is JsonValueKind.True or JsonValueKind.False &&
+			element.GetBoolean();
+
+	private static void ThrowIfNullOrWhiteSpace(string value, string parameterName)
+	{
+		if (string.IsNullOrWhiteSpace(value))
+		{
+			throw new ArgumentException("Value cannot be null or whitespace.", parameterName);
+		}
+	}
+}
+
+public sealed class ProjectDataBuildSubmissionRecord
+{
+	public int SubmissionId { get; set; }
+	public string Phase { get; set; } = string.Empty;
+	public bool MSBuildIsRestoring { get; set; }
+	public string[] EntryProjects { get; set; } = [];
+	public string[] TargetNames { get; set; } = [];
+	public ProjectDataBuildEventContextRecord? Context { get; set; }
+}
+
+public sealed class ProjectDataBuildContextRecord
+{
+	public string Kind { get; set; } = string.Empty;
+	public string ProjectFilePath { get; set; } = string.Empty;
+	public ProjectDataBuildEventContextRecord? Context { get; set; }
+	public ProjectDataBuildEventContextRecord? ParentContext { get; set; }
+}
+
+public sealed class ProjectDataBuildDiagnosticRecord
+{
+	public const string FileProjectPathSource = "File";
+	public const string ProjectFileProjectPathSource = "ProjectFile";
+	public const string ContextProjectPathSource = "Context";
+	public const string UnknownProjectPathSource = "Unknown";
+
+	public string Severity { get; set; } = string.Empty;
+	public string Phase { get; set; } = string.Empty;
+	public string ProjectFilePath { get; set; } = string.Empty;
+	public string ProjectFilePathSource { get; set; } = UnknownProjectPathSource;
+	public string FilePath { get; set; } = string.Empty;
+	public string Code { get; set; } = string.Empty;
+	public string Message { get; set; } = string.Empty;
+	public int Line { get; set; }
+	public int Column { get; set; }
+	public ProjectDataBuildEventContextRecord? Context { get; set; }
+}
+
+public sealed class ProjectDataBuildEventContextRecord
+{
+	public int NodeId { get; set; }
+	public int ProjectContextId { get; set; }
+	public int ProjectInstanceId { get; set; }
+	public int TargetId { get; set; }
+	public int TaskId { get; set; }
+	public int SubmissionId { get; set; }
+	public int EvaluationId { get; set; }
+	public long BuildRequestId { get; set; }
+}

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/ProjectDataBuildDiagnosticProtocol.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/ProjectDataBuildDiagnosticProtocol.cs
@@ -1,0 +1,98 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using System.Text;
+
+namespace Microsoft.NET.ProjectData;
+
+/// <summary>
+/// Private, versioned stderr framing for provisional ProjectDataBuild diagnostics.
+/// Frames are diagnostics-only and never provide terminal-state evidence.
+/// </summary>
+public static class ProjectDataBuildDiagnosticProtocol
+{
+	public const int Version = 1;
+	public const string Prefix = "@@CSDEVKIT_PROJECTDATA_DIAGNOSTIC@@";
+
+	private static readonly Encoding Utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
+	public static string Encode(string attemptId, ProjectDataBuildDiagnosticRecord diagnostic)
+	{
+		if (string.IsNullOrWhiteSpace(attemptId))
+		{
+			throw new ArgumentException("Value cannot be null or whitespace.", nameof(attemptId));
+		}
+
+		if (diagnostic is null)
+		{
+			throw new ArgumentNullException(nameof(diagnostic));
+		}
+
+		return string.Join(
+			"|",
+			Prefix + Version.ToString(CultureInfo.InvariantCulture),
+			EncodeField(attemptId),
+			EncodeField(diagnostic.Phase),
+			EncodeField(diagnostic.Severity),
+			EncodeField(diagnostic.ProjectFilePath),
+			EncodeField(diagnostic.FilePath),
+			EncodeField(diagnostic.Code),
+			diagnostic.Line.ToString(CultureInfo.InvariantCulture),
+			diagnostic.Column.ToString(CultureInfo.InvariantCulture),
+			EncodeField(diagnostic.Message));
+	}
+
+	public static bool TryDecode(string line, string expectedAttemptId, out ProjectDataBuildDiagnosticRecord diagnostic)
+	{
+		diagnostic = new ProjectDataBuildDiagnosticRecord();
+		if (string.IsNullOrEmpty(line) ||
+			string.IsNullOrEmpty(expectedAttemptId) ||
+			!line.StartsWith(Prefix, StringComparison.Ordinal))
+		{
+			return false;
+		}
+
+		try
+		{
+			string[] fields = line.Split('|');
+			if (fields.Length != 10 ||
+				!string.Equals(fields[0], Prefix + Version.ToString(CultureInfo.InvariantCulture), StringComparison.Ordinal))
+			{
+				return false;
+			}
+
+			string attemptId = DecodeField(fields[1]);
+			if (!string.Equals(attemptId, expectedAttemptId, StringComparison.Ordinal) ||
+				!int.TryParse(fields[7], NumberStyles.Integer, CultureInfo.InvariantCulture, out int lineNumber) ||
+				!int.TryParse(fields[8], NumberStyles.Integer, CultureInfo.InvariantCulture, out int columnNumber))
+			{
+				return false;
+			}
+
+			diagnostic = new ProjectDataBuildDiagnosticRecord
+			{
+				Phase = DecodeField(fields[2]),
+				Severity = DecodeField(fields[3]),
+				ProjectFilePath = DecodeField(fields[4]),
+				FilePath = DecodeField(fields[5]),
+				Code = DecodeField(fields[6]),
+				Line = lineNumber,
+				Column = columnNumber,
+				Message = DecodeField(fields[9]),
+			};
+			return true;
+		}
+		catch (Exception ex) when (ex is FormatException or ArgumentException)
+		{
+			return false;
+		}
+	}
+
+	private static string EncodeField(string? value)
+		=> Convert.ToBase64String(Utf8NoBom.GetBytes(value ?? string.Empty));
+
+	private static string DecodeField(string value)
+		=> Utf8NoBom.GetString(Convert.FromBase64String(value));
+}

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/ProjectDataBuildReceipt.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/ProjectDataBuildReceipt.cs
@@ -1,0 +1,266 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Microsoft.NET.ProjectData;
+
+/// <summary>
+/// Reads and writes completion-only evidence for one ProjectDataBuild attempt.
+/// </summary>
+public static class ProjectDataBuildReceipt
+{
+	public const int SchemaVersion = 2;
+	public const string AggregateCompletionFileName = "aggregate.completed";
+
+	private static readonly Encoding Utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
+	public static string GetReceiptFilePath(string receiptDirectory, string projectFilePath)
+	{
+		ThrowIfNullOrWhiteSpace(receiptDirectory, nameof(receiptDirectory));
+		ThrowIfNullOrWhiteSpace(projectFilePath, nameof(projectFilePath));
+
+		string normalizedProjectPath = NormalizeProjectPath(projectFilePath);
+		using SHA256 sha256 = SHA256.Create();
+		string fileName = HexEncoder.ToLowerHex(sha256.ComputeHash(Utf8NoBom.GetBytes(normalizedProjectPath))) + ".completed";
+		return Path.Combine(receiptDirectory, fileName);
+	}
+
+	public static string GetAggregateCompletionFilePath(string receiptDirectory)
+	{
+		ThrowIfNullOrWhiteSpace(receiptDirectory, nameof(receiptDirectory));
+		return Path.Combine(receiptDirectory, AggregateCompletionFileName);
+	}
+
+	public static string Write(string receiptDirectory, string attemptId, string projectFilePath)
+	{
+		ValidateInputs(receiptDirectory, attemptId);
+		ThrowIfNullOrWhiteSpace(projectFilePath, nameof(projectFilePath));
+
+		Directory.CreateDirectory(receiptDirectory);
+		string fullProjectPath = Path.GetFullPath(projectFilePath);
+		string receiptPath = GetReceiptFilePath(receiptDirectory, fullProjectPath);
+		string content =
+			$"version={SchemaVersion}\n" +
+			$"attempt={attemptId}\n" +
+			$"project={fullProjectPath}\n";
+		WriteAllTextAtomically(receiptPath, content);
+		return receiptPath;
+	}
+
+	public static bool TryRead(
+		string receiptDirectory,
+		string attemptId,
+		string projectFilePath,
+		out ProjectDataBuildReceiptData receipt)
+	{
+		receipt = new ProjectDataBuildReceiptData();
+		try
+		{
+			ValidateInputs(receiptDirectory, attemptId);
+			ThrowIfNullOrWhiteSpace(projectFilePath, nameof(projectFilePath));
+
+			string receiptPath = GetReceiptFilePath(receiptDirectory, projectFilePath);
+			if (!File.Exists(receiptPath))
+			{
+				return false;
+			}
+
+			Dictionary<string, string> values = ReadValues(receiptPath);
+			if (values.Count != 3 ||
+				!TryGetInt(values, "version", out int version) ||
+				version != SchemaVersion ||
+				!values.TryGetValue("attempt", out string? receiptAttemptId) ||
+				!string.Equals(receiptAttemptId, attemptId, StringComparison.Ordinal) ||
+				!values.TryGetValue("project", out string? receiptProjectPath) ||
+				!PathsEqual(receiptProjectPath, projectFilePath))
+			{
+				return false;
+			}
+
+			receipt = new ProjectDataBuildReceiptData
+			{
+				AttemptId = receiptAttemptId,
+				ProjectFilePath = receiptProjectPath,
+				ReceiptFilePath = receiptPath,
+			};
+			return true;
+		}
+		catch (Exception ex) when (IsRecoverableEvidenceException(ex))
+		{
+			System.Diagnostics.Trace.TraceWarning(
+				"[ProjectDataBuildReceipt] Failed to read completion receipt for {0}: {1}",
+				projectFilePath,
+				ex.Message);
+			return false;
+		}
+	}
+
+	public static void WriteAggregateCompletion(string receiptDirectory, string attemptId)
+	{
+		ValidateInputs(receiptDirectory, attemptId);
+		Directory.CreateDirectory(receiptDirectory);
+		string content =
+			$"version={SchemaVersion}\n" +
+			$"attempt={attemptId}\n";
+		WriteAllTextAtomically(GetAggregateCompletionFilePath(receiptDirectory), content);
+	}
+
+	public static bool TryReadAggregateCompletion(string receiptDirectory, string attemptId)
+	{
+		try
+		{
+			ValidateInputs(receiptDirectory, attemptId);
+			string receiptPath = GetAggregateCompletionFilePath(receiptDirectory);
+			if (!File.Exists(receiptPath))
+			{
+				return false;
+			}
+
+			Dictionary<string, string> values = ReadValues(receiptPath);
+			return values.Count == 2 &&
+				TryGetInt(values, "version", out int version) &&
+				version == SchemaVersion &&
+				values.TryGetValue("attempt", out string? receiptAttemptId) &&
+				string.Equals(receiptAttemptId, attemptId, StringComparison.Ordinal);
+		}
+		catch (Exception ex) when (IsRecoverableEvidenceException(ex))
+		{
+			System.Diagnostics.Trace.TraceWarning(
+				"[ProjectDataBuildReceipt] Failed to read aggregate completion for attempt {0}: {1}",
+				attemptId,
+				ex.Message);
+			return false;
+		}
+	}
+
+	private static void ValidateInputs(string receiptDirectory, string attemptId)
+	{
+		ThrowIfNullOrWhiteSpace(receiptDirectory, nameof(receiptDirectory));
+		ThrowIfNullOrWhiteSpace(attemptId, nameof(attemptId));
+	}
+
+	private static Dictionary<string, string> ReadValues(string path)
+	{
+		Dictionary<string, string> values = new(StringComparer.Ordinal);
+		foreach (string line in File.ReadAllLines(path))
+		{
+			int separatorIndex = line.IndexOf('=');
+			if (separatorIndex <= 0)
+			{
+				throw new FormatException($"Receipt '{path}' contains a malformed line.");
+			}
+
+			string key = line.Substring(0, separatorIndex);
+			if (values.ContainsKey(key))
+			{
+				throw new FormatException($"Receipt '{path}' contains a duplicate '{key}' field.");
+			}
+
+			values.Add(key, line.Substring(separatorIndex + 1));
+		}
+
+		return values;
+	}
+
+	private static bool TryGetInt(Dictionary<string, string> values, string key, out int value)
+	{
+		value = 0;
+		return values.TryGetValue(key, out string? text) && int.TryParse(text, out value);
+	}
+
+	private static string NormalizeProjectPath(string projectFilePath)
+	{
+		string fullPath = Path.GetFullPath(projectFilePath);
+		return RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+			? fullPath
+			: fullPath.ToUpperInvariant();
+	}
+
+	private static bool PathsEqual(string left, string right)
+		=> string.Equals(
+			Path.GetFullPath(left).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
+			Path.GetFullPath(right).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
+			RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase);
+
+	internal static void WriteAllTextAtomically(string path, string content)
+	{
+		string? directory = Path.GetDirectoryName(path);
+		if (!string.IsNullOrEmpty(directory))
+		{
+			Directory.CreateDirectory(directory);
+		}
+
+		string tempPath = path + "." + Guid.NewGuid().ToString("N") + ".tmp";
+		try
+		{
+			File.WriteAllText(tempPath, content, Utf8NoBom);
+			IOException? lastWriteError = null;
+			for (int attempt = 0; attempt < 8; attempt++)
+			{
+				try
+				{
+					if (File.Exists(path))
+					{
+						if (string.Equals(File.ReadAllText(path, Utf8NoBom), content, StringComparison.Ordinal))
+						{
+							return;
+						}
+
+						File.Replace(tempPath, path, destinationBackupFileName: null);
+					}
+					else
+					{
+						File.Move(tempPath, path);
+					}
+
+					return;
+				}
+				catch (IOException ex)
+				{
+					lastWriteError = ex;
+					Thread.Sleep(1);
+				}
+			}
+
+			throw new IOException($"Failed to atomically write ProjectData build receipt '{path}' after concurrent write retries.", lastWriteError);
+		}
+		finally
+		{
+			try
+			{
+				File.Delete(tempPath);
+			}
+			catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+			{
+			}
+		}
+	}
+
+	private static bool IsRecoverableEvidenceException(Exception ex)
+		=> ex is IOException
+			or UnauthorizedAccessException
+			or FormatException
+			or ArgumentException
+			or NotSupportedException
+			or InvalidOperationException
+			or CryptographicException;
+
+	private static void ThrowIfNullOrWhiteSpace(string value, string parameterName)
+	{
+		if (string.IsNullOrWhiteSpace(value))
+		{
+			throw new ArgumentException("Value cannot be null or whitespace.", parameterName);
+		}
+	}
+}
+
+public sealed class ProjectDataBuildReceiptData
+{
+	public string AttemptId { get; set; } = string.Empty;
+	public string ProjectFilePath { get; set; } = string.Empty;
+	public string ReceiptFilePath { get; set; } = string.Empty;
+}

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/UserFolderCachePath.cs
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData/UserFolderCachePath.cs
@@ -56,6 +56,20 @@ public static class UserFolderCachePath
 		return Path.Combine(baseDir, hex.Substring(0, 2), hex.Substring(2));
 	}
 
+	internal static bool TryCompute(string projectFilePath, out string cacheFilePath)
+	{
+		try
+		{
+			cacheFilePath = Compute(projectFilePath);
+			return true;
+		}
+		catch (InvalidOperationException)
+		{
+			cacheFilePath = string.Empty;
+			return false;
+		}
+	}
+
 	/// <summary>
 	/// Returns the cache root directory used by <see cref="Compute"/>.
 	///


### PR DESCRIPTION
### Complete ProjectData mirror refresh in progress

This draft is being expanded from the initial safe slice to the complete shared ProjectData delta from vs-green.

- Previous source: `11b0afc9aece97a12dada4a3c6cf12622bb33232`
- Current source: `9152330d1208984fe6d572ba96846b411e586db4`
- Reviewed range: `11b0afc9aece97a12dada4a3c6cf12622bb33232..9152330d1208984fe6d572ba96846b411e586db4`

The full reader/donor/model/schema/API/cancellation and Tasks/writer/targets/tests changes, plus required Roslyn-owned integration, are now in scope. Shared files will be updated only from the regenerated reviewed mirror artifacts. Validation and the final detailed description will be added before this PR is marked ready.

This refresh follows the original ProjectData source drop in https://github.com/dotnet/roslyn/pull/84790.