### PR TITLE
Provide IntelliSense for ~/ asset paths in Razor components

### DIFF
--- a/.github/instructions/Razor.instructions.md
+++ b/.github/instructions/Razor.instructions.md
@@ -54,6 +54,18 @@ their original sub-tree layout
   `TagHelperDescriptor`s whose descriptor-level metadata carries the parsed values. A later
   optimization pass reads the full discovered set via `ITagHelperFeature.GetTagHelpers()` (not the
   document's in-scope tag helpers, which are namespace-scoped) and filters by metadata kind.
+- **Tooling consuming runtime-declared attribute lists**: the same scoping caveat applies on the
+  tooling side. `TagHelperDocumentContext.TagHelpers` is the document's *in-scope* set, so a carrier
+  whose declaring type lives in an un-imported namespace is missing from it. Read the project-wide
+  set with `RemoteProjectSnapshot.GetTagHelpersAsync()` instead, or completion and compilation will
+  disagree about what opted in. `AssetPathCompletionInfo` does this for `[AcceptsAssetPath]`.
+- **Project data from the SDK**: MSBuild flows per-project data to tooling either as a
+  `CompilerVisibleProperty` (read from `Project.AnalyzerOptions.AnalyzerConfigOptionsProvider`
+  global options) or as an `AdditionalFiles` item tagged with `CompilerVisibleItemMetadata` (read
+  per-file from the same provider, as the generator does for `TargetPath` / `CssScope`). Prefer the
+  latter for anything file-sized: it rides the workspace snapshot into OOP, so invalidation is by
+  document version with no watcher or disk access. `StaticWebAssetsProvider` reads
+  `staticwebassets.intellisense.json` this way, keyed on `build_metadata.AdditionalFiles.IsStaticWebAssetsManifest`.
 - **Visual Studio options**: Register Razor Advanced settings in
   `Microsoft.VisualStudio.RazorExtension\UnifiedSettings\razor.registration.json`, localize
   their UI text in `VSPackage.resx`, read them through `OptionsStorage`, and add remotely consumed

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/AssetPathCompletionDescription.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/AssetPathCompletionDescription.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.CodeAnalysis.Razor.Completion;
+
+/// <summary>
+/// Placeholder description for static web asset completions. The asset key is the entire payload of
+/// the item, and it is already the label, so there is nothing further to tell the user.
+/// </summary>
+internal sealed class AssetPathCompletionDescription : CompletionDescription
+{
+    public static readonly AssetPathCompletionDescription Instance = new();
+
+    private AssetPathCompletionDescription()
+    {
+    }
+
+    public override string Description => string.Empty;
+}

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/CompletionTriggerAndCommitCharacters.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/CompletionTriggerAndCommitCharacters.cs
@@ -22,7 +22,10 @@ internal class CompletionTriggerAndCommitCharacters(IClientCapabilitiesService c
     private static readonly FrozenSet<char> _csharpTriggerCharacters = [' ', '(', '=', '#', '.', '<', '[', '{', '"', '/', ':', '~'];
     private static readonly FrozenSet<char> _vsHtmlTriggerCharacters = [TransitionCharacter, ':', '#', '.', '!', '*', ',', '(', '[', '-', '<', '&', '\\', '/', '\'', '"', '=', ':', ' ', '`'];
     private static readonly FrozenSet<char> _vsCodeHtmlTriggerCharacters = [TransitionCharacter, '#', '.', '!', ',', '<'];
-    private static readonly FrozenSet<char> _razorTriggerCharacters = [TransitionCharacter, '<', ':', ' '];
+    // '/' and '~' are here so that typing '~/' inside an opted-in attribute value pops the static
+    // web asset list. Both are already registered overall via the C# set, so this only widens which
+    // triggers reach the Razor providers; every provider that doesn't care returns immediately.
+    private static readonly FrozenSet<char> _razorTriggerCharacters = [TransitionCharacter, '<', ':', ' ', '~', '/'];
 
     private FrozenSet<char> HtmlTriggerCharacters => _clientCapabilitiesService.ClientCapabilities.SupportsVisualStudioExtensions
         ? _vsHtmlTriggerCharacters

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItem.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItem.cs
@@ -131,4 +131,16 @@ internal sealed class RazorCompletionItem
         string displayText, string insertText,
         ImmutableArray<RazorCommitCharacter> commitCharacters)
         => new(RazorCompletionItemKind.CSharpRazorKeyword, displayText, insertText, sortText: null, new CSharpRazorKeywordCompletionDescription(displayText), commitCharacters, isSnippet: false);
+
+    /// <summary>
+    /// Creates an item for a static web asset offered inside a <c>~/</c> attribute value.
+    /// </summary>
+    /// <remarks>
+    /// No commit characters: an asset key can contain <c>/</c>, <c>.</c> and <c>-</c>, all of which
+    /// would otherwise commit the item partway through typing a longer path.
+    /// </remarks>
+    public static RazorCompletionItem CreateAssetPath(
+        string displayText, string insertText,
+        LinePositionSpan replacementRange)
+        => new(RazorCompletionItemKind.AssetPath, displayText, insertText, sortText: null, descriptionInfo: AssetPathCompletionDescription.Instance, commitCharacters: [], isSnippet: false, replacementRange: replacementRange);
 }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItemKind.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItemKind.cs
@@ -14,4 +14,5 @@ internal enum RazorCompletionItemKind
     TagHelperElement,
     TagHelperAttribute,
     Attribute,
+    AssetPath,
 }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/AssetPathCompletionFacts.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/AssetPathCompletionFacts.cs
@@ -1,0 +1,239 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Components;
+using Microsoft.AspNetCore.Razor.Language.Syntax;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Editor.Razor;
+using RazorSyntaxNode = Microsoft.AspNetCore.Razor.Language.Syntax.SyntaxNode;
+
+namespace Microsoft.CodeAnalysis.Remote.Razor.Completion;
+
+/// <summary>
+/// Recognizes the positions where <c>~/</c> asset paths are meaningful: inside the value of an
+/// attribute that opted into asset-path expansion, on a value that starts with <c>~/</c>.
+/// </summary>
+/// <remarks>
+/// Shared by the completion provider and by the decision to suppress the HTML language server's
+/// relative-path completions, so the two cannot disagree about where an asset path is being typed.
+/// The opt-in rules mirror <c>ComponentTildePathPass</c>: an allowlisted <c>(element, attribute)</c>
+/// pair from <c>[AcceptsAssetPath]</c>, or a component parameter marked <c>[AssetPath]</c>.
+/// </remarks>
+internal static class AssetPathCompletionFacts
+{
+    public const string TildePrefix = "~/";
+
+    /// <summary>
+    /// Whether asset path expansion can happen in this document at all. The tag helper producer that
+    /// discovers <c>[AcceptsAssetPath]</c> is registered from Razor 3.0, but
+    /// <c>ComponentTildePathPass</c> only expands from 11.0, so a project referencing a modern
+    /// runtime while pinned to an older language version has the opt-in metadata and no expansion.
+    /// Offering completions there would promise a rewrite that never happens.
+    /// </summary>
+    public static bool IsSupported(RazorParserOptions options)
+        => options.FileKind.IsComponent() &&
+           options.LanguageVersion >= RazorLanguageVersion.Version_11_0;
+
+    /// <summary>
+    /// A purely textual test for whether the position could be inside a <c>~/</c> attribute value,
+    /// used to decide whether the project-scoped asset data is worth resolving at all. Scans back to
+    /// the opening quote, so it costs nothing on the overwhelming majority of keystrokes that are
+    /// nowhere near an asset path.
+    /// </summary>
+    public static bool IsAssetPathCandidate(SourceText sourceText, int absoluteIndex)
+    {
+        if (absoluteIndex < 0 || absoluteIndex > sourceText.Length)
+        {
+            return false;
+        }
+
+        for (var i = absoluteIndex - 1; i >= 0; i--)
+        {
+            var c = sourceText[i];
+
+            if (c is '"' or '\'')
+            {
+                return i + 2 < sourceText.Length &&
+                       sourceText[i + 1] == '~' &&
+                       sourceText[i + 2] == '/';
+            }
+
+            // An attribute value can't span these, so anything beyond one is a different construct.
+            if (c is '<' or '>' or '\r' or '\n')
+            {
+                return false;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Determines whether <paramref name="absoluteIndex"/> sits in an opted-in attribute value that
+    /// begins with <c>~/</c>, and if so returns the span running from just after the prefix to the
+    /// end of the value, which is the text a completion item replaces.
+    /// </summary>
+    public static bool TryGetAssetPathContext(
+        RazorSyntaxNode? owner,
+        AssetPathCompletionInfo info,
+        SourceText sourceText,
+        int absoluteIndex,
+        out TextSpan replacementSpan)
+    {
+        replacementSpan = default;
+
+        if (info.IsEmpty ||
+            FindAttribute(owner) is not { } attribute ||
+            !IsOptedIn(attribute, info))
+        {
+            return false;
+        }
+
+        var valueSpan = GetValueSpan(attribute);
+        if (!valueSpan.IntersectsWith(absoluteIndex) ||
+            valueSpan.Length < TildePrefix.Length ||
+            sourceText.ToString(new TextSpan(valueSpan.Start, TildePrefix.Length)) != TildePrefix)
+        {
+            return false;
+        }
+
+        if (!IsStaticLiteral(attribute))
+        {
+            // Expansion only applies to a value that is entirely static text, so offering an asset
+            // here would suggest something the compiler leaves as a literal and diagnoses.
+            return false;
+        }
+
+        var pathStart = valueSpan.Start + TildePrefix.Length;
+        if (absoluteIndex < pathStart)
+        {
+            // The cursor is on the '~' or the '/' itself, so there is no path being typed yet.
+            return false;
+        }
+
+        replacementSpan = TextSpan.FromBounds(pathStart, valueSpan.End);
+        return true;
+    }
+
+    /// <summary>
+    /// Walks out to the attribute containing the position, stopping at the enclosing element so an
+    /// index that is in no attribute value doesn't pick up an unrelated attribute further out.
+    /// </summary>
+    private static RazorSyntaxNode? FindAttribute(RazorSyntaxNode? owner)
+    {
+        for (var node = owner; node is not null; node = node.Parent)
+        {
+            switch (node)
+            {
+                case MarkupAttributeBlockSyntax:
+                case MarkupTagHelperAttributeSyntax:
+                    return node;
+
+                case MarkupElementSyntax:
+                case MarkupTagHelperElementSyntax:
+                    return null;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool IsOptedIn(RazorSyntaxNode attribute, AssetPathCompletionInfo info)
+        => attribute switch
+        {
+            MarkupAttributeBlockSyntax attributeBlock
+                => GetElementName(attributeBlock) is { } elementName &&
+                   info.AcceptsAssetPath(elementName, attributeBlock.Name.GetContent()),
+
+            MarkupTagHelperAttributeSyntax tagHelperAttribute
+                => AcceptsAssetPath(tagHelperAttribute),
+
+            _ => false
+        };
+
+    private static bool AcceptsAssetPath(MarkupTagHelperAttributeSyntax attribute)
+    {
+        if (attribute is not { Parent.Parent: MarkupTagHelperElementSyntax { TagHelperInfo.BindingResult: var binding } })
+        {
+            return false;
+        }
+
+        var attributeName = attribute.TagHelperAttributeInfo.Name;
+
+        foreach (var tagHelper in binding.TagHelpers)
+        {
+            foreach (var boundAttribute in tagHelper.BoundAttributes)
+            {
+                if (string.Equals(boundAttribute.Name, attributeName, StringComparison.Ordinal) &&
+                    boundAttribute.Metadata is PropertyMetadata { AcceptsAssetPath: true })
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Whether the attribute's value is entirely static text. A value that mixes a literal with a
+    /// C# expression never expands, so the '@' transition is what disqualifies it.
+    /// </summary>
+    private static bool IsStaticLiteral(RazorSyntaxNode attribute)
+    {
+        var value = attribute switch
+        {
+            MarkupAttributeBlockSyntax a => (RazorSyntaxNode?)a.Value,
+            MarkupTagHelperAttributeSyntax a => a.Value,
+            _ => null
+        };
+
+        if (value is null)
+        {
+            return true;
+        }
+
+        foreach (var descendant in value.DescendantNodes())
+        {
+            if (descendant is CSharpSyntaxNode or MarkupDynamicAttributeValueSyntax)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// The span between the quotes. An attribute whose value hasn't been typed yet has no value
+    /// node, so the span is empty but still positioned where the text will go.
+    /// </summary>
+    private static TextSpan GetValueSpan(RazorSyntaxNode attribute)
+    {
+        var (value, valuePrefix, valueSuffix) = attribute switch
+        {
+            MarkupAttributeBlockSyntax a => ((RazorSyntaxNode?)a.Value, a.ValuePrefix, a.ValueSuffix),
+            MarkupTagHelperAttributeSyntax a => (a.Value, a.ValuePrefix, a.ValueSuffix),
+            _ => (null, null, null)
+        };
+
+        if (value is not null)
+        {
+            return value.Span;
+        }
+
+        if (valuePrefix is not null)
+        {
+            return new TextSpan(valuePrefix.Span.End, 0);
+        }
+
+        return valueSuffix is not null ? new TextSpan(valueSuffix.Span.Start, 0) : default;
+    }
+
+    private static string? GetElementName(RazorSyntaxNode attribute)
+        => HtmlFacts.TryGetElementInfo(attribute.Parent, out var containingTagNameToken, out _, out _)
+            ? containingTagNameToken.Content
+            : null;
+}

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/AssetPathCompletionInfo.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/AssetPathCompletionInfo.cs
@@ -1,0 +1,71 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Components;
+
+namespace Microsoft.CodeAnalysis.Remote.Razor.Completion;
+
+/// <summary>
+/// The project-scoped data an asset path completion needs: which element/attribute pairs opted into
+/// <c>~/</c> expansion, and the asset keys that can be offered inside one.
+/// </summary>
+internal sealed class AssetPathCompletionInfo
+{
+    public static readonly AssetPathCompletionInfo Empty = new([], new(StringComparer.OrdinalIgnoreCase));
+
+    private readonly Dictionary<string, HashSet<string>> _allowedElementAttributes;
+
+    public ImmutableArray<string> Assets { get; }
+
+    private AssetPathCompletionInfo(ImmutableArray<string> assets, Dictionary<string, HashSet<string>> allowedElementAttributes)
+    {
+        Assets = assets;
+        _allowedElementAttributes = allowedElementAttributes;
+    }
+
+    public bool IsEmpty => Assets.Length == 0;
+
+    public bool AcceptsAssetPath(string elementName, string attributeName)
+        => _allowedElementAttributes.TryGetValue(elementName, out var attributes) &&
+           attributes.Contains(attributeName);
+
+    public AssetPathCompletionInfo WithAssets(ImmutableArray<string> assets)
+        => new(assets, _allowedElementAttributes);
+
+    /// <summary>
+    /// Builds the allowlist from every discovered tag helper rather than the document's in-scope set.
+    /// The carriers produced from <c>[AcceptsAssetPath]</c> live on a type in the runtime's namespace,
+    /// so scoping them by the document's <c>@using</c> directives would make expansion and completion
+    /// disagree about which attributes opted in. <c>ComponentTildePathPass</c> reads the full set for
+    /// the same reason.
+    /// </summary>
+    public static AssetPathCompletionInfo Create(TagHelperCollection tagHelpers)
+    {
+        // Both comparisons are case-insensitive, matching HTML semantics.
+        var allowedElementAttributes = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var tagHelper in tagHelpers)
+        {
+            if (tagHelper.Metadata is not AssetPathMetadata { Element: var element, Attribute: var attribute })
+            {
+                continue;
+            }
+
+            if (!allowedElementAttributes.TryGetValue(element, out var attributes))
+            {
+                attributes = new(StringComparer.OrdinalIgnoreCase);
+                allowedElementAttributes.Add(element, attributes);
+            }
+
+            attributes.Add(attribute);
+        }
+
+        return allowedElementAttributes.Count == 0
+            ? Empty
+            : new AssetPathCompletionInfo([], allowedElementAttributes);
+    }
+}

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/AssetPathCompletionInfoProvider.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/AssetPathCompletionInfoProvider.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Composition;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Remote.Razor.StaticWebAssets;
+
+namespace Microsoft.CodeAnalysis.Remote.Razor.Completion;
+
+/// <summary>
+/// Assembles the project-scoped data asset path completion needs, caching each half against the
+/// immutable object it derives from so that repeated requests against an unchanged project are
+/// dictionary lookups.
+/// </summary>
+[Export(typeof(AssetPathCompletionInfoProvider)), Shared]
+[method: ImportingConstructor]
+internal sealed class AssetPathCompletionInfoProvider(StaticWebAssetsProvider staticWebAssetsProvider)
+{
+    private readonly StaticWebAssetsProvider _staticWebAssetsProvider = staticWebAssetsProvider;
+    private readonly ConditionalWeakTable<TagHelperCollection, AssetPathCompletionInfo> _allowListCache = new();
+
+    public async ValueTask<AssetPathCompletionInfo> GetInfoAsync(RemoteProjectSnapshot projectSnapshot, CancellationToken cancellationToken)
+    {
+        var tagHelpers = await projectSnapshot.GetTagHelpersAsync(cancellationToken).ConfigureAwait(false);
+
+        if (!_allowListCache.TryGetValue(tagHelpers, out var info))
+        {
+            info = _allowListCache.GetValue(tagHelpers, AssetPathCompletionInfo.Create);
+        }
+
+        // Nothing opted in, so the asset list would have nowhere to be offered.
+        if (ReferenceEquals(info, AssetPathCompletionInfo.Empty))
+        {
+            return AssetPathCompletionInfo.Empty;
+        }
+
+        var assets = await _staticWebAssetsProvider.GetAssetsAsync(projectSnapshot, cancellationToken).ConfigureAwait(false);
+
+        return assets.IsEmpty ? AssetPathCompletionInfo.Empty : info.WithAssets(assets);
+    }
+}

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/AssetPathCompletionItemProvider.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/AssetPathCompletionItemProvider.cs
@@ -1,0 +1,55 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.PooledObjects;
+using Microsoft.CodeAnalysis.Razor.Completion;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.Remote.Razor.Completion;
+
+/// <summary>
+/// Offers the project's static web assets inside an opted-in attribute value that starts with
+/// <c>~/</c>, which the compiler rewrites into an <c>Assets["..."]</c> lookup.
+/// </summary>
+[Export(typeof(IRazorCompletionItemProvider)), Shared]
+internal sealed class AssetPathCompletionItemProvider : IRazorCompletionItemProvider
+{
+    public ImmutableArray<RazorCompletionItem> GetCompletionItems(RazorCompletionContext context)
+    {
+        // Expansion only happens in components, and only from Razor 11.0, so offering the paths
+        // anywhere else would suggest syntax that stays a literal.
+        if (!AssetPathCompletionFacts.IsSupported(context.SyntaxTree.Options))
+        {
+            return [];
+        }
+
+        if (context.AssetPathInfo is not { IsEmpty: false } info)
+        {
+            return [];
+        }
+
+        var sourceText = context.CodeDocument.Source.Text;
+
+        if (!AssetPathCompletionFacts.TryGetAssetPathContext(context.Owner, info, sourceText, context.AbsoluteIndex, out var replacementSpan))
+        {
+            return [];
+        }
+
+        var replacementRange = sourceText.GetLinePositionSpan(replacementSpan);
+
+        using var completionItems = new PooledArrayBuilder<RazorCompletionItem>(info.Assets.Length);
+
+        foreach (var asset in info.Assets)
+        {
+            completionItems.Add(RazorCompletionItem.CreateAssetPath(
+                displayText: asset,
+                insertText: asset,
+                replacementRange: replacementRange));
+        }
+
+        return completionItems.ToImmutable();
+    }
+}

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/AssetPathCompletionItemProvider.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/AssetPathCompletionItemProvider.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Immutable;
 using System.Composition;
-using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis.Razor.Completion;
 using Microsoft.CodeAnalysis.Text;

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/RazorCompletionContext.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/RazorCompletionContext.cs
@@ -24,4 +24,11 @@ internal record RazorCompletionContext(
     /// Null when local HTML completions were not produced for this context (e.g., non-HTML position or no element completions).
     /// </summary>
     public HashSet<string>? HtmlLabels { get; init; }
+
+    /// <summary>
+    /// The opted-in element/attribute pairs and static web asset keys for the containing project, or
+    /// <see langword="null"/> when the position isn't one where an asset path could be offered.
+    /// Resolved by the caller because it is project-scoped and asynchronous, while providers are not.
+    /// </summary>
+    public AssetPathCompletionInfo? AssetPathInfo { get; init; }
 }

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/RazorCompletionListProvider.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/RazorCompletionListProvider.cs
@@ -281,6 +281,38 @@ internal sealed class RazorCompletionListProvider(
                     completionItem = csharpRazorKeywordCompletionItem;
                     return true;
                 }
+            case RazorCompletionItemKind.AssetPath:
+                {
+                    var assetPathCompletionItem = new VSInternalCompletionItem()
+                    {
+                        Label = razorCompletionItem.DisplayText,
+                        FilterText = razorCompletionItem.DisplayText,
+                        SortText = razorCompletionItem.SortText,
+                        InsertTextFormat = insertTextFormat,
+                        Kind = CompletionItemKind.File,
+                    };
+
+                    // An explicit edit rather than InsertText: asset keys contain '/' and '.', which
+                    // the editor's word-boundary heuristic treats as boundaries, so it would replace
+                    // only the last segment of a partially typed path.
+                    if (razorCompletionItem.ReplacementRange is { } replacementRange)
+                    {
+                        assetPathCompletionItem.TextEdit = new TextEdit()
+                        {
+                            Range = replacementRange.ToRange(),
+                            NewText = razorCompletionItem.InsertText,
+                        };
+                    }
+                    else
+                    {
+                        assetPathCompletionItem.InsertText = razorCompletionItem.InsertText;
+                    }
+
+                    assetPathCompletionItem.UseCommitCharactersFrom(razorCompletionItem, clientCapabilities);
+
+                    completionItem = assetPathCompletionItem;
+                    return true;
+                }
         }
 
         completionItem = null;

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/RemoteCompletionService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/RemoteCompletionService.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis.LanguageServer;
 using Microsoft.CodeAnalysis.LanguageServer.Handler;
@@ -51,6 +52,7 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
     private readonly IRazorFormattingService _formattingService = args.ExportProvider.GetExportedValue<IRazorFormattingService>();
     private readonly IDocumentMappingService _documentMappingService = args.ExportProvider.GetExportedValue<IDocumentMappingService>();
     private readonly ITelemetryReporter _telemetryReporter = args.ExportProvider.GetExportedValue<ITelemetryReporter>();
+    private readonly AssetPathCompletionInfoProvider _assetPathCompletionInfoProvider = args.ExportProvider.GetExportedValue<AssetPathCompletionInfoProvider>();
 
     public ValueTask<CompletionPositionInfo?> GetPositionInfoAsync(
         JsonSerializableRazorSolutionWrapper solutionInfo,
@@ -106,7 +108,58 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
         var shouldIncludeHtmlCompletions = positionInfo.LanguageKind == RazorLanguageKind.Html
             && !DelegatedCompletionHelper.IsInDirectiveAttributeParameterContext(codeDocument, index);
 
+        if (shouldIncludeHtmlCompletions &&
+            await IsAssetPathContextAsync(documentSnapshot, codeDocument, sourceText, index, cancellationToken).ConfigureAwait(false))
+        {
+            // The HTML server offers sibling files here, which are the wrong thing entirely: a '~/'
+            // value resolves against the static web assets manifest, not the file system.
+            shouldIncludeHtmlCompletions = false;
+        }
+
         return new CompletionPositionInfo(ProvisionalTextEdit: null, positionInfo, shouldIncludeSnippets, shouldIncludeHtmlCompletions, isStartTagContext);
+    }
+
+    /// <summary>
+    /// Resolves the project's asset path data, but only once a cheap textual check says the position
+    /// looks like a <c>~/</c> value. Completion runs on most keystrokes and this data is
+    /// project-scoped, so the common case must not pay for it.
+    /// </summary>
+    private async ValueTask<AssetPathCompletionInfo?> TryGetAssetPathInfoAsync(
+        RemoteDocumentSnapshot documentSnapshot,
+        RazorCodeDocument codeDocument,
+        SourceText sourceText,
+        int absoluteIndex,
+        CancellationToken cancellationToken)
+    {
+        if (!AssetPathCompletionFacts.IsSupported(codeDocument.GetRequiredTagHelperRewrittenSyntaxTree().Options) ||
+            !AssetPathCompletionFacts.IsAssetPathCandidate(sourceText, absoluteIndex))
+        {
+            return null;
+        }
+
+        var info = await _assetPathCompletionInfoProvider
+            .GetInfoAsync(documentSnapshot.ProjectSnapshot, cancellationToken)
+            .ConfigureAwait(false);
+
+        return info.IsEmpty ? null : info;
+    }
+
+    private async ValueTask<bool> IsAssetPathContextAsync(
+        RemoteDocumentSnapshot documentSnapshot,
+        RazorCodeDocument codeDocument,
+        SourceText sourceText,
+        int absoluteIndex,
+        CancellationToken cancellationToken)
+    {
+        if (await TryGetAssetPathInfoAsync(documentSnapshot, codeDocument, sourceText, absoluteIndex, cancellationToken).ConfigureAwait(false) is not { } info)
+        {
+            return false;
+        }
+
+        var owner = codeDocument.GetRequiredTagHelperRewrittenSyntaxTree().Root
+            .FindInnermostNode(absoluteIndex, includeWhitespace: true, walkMarkersBack: true);
+
+        return AssetPathCompletionFacts.TryGetAssetPathContext(owner, info, sourceText, absoluteIndex, out _);
     }
 
     /// <summary>
@@ -250,6 +303,15 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
             codeDocument,
             out var razorCompletionContext,
             out var localHtmlCompletionList);
+
+        if (isRazorTrigger)
+        {
+            var sourceText = codeDocument.Source.Text;
+            if (await TryGetAssetPathInfoAsync(documentSnapshot, codeDocument, sourceText, documentPositionInfo.HostDocumentIndex, cancellationToken).ConfigureAwait(false) is { } assetPathInfo)
+            {
+                razorCompletionContext = razorCompletionContext with { AssetPathInfo = assetPathInfo };
+            }
+        }
 
         if (!isCSharpTrigger && !isRazorTrigger)
         {

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/StaticWebAssets/StaticWebAssetsManifestReader.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/StaticWebAssets/StaticWebAssetsManifestReader.cs
@@ -1,0 +1,102 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Razor.PooledObjects;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.Remote.Razor.StaticWebAssets;
+
+/// <summary>
+/// Reads the static web assets IntelliSense manifest the SDK emits, which lists the keys that
+/// resolve through <c>ResourceAssetCollection</c> at runtime:
+/// <code>
+/// { "Version": 1, "Assets": [ "app.css", "_framework/blazor.web.js" ] }
+/// </code>
+/// </summary>
+internal static class StaticWebAssetsManifestReader
+{
+    private const int SupportedVersion = 1;
+
+    /// <summary>
+    /// Returns the asset keys in the manifest, or an empty array if it cannot be understood. A
+    /// manifest from a newer SDK, or one that is malformed because a build is midway through
+    /// writing it, costs completions rather than failing the request that asked for them.
+    /// </summary>
+    public static ImmutableArray<string> Read(SourceText text)
+    {
+        try
+        {
+            return ReadCore(text);
+        }
+        catch (JsonException)
+        {
+            return [];
+        }
+    }
+
+    private static ImmutableArray<string> ReadCore(SourceText text)
+    {
+        var reader = new Utf8JsonReader(GetUtf8Bytes(text), isFinalBlock: true, state: default);
+
+        if (!reader.Read() || reader.TokenType != JsonTokenType.StartObject)
+        {
+            return [];
+        }
+
+        var version = 0;
+        var assets = ImmutableArray<string>.Empty;
+
+        while (reader.Read() && reader.TokenType == JsonTokenType.PropertyName)
+        {
+            if (reader.ValueTextEquals("Version"))
+            {
+                reader.Read();
+                version = reader.TokenType == JsonTokenType.Number ? reader.GetInt32() : 0;
+            }
+            else if (reader.ValueTextEquals("Assets"))
+            {
+                assets = ReadAssets(ref reader);
+            }
+            else
+            {
+                reader.Read();
+                reader.Skip();
+            }
+        }
+
+        return version == SupportedVersion ? assets : [];
+    }
+
+    private static ImmutableArray<string> ReadAssets(ref Utf8JsonReader reader)
+    {
+        if (!reader.Read() || reader.TokenType != JsonTokenType.StartArray)
+        {
+            return [];
+        }
+
+        using var builder = new PooledArrayBuilder<string>();
+
+        while (reader.Read() && reader.TokenType == JsonTokenType.String)
+        {
+            if (reader.GetString() is { Length: > 0 } asset)
+            {
+                builder.Add(asset);
+            }
+        }
+
+        return builder.ToImmutable();
+    }
+
+    private static byte[] GetUtf8Bytes(SourceText text)
+    {
+        // The manifest is a few KB even for asset-heavy apps, so materializing it is cheaper than
+        // the machinery needed to feed the reader in chunks.
+        var content = text.ToString();
+        var bytes = new byte[Encoding.UTF8.GetByteCount(content)];
+        Encoding.UTF8.GetBytes(content, 0, content.Length, bytes, 0);
+        return bytes;
+    }
+}

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/StaticWebAssets/StaticWebAssetsProvider.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/StaticWebAssets/StaticWebAssetsProvider.cs
@@ -1,0 +1,88 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Immutable;
+using System.Composition;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
+
+namespace Microsoft.CodeAnalysis.Remote.Razor.StaticWebAssets;
+
+/// <summary>
+/// Supplies the static web asset keys available to a project, as declared by the IntelliSense
+/// manifest the SDK flows in as an additional file.
+/// </summary>
+/// <remarks>
+/// Arriving as an additional file rather than a file read off disk is what makes this cheap to keep
+/// current: the manifest is part of the workspace snapshot, so a rebuild that changes it produces a
+/// new document version and invalidates the cached parse with no watcher or polling involved.
+/// </remarks>
+[Export(typeof(StaticWebAssetsProvider)), Shared]
+internal sealed class StaticWebAssetsProvider
+{
+    private const string ManifestFileName = "staticwebassets.intellisense.json";
+    private const string ManifestMetadataKey = "build_metadata.AdditionalFiles.IsStaticWebAssetsManifest";
+
+    private readonly ConditionalWeakTable<TextDocument, StrongBox<ImmutableArray<string>>> _cache = new();
+
+    /// <summary>
+    /// Returns the asset keys for <paramref name="projectSnapshot"/>, or an empty array when the
+    /// project has no manifest -- an older SDK, a project that has never been built, or one that
+    /// isn't a web project at all.
+    /// </summary>
+    public async ValueTask<ImmutableArray<string>> GetAssetsAsync(RemoteProjectSnapshot projectSnapshot, CancellationToken cancellationToken)
+    {
+        if (TryFindManifestDocument(projectSnapshot.Project) is not { } manifestDocument)
+        {
+            return [];
+        }
+
+        // Keyed on the document instance because Roslyn documents are immutable: an edit or rebuild
+        // produces a different instance, which misses the cache and reparses.
+        if (_cache.TryGetValue(manifestDocument, out var cached))
+        {
+            return cached.Value;
+        }
+
+        var text = await manifestDocument.GetTextAsync(cancellationToken).ConfigureAwait(false);
+        var assets = StaticWebAssetsManifestReader.Read(text);
+
+        return _cache.GetValue(manifestDocument, _ => new StrongBox<ImmutableArray<string>>(assets)).Value;
+    }
+
+    private static TextDocument? TryFindManifestDocument(Project project)
+    {
+        var optionsProvider = project.AnalyzerOptions.AnalyzerConfigOptionsProvider;
+
+        foreach (var document in project.AdditionalDocuments)
+        {
+            // Checking the name first keeps the common case -- a project whose additional files are
+            // all .razor -- from querying analyzer config options once per document.
+            if (document.FilePath is not { } filePath ||
+                !string.Equals(Path.GetFileName(filePath), ManifestFileName, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            foreach (var additionalText in project.AnalyzerOptions.AdditionalFiles)
+            {
+                if (!string.Equals(additionalText.Path, filePath, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                if (optionsProvider.GetOptions(additionalText).TryGetValue(ManifestMetadataKey, out var value) &&
+                    string.Equals(value, "true", StringComparison.OrdinalIgnoreCase))
+                {
+                    return document;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Razor/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Language/IntegrationTests/RazorToolingIntegrationTestBase.cs
+++ b/src/Razor/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Language/IntegrationTests/RazorToolingIntegrationTestBase.cs
@@ -182,7 +182,7 @@ public class RazorToolingIntegrationTestBase : ToolingTestBase
         {
             // The first phase won't include any metadata references for component discovery. This mirrors
             // what the build does.
-            var projectEngine = CreateProjectEngine(RazorConfiguration.Default, Array.Empty<MetadataReference>());
+            var projectEngine = CreateProjectEngine(Configuration, Array.Empty<MetadataReference>());
 
             RazorCodeDocument codeDocument;
             foreach (var item in AdditionalRazorItems)
@@ -213,7 +213,7 @@ public class RazorToolingIntegrationTestBase : ToolingTestBase
 
             // Add the 'temp' compilation as a metadata reference
             var references = BaseCompilation.References.Concat(new[] { tempAssembly.Compilation.ToMetadataReference() }).ToArray();
-            projectEngine = CreateProjectEngine(RazorConfiguration.Default, references);
+            projectEngine = CreateProjectEngine(Configuration, references);
 
             // Now update the any additional files
             foreach (var item in AdditionalRazorItems)

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Completion/CompletionTriggerAndCommitCharactersTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.UnitTests/Completion/CompletionTriggerAndCommitCharactersTest.cs
@@ -1,0 +1,96 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Linq;
+using Microsoft.AspNetCore.Razor.LanguageServer.Test;
+using Microsoft.AspNetCore.Razor.Test.Common;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.CodeAnalysis.Razor.Completion;
+
+/// <summary>
+/// Pins the trigger character sets. These flow straight into the LSP registration, so widening one
+/// changes how often the editor asks for completions across every Razor document, and narrowing one
+/// silently stops a feature from ever being offered on typing.
+/// </summary>
+public class CompletionTriggerAndCommitCharactersTest(ITestOutputHelper testOutput) : ToolingTestBase(testOutput)
+{
+    private static CompletionTriggerAndCommitCharacters Create(bool supportsVisualStudioExtensions)
+        => new(new TestClientCapabilitiesService(
+            new VSInternalClientCapabilities() { SupportsVisualStudioExtensions = supportsVisualStudioExtensions }));
+
+    [Theory]
+    [InlineData("@")]
+    [InlineData("<")]
+    [InlineData(":")]
+    [InlineData(" ")]
+    // '~' and '/' let the asset path list appear as '~/' is typed inside an opted-in attribute.
+    [InlineData("~")]
+    [InlineData("/")]
+    public void RazorTriggerCharacters(string character)
+    {
+        Assert.True(Create(supportsVisualStudioExtensions: true).IsValidRazorTrigger(TypingContext(character)));
+    }
+
+    [Theory]
+    [InlineData("!")]
+    [InlineData(".")]
+    [InlineData("#")]
+    [InlineData("(")]
+    [InlineData("\"")]
+    public void NonRazorTriggerCharacters(string character)
+    {
+        Assert.False(Create(supportsVisualStudioExtensions: true).IsValidRazorTrigger(TypingContext(character)));
+    }
+
+    [Fact]
+    public void ExplicitInvocationIsAlwaysAValidRazorTrigger()
+    {
+        var context = new VSInternalCompletionContext()
+        {
+            InvokeKind = VSInternalCompletionInvokeKind.Explicit,
+            TriggerKind = CompletionTriggerKind.Invoked
+        };
+
+        Assert.True(Create(supportsVisualStudioExtensions: true).IsValidRazorTrigger(context));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AllTriggerCharactersAreUnchangedByTheRazorSet(bool supportsVisualStudioExtensions)
+    {
+        // '~' and '/' were already registered through the C# set, so adding them to the Razor set
+        // must not change what the editor is told to trigger on.
+        var all = Create(supportsVisualStudioExtensions).AllTriggerCharacters;
+
+        Assert.Contains("~", all);
+        Assert.Contains("/", all);
+        Assert.Equal(all.Length, all.Distinct().Count());
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void HtmlAndCSharpTriggersAreUnaffected(bool supportsVisualStudioExtensions)
+    {
+        var triggers = Create(supportsVisualStudioExtensions);
+
+        // '/' reaching the Razor providers must not also make it an HTML trigger in VS Code, where
+        // the HTML set is deliberately small.
+        Assert.Equal(supportsVisualStudioExtensions, triggers.IsHtmlTriggerCharacter("/"));
+        Assert.False(triggers.IsHtmlTriggerCharacter("~"));
+
+        Assert.True(triggers.IsCSharpTriggerCharacter("/"));
+        Assert.True(triggers.IsCSharpTriggerCharacter("~"));
+    }
+
+    private static VSInternalCompletionContext TypingContext(string triggerCharacter)
+        => new()
+        {
+            InvokeKind = VSInternalCompletionInvokeKind.Typing,
+            TriggerCharacter = triggerCharacter,
+            TriggerKind = CompletionTriggerKind.TriggerCharacter
+        };
+}

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.UnitTests/Completion/AssetPathCompletionItemProviderTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.UnitTests/Completion/AssetPathCompletionItemProviderTest.cs
@@ -1,0 +1,313 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Components;
+using Microsoft.AspNetCore.Razor.Language.IntegrationTests;
+using Microsoft.AspNetCore.Razor.Language.Syntax;
+using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.CodeAnalysis.Razor.Completion;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.CodeAnalysis.Remote.Razor.Completion;
+
+public class AssetPathCompletionItemProviderTest : RazorToolingIntegrationTestBase
+{
+    // The runtime types the compiler keys off aren't in the reference assemblies used by these
+    // tests, so they're declared here. Mirrors the stubs the compiler's tilde-path tests use.
+    private const string AssetPathStubs = """
+        namespace Microsoft.AspNetCore.Components
+        {
+            [System.AttributeUsage(System.AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+            public sealed class AssetPathAttribute : System.Attribute
+            {
+                public AssetPathAttribute() { }
+            }
+
+            [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
+            public sealed class AcceptsAssetPathAttribute : System.Attribute
+            {
+                public AcceptsAssetPathAttribute(string elementName, string attributeName)
+                {
+                    ElementName = elementName;
+                    AttributeName = attributeName;
+                }
+
+                public string ElementName { get; }
+                public string AttributeName { get; }
+            }
+        }
+
+        namespace Microsoft.AspNetCore.Components.Web
+        {
+            [Microsoft.AspNetCore.Components.AcceptsAssetPath("img", "src")]
+            [Microsoft.AspNetCore.Components.AcceptsAssetPath("link", "href")]
+            [Microsoft.AspNetCore.Components.AcceptsAssetPath("script", "src")]
+            public static class AssetPathAttributes { }
+        }
+        """;
+
+    private const string ImageComponent = """
+        using Microsoft.AspNetCore.Components;
+
+        namespace Test
+        {
+            public class Image : ComponentBase
+            {
+                [Parameter]
+                [AssetPath]
+                public string Source { get; set; }
+
+                [Parameter]
+                public string Alt { get; set; }
+            }
+        }
+        """;
+
+    private static readonly ImmutableArray<string> s_assets =
+    [
+        "app.css",
+        "images/logo.png",
+        "images/hero.png",
+        "_framework/blazor.web.js"
+    ];
+
+    private readonly AssetPathCompletionItemProvider _provider = new();
+    private readonly RazorCompletionOptions _options = new(
+        SnippetsSupported: true,
+        AutoInsertAttributeQuotes: true,
+        CommitElementsWithSpace: true,
+        IsVsCode: false);
+
+    internal override RazorFileKind? FileKind => RazorFileKind.Component;
+    internal override bool UseTwoPhaseCompilation => true;
+
+    // Asset path expansion is gated to Razor 11.0, and RazorLanguageVersion.Latest is still 9.0, so
+    // the default configuration would compile these documents with the feature switched off.
+    internal override RazorConfiguration Configuration { get; } =
+        RazorConfiguration.Default with { LanguageVersion = RazorLanguageVersion.Version_11_0 };
+
+    public AssetPathCompletionItemProviderTest(ITestOutputHelper testOutput)
+        : base(testOutput)
+    {
+    }
+
+    [Fact]
+    public void AllowlistedHtmlAttribute_OffersAssets()
+    {
+        TestCode testCode = """<img src="~/ima$$" />""";
+
+        var completions = GetCompletionItems(testCode);
+
+        Assert.Equal(s_assets.Sort(), completions.Select(c => c.DisplayText).Order());
+    }
+
+    [Fact]
+    public void AllowlistedHtmlAttribute_ReplacesOnlyThePathAfterTheTilde()
+    {
+        TestCode testCode = """<img src="~/ima$$ges/old.png" />""";
+
+        var completions = GetCompletionItems(testCode);
+
+        // The replacement has to cover the whole path, not just the segment after the last '/',
+        // or committing leaves the old value behind.
+        var item = Assert.Single(completions, c => c.DisplayText == "images/logo.png");
+        var range = Assert.NotNull(item.ReplacementRange);
+        Assert.Equal(12, range.Start.Character);
+        Assert.Equal(26, range.End.Character);
+    }
+
+    [Fact]
+    public void EmptyPathAfterTilde_OffersAssets()
+    {
+        TestCode testCode = """<img src="~/$$" />""";
+
+        var completions = GetCompletionItems(testCode);
+
+        Assert.NotEmpty(completions);
+    }
+
+    [Fact]
+    public void CursorInsideTildePrefix_OffersNothing()
+    {
+        TestCode testCode = """<img src="~$$/" />""";
+
+        Assert.Empty(GetCompletionItems(testCode));
+    }
+
+    [Fact]
+    public void ValueWithoutTilde_OffersNothing()
+    {
+        TestCode testCode = """<img src="images/$$" />""";
+
+        Assert.Empty(GetCompletionItems(testCode));
+    }
+
+    [Fact]
+    public void AttributeNotOnTheAllowlist_OffersNothing()
+    {
+        TestCode testCode = """<img alt="~/ima$$" />""";
+
+        Assert.Empty(GetCompletionItems(testCode));
+    }
+
+    [Fact]
+    public void ElementNotOnTheAllowlist_OffersNothing()
+    {
+        TestCode testCode = """<div data-src="~/ima$$"></div>""";
+
+        Assert.Empty(GetCompletionItems(testCode));
+    }
+
+    [Fact]
+    public void AttributeName_OffersNothing()
+    {
+        TestCode testCode = """<img sr$$c="~/images/logo.png" />""";
+
+        Assert.Empty(GetCompletionItems(testCode));
+    }
+
+    [Fact]
+    public void NoAssets_OffersNothing()
+    {
+        TestCode testCode = """<img src="~/ima$$" />""";
+
+        Assert.Empty(GetCompletionItems(testCode, assets: []));
+    }
+
+    [Fact]
+    public void ComponentParameterMarkedAssetPath_OffersAssets()
+    {
+        AdditionalSyntaxTrees.Add(Parse(ImageComponent));
+
+        TestCode testCode = """<Image Source="~/ima$$" />""";
+
+        Assert.NotEmpty(GetCompletionItems(testCode));
+    }
+
+    [Fact]
+    public void ComponentParameterWithoutAssetPath_OffersNothing()
+    {
+        AdditionalSyntaxTrees.Add(Parse(ImageComponent));
+
+        TestCode testCode = """<Image Alt="~/ima$$" />""";
+
+        Assert.Empty(GetCompletionItems(testCode));
+    }
+
+    [Fact]
+    public void MixedContent_OffersNothing()
+    {
+        TestCode testCode = """<img src="~/@folder/ima$$" />""";
+
+        Assert.Empty(GetCompletionItems(testCode));
+    }
+
+    [Fact]
+    public void LegacyDocument_OffersNothing()
+    {
+        TestCode testCode = """<img src="~/ima$$" />""";
+
+        Assert.Empty(GetCompletionItems(testCode, fileKind: RazorFileKind.Legacy));
+    }
+
+    [Theory]
+    // The producer that discovers [AcceptsAssetPath] is registered from Razor 3.0, but
+    // ComponentTildePathPass only expands from 11.0, so a project can carry the opt-in metadata
+    // while nothing it writes will actually be rewritten. Note 'Latest' is still 9.0; the feature
+    // is only on under 'preview'.
+    [InlineData("10.0", RazorFileKind.Component, false)]
+    [InlineData("latest", RazorFileKind.Component, false)]
+    [InlineData("11.0", RazorFileKind.Component, true)]
+    [InlineData("preview", RazorFileKind.Component, true)]
+    [InlineData("11.0", RazorFileKind.Legacy, false)]
+    public void IsSupported(string version, RazorFileKind fileKind, bool expected)
+    {
+        var options = RazorParserOptions.Create(RazorLanguageVersion.Parse(version), fileKind);
+
+        Assert.Equal(expected, AssetPathCompletionFacts.IsSupported(options));
+    }
+
+    [Fact]
+    public void Create_IgnoresTagHelpersWithoutAssetPathMetadata()
+    {
+        var info = AssetPathCompletionInfo.Create(TagHelperCollection.Create(
+            [TagHelperDescriptorBuilder.Create("Test.Component", "TestAssembly").Build()]));
+
+        Assert.Same(AssetPathCompletionInfo.Empty, info);
+    }
+
+    [Fact]
+    public void AcceptsAssetPath_IsCaseInsensitive()
+    {
+        var info = CreateInfo(s_assets);
+
+        Assert.True(info.AcceptsAssetPath("IMG", "SRC"));
+        Assert.False(info.AcceptsAssetPath("img", "alt"));
+    }
+
+    private ImmutableArray<RazorCompletionItem> GetCompletionItems(
+        TestCode testCode,
+        ImmutableArray<string>? assets = null,
+        RazorFileKind fileKind = RazorFileKind.Component)
+    {
+        AdditionalSyntaxTrees.Add(Parse(AssetPathStubs));
+
+        var result = CompileToCSharp("Test.razor", testCode.Text, throwOnFailure: false, fileKind: fileKind);
+        var codeDocument = result.CodeDocument;
+
+        var syntaxTree = codeDocument.GetRequiredTagHelperRewrittenSyntaxTree();
+        var owner = syntaxTree.Root.FindInnermostNode(testCode.Position, includeWhitespace: true, walkMarkersBack: true);
+        owner = RazorCompletionFactsService.AdjustSyntaxNodeForWordBoundary(owner, testCode.Position);
+
+        var context = new RazorCompletionContext(
+            codeDocument,
+            testCode.Position,
+            owner,
+            syntaxTree,
+            codeDocument.GetRequiredTagHelperContext(),
+            CompletionReason.Typing,
+            _options)
+        {
+            AssetPathInfo = CreateInfo(assets ?? s_assets)
+        };
+
+        return _provider.GetCompletionItems(context);
+    }
+
+    /// <summary>
+    /// Builds the allowlist from carrier descriptors directly rather than from the compiled
+    /// document's tag helpers, because the document's set is namespace-scoped and asset path
+    /// expansion deliberately isn't.
+    /// </summary>
+    private static AssetPathCompletionInfo CreateInfo(ImmutableArray<string> assets)
+    {
+        var carriers = new[]
+        {
+            CreateCarrier("img", "src"),
+            CreateCarrier("link", "href"),
+            CreateCarrier("script", "src")
+        };
+
+        return AssetPathCompletionInfo.Create(TagHelperCollection.Create(carriers)).WithAssets(assets);
+    }
+
+    private static TagHelperDescriptor CreateCarrier(string element, string attribute)
+    {
+        var builder = TagHelperDescriptorBuilder.Create(
+            TagHelperKind.AssetPath, $"{element}[{attribute}]", "Microsoft.AspNetCore.Components");
+
+        builder.SetTypeName(
+            "Microsoft.AspNetCore.Components.Web.AssetPathAttributes",
+            "Microsoft.AspNetCore.Components.Web",
+            "AssetPathAttributes");
+
+        builder.CaseSensitive = true;
+        builder.SetMetadata(new AssetPathMetadata { Element = element, Attribute = attribute });
+
+        return builder.Build();
+    }
+}

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.UnitTests/StaticWebAssets/StaticWebAssetsManifestReaderTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.UnitTests/StaticWebAssets/StaticWebAssetsManifestReaderTest.cs
@@ -1,0 +1,91 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.CodeAnalysis.Text;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Remote.Razor.StaticWebAssets;
+
+public class StaticWebAssetsManifestReaderTest
+{
+    [Fact]
+    public void ReadsAssetsInOrder()
+    {
+        var assets = Read("""
+            { "Version": 1, "Assets": [ "app.css", "images/logo.png" ] }
+            """);
+
+        Assert.Equal(["app.css", "images/logo.png"], assets);
+    }
+
+    [Fact]
+    public void EmptyAssetList()
+    {
+        Assert.Empty(Read("""{ "Version": 1, "Assets": [] }"""));
+    }
+
+    [Fact]
+    public void ToleratesUnknownProperties()
+    {
+        var assets = Read("""
+            {
+              "Version": 1,
+              "Source": { "Name": "App", "Nested": [ 1, 2 ] },
+              "Assets": [ "app.css" ]
+            }
+            """);
+
+        Assert.Equal(["app.css"], assets);
+    }
+
+    [Fact]
+    public void PropertyOrderDoesNotMatter()
+    {
+        var assets = Read("""
+            { "Assets": [ "app.css" ], "Version": 1 }
+            """);
+
+        Assert.Equal(["app.css"], assets);
+    }
+
+    [Theory]
+    // A version we don't understand may mean something entirely different by "Assets".
+    [InlineData("""{ "Version": 2, "Assets": [ "app.css" ] }""")]
+    [InlineData("""{ "Assets": [ "app.css" ] }""")]
+    // Truncated because a build was midway through writing the file.
+    [InlineData("""{ "Version": 1, "Assets": [ "app.c""")]
+    [InlineData("not json at all")]
+    [InlineData("[]")]
+    [InlineData("")]
+    public void UnusableManifestYieldsNoAssets(string json)
+    {
+        Assert.Empty(Read(json));
+    }
+
+    [Fact]
+    public void ReadsRealSdkOutput()
+    {
+        // Verbatim output of GenerateStaticWebAssetsIntelliSenseManifest for a component app with a
+        // wwwroot, kept as-is so a change to the SDK's shape fails here rather than silently
+        // costing every completion.
+        var assets = Read("""
+            {"Version":1,"Assets":["ComponentApp.bundle.scp.css","ComponentApp.styles.css","_framework/blazor.server.js","_framework/blazor.server.js.map","_framework/blazor.web.js","_framework/blazor.web.js.map","css/site.css","images/logo.svg"]}
+            """);
+
+        Assert.Equal(
+            [
+                "ComponentApp.bundle.scp.css",
+                "ComponentApp.styles.css",
+                "_framework/blazor.server.js",
+                "_framework/blazor.server.js.map",
+                "_framework/blazor.web.js",
+                "_framework/blazor.web.js.map",
+                "css/site.css",
+                "images/logo.svg"
+            ],
+            assets);
+    }
+
+    private static string[] Read(string json)
+        => [.. StaticWebAssetsManifestReader.Read(SourceText.From(json))];
+}


### PR DESCRIPTION
Adds IntelliSense for `~/` asset paths in Razor components, the tooling half of
the compile-time expansion that landed in #84796.

Fixes #84793

## What this does

Inside an attribute that opted into asset-path expansion, typing `~/` now offers
the project's static web assets:

```razor
<img src="~/im|" />        <!-- images/logo.png, images/hero.png, app.css, ... -->
<Image Source="~/im|" />   <!-- [AssetPath] component parameters too -->
```

The HTML language server currently fills this gap with *relative file path*
completions, which are the wrong thing entirely for a value resolved against the
static web assets manifest rather than the file system. Those are now suppressed
once the value starts with `~/`.

## Where the data comes from

The set of keys that resolve through `ResourceAssetCollection` arrives as an
`AdditionalFile` tagged `IsStaticWebAssetsManifest`, emitted by a companion
change in dotnet/sdk. Riding the workspace snapshot means invalidation is by
document version, with no file watcher and no disk access from OOP.

**This PR is inert until that SDK change ships** — an absent manifest yields an
empty asset set and no completions — so it can merge independently.

## Notes for reviewers

- **The allowlist comes from the project-wide tag helper set, not the
  document's.** The carriers produced from `[AcceptsAssetPath]` live on a type in
  the runtime's namespace, so scoping them by the document's `@using` directives
  would let completion and compilation disagree about which attributes opted in.
  `ComponentTildePathPass` reads the full set for the same reason.
- **Two gates keep the offer honest.** The producer that discovers
  `[AcceptsAssetPath]` is registered from Razor 3.0 while expansion only happens
  from 11.0, so a project can hold the opt-in metadata with nothing rewritten.
  Note `RazorLanguageVersion.Latest` is still 9.0, so today this only lights up
  under `preview`. Mixed literal/expression values are excluded too, matching the
  pass.
- **Trigger characters.** `~` and `/` are added to the Razor set. Both already
  reach the client's registration through the C# set, so what the editor triggers
  on is unchanged; this only widens what is routed to the Razor providers, all of
  which early-out. Nothing pinned these sets before, so the last commit adds a
  test that does — worth a look, since `/` now reaches the providers on every
  closing tag.
- **Explicit `TextEdit` on items.** Asset keys contain `/` and `.`, so the
  editor's word-boundary heuristic would otherwise replace only the last segment
  of a partially typed path.

## Testing

`AssetPathCompletionItemProviderTest` covers the HTML allowlist, `[AssetPath]`
parameters, non-opted-in element/attribute, cursor inside the `~/` prefix, cursor
in the attribute name, empty asset set, mixed content, legacy documents, and the
language-version gate. `StaticWebAssetsManifestReaderTest` includes verbatim real
SDK output so a shape change there fails loudly rather than silently costing
completions.

Green locally: Remote.Razor 519/519, Workspaces 423/423,
VisualStudioCode.RazorExtension 1525/1525.

Each of the three commits builds and tests independently.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85058)