### PR TITLE
Discover `.editorconfig` files in folders that have Razor files

### DIFF
--- a/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
@@ -45,9 +45,9 @@
   <!-- Import the list of service hub services we proffer, to generate various files to include in the VSIX -->
   <Import Project="$(RepositoryEngineeringDir)targets\RazorServices.props" />
 
-  <!-- Include Razor SDK design time assets in the VSIX -->
+  <!-- Include Razor design-time assets in the VSIX -->
   <ItemGroup>
-    <Content Include="$(PkgMicrosoft_NET_Sdk_Razor)\targets\Microsoft.NET.Sdk.Razor.DesignTime.targets">
+    <Content Include="..\Microsoft.VisualStudioCode.RazorExtension\Targets\Microsoft.NET.Sdk.Razor.DesignTime.targets">
       <IncludeInVsix>true</IncludeInVsix>
       <InstallRoot>MSBuild</InstallRoot>
       <VSIXSubPath>Microsoft\VisualStudio\Razor\</VSIXSubPath>

--- a/src/Razor/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/Targets/Microsoft.NET.Sdk.Razor.DesignTime.targets
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/Targets/Microsoft.NET.Sdk.Razor.DesignTime.targets
@@ -86,6 +86,35 @@ Copyright (c) .NET Foundation. All rights reserved.
     </PropertyPageSchema>
   </ItemGroup>
 
+  <!--
+    Microsoft.Managed.Core.targets discovers analyzer config files from Compile items. Razor files
+    can live in directories without Compile items, so include their directories in design-time
+    discovery as well. Default Razor items are resolved from Content during target execution, so
+    include both Content and any Razor items that were added explicitly during evaluation.
+
+    Microsoft.Managed.DesignTime.targets copies PotentialEditorConfigFiles into
+    AdditionalDesignTimeBuildInput before this file is imported, so add the Razor candidates to both.
+  -->
+  <ItemGroup Condition="'$(DesignTimeBuild)' == 'true' and '$(DiscoverEditorConfigFiles)' != 'false'">
+    <_RazorAnalyzerConfigInputs Include="@(Content->WithMetadataValue('Extension', '.razor'));@(Content->WithMetadataValue('Extension', '.cshtml'))" />
+    <_RazorAnalyzerConfigInputs Include="@(RazorGenerate);@(RazorComponent)" />
+    <_RazorAllDirectoriesAbove Include="@(_RazorAnalyzerConfigInputs->GetPathsOfAllDirectoriesAbove())" />
+    <_RazorPotentialEditorConfigFiles Include="@(_RazorAllDirectoriesAbove->'%(FullPath)'->Distinct()->Combine('.editorconfig'))" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(DesignTimeBuild)' == 'true' and '$(DiscoverEditorConfigFiles)' != 'false'">
+    <PotentialEditorConfigFiles
+      Include="@(_RazorPotentialEditorConfigFiles)"
+      Exclude="@(PotentialEditorConfigFiles)" />
+    <AdditionalDesignTimeBuildInput
+      Include="@(_RazorPotentialEditorConfigFiles)"
+      Exclude="@(AdditionalDesignTimeBuildInput)"
+      ContentSensitive="false" />
+    <EditorConfigFiles
+      Include="@(PotentialEditorConfigFiles->Exists())"
+      Exclude="@(EditorConfigFiles)" />
+  </ItemGroup>
+
   <Target
     Name="RazorGenerateDesignTime"
     DependsOnTargets="ResolveRazorGenerateInputs;AssignRazorGenerateTargetPaths"

--- a/src/Razor/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/Targets/Readme.md
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/Targets/Readme.md
@@ -1,3 +1,5 @@
 ### Note
 
-This (and code in Rules) was pulled from the [sdk](https://github.com/dotnet/sdk/blob/8f983a2c12162e49af7a7f2eb7744d220859f42b/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.DesignTime.targets). These files are for tooling to define specific design time behavior and thus should be owned by tooling. As of writing these are only used in VS Code.
+This target (and the files under Rules) originated in the [.NET SDK](https://github.com/dotnet/sdk/blob/8f983a2c12162e49af7a7f2eb7744d220859f42b/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.DesignTime.targets). These files define tooling-specific design-time behavior and are therefore owned by tooling.
+
+`Microsoft.NET.Sdk.Razor.DesignTime.targets` is the single source packaged into both the Visual Studio Razor VSIX and `roslyn-language-server`.


### PR DESCRIPTION
This is the next part of wider `.editorconfig` support, following up on the fix for https://github.com/dotnet/razor/issues/5607

Currently Roslyn's targets only discovered `.editorconfig` files in folders that have `<Compile>` items, so a folder with only Razor files can have an `.editorconfig` file, and unless explicitly added to the right item collection in the project, it will be ignored by Razor formatting. This adds a target in to fix that.

It also updates our VSIX by shipping the same design time targets file in it, as we ship in the C# extension, rather than pulling from the Razor SDK at build time.

This works around https://github.com/dotnet/roslyn/issues/67793 for the Razor case at least.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85042)