### PR TITLE
Fix Razor formatting around blank lines and Razor comments

### DIFF
--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Formatting/FormattingUtilities.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Formatting/FormattingUtilities.cs
@@ -341,8 +341,7 @@ internal static class FormattingUtilities
                     while (iFormatted + 1 < formattedText.Lines.Count &&
                         formattedText.Lines[iFormatted + 1].Span.Length == 0 &&
                         iOriginal + 1 < originalText.Lines.Count &&
-                        originalText.Lines[iOriginal + 1] is { } nextOriginalLine &&
-                        nextOriginalLine.Span.Length != 0)
+                        originalText.Lines[iOriginal + 1].GetFirstNonWhitespaceOffset() is not null)
                     {
                         // Next formatted line is blank but next original line isn't, so the
                         // formatter inserted a blank line. Consume it and preserve it in the output.
@@ -353,14 +352,15 @@ internal static class FormattingUtilities
                     }
                 }
             }
-            else if (originalText.Lines[iOriginal] is { } blankOriginalLine &&
+            else if (iOriginal + 1 < originalText.Lines.Count &&
+                originalText.Lines[iOriginal] is { } blankOriginalLine &&
                 blankOriginalLine.GetFirstNonWhitespaceOffset() is null)
             {
                 // The current lines are an aligned blank pair. Consume any additional formatted blank lines
-                // before the next non-blank original line so the line mapping remains synchronized.
+                // before the next non-blank mapped original line so the line mapping remains synchronized.
                 while (iFormatted + 1 < formattedText.Lines.Count &&
                     formattedText.Lines[iFormatted + 1].Span.Length == 0 &&
-                    iOriginal + 1 < originalText.Lines.Count &&
+                    (formattedLineInfo[iOriginal + 1].ProcessIndentation || formattedLineInfo[iOriginal + 1].ProcessFormatting) &&
                     originalText.Lines[iOriginal + 1].GetFirstNonWhitespaceOffset() is not null)
                 {
                     iFormatted++;

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Formatting/FormattingUtilities.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Formatting/FormattingUtilities.cs
@@ -338,30 +338,32 @@ internal static class FormattingUtilities
                     // the formatter may have inserted a blank line after the current line too. In that case we need to make sure
                     // we advance the formatted line pointer past it, but also include it. This only applies if the line after the
                     // blank line matches the next original line and the next original line isn't blank (ie, an actual insertion)
-                    while (iFormatted + 1 < formattedText.Lines.Count &&
-                        formattedText.Lines[iFormatted + 1].Span.Length == 0 &&
-                        iOriginal + 1 < originalText.Lines.Count &&
+                    if (iOriginal + 1 < originalText.Lines.Count &&
                         originalText.Lines[iOriginal + 1].GetFirstNonWhitespaceOffset() is not null)
                     {
-                        // Next formatted line is blank but next original line isn't, so the
-                        // formatter inserted a blank line. Consume it and preserve it in the output.
-                        // We insert at EndIncludingLineBreak so the blank line appears after any
-                        // wrapped lines that ConsumeNewLines inserted (which also use EndIncludingLineBreak).
-                        iFormatted++;
-                        formattingChanges.Add(new TextChange(new(originalLine.EndIncludingLineBreak, 0), context.NewLineString));
+                        while (iFormatted + 1 < formattedText.Lines.Count &&
+                            formattedText.Lines[iFormatted + 1].Span.Length == 0)
+                        {
+                            // Next formatted line is blank but next original line isn't, so the
+                            // formatter inserted a blank line. Consume it and preserve it in the output.
+                            // We insert at EndIncludingLineBreak so the blank line appears after any
+                            // wrapped lines that ConsumeNewLines inserted (which also use EndIncludingLineBreak).
+                            iFormatted++;
+                            formattingChanges.Add(new TextChange(new(originalLine.EndIncludingLineBreak, 0), context.NewLineString));
+                        }
                     }
                 }
             }
             else if (iOriginal + 1 < originalText.Lines.Count &&
                 originalText.Lines[iOriginal] is { } blankOriginalLine &&
-                blankOriginalLine.GetFirstNonWhitespaceOffset() is null)
+                blankOriginalLine.GetFirstNonWhitespaceOffset() is null &&
+                originalText.Lines[iOriginal + 1].GetFirstNonWhitespaceOffset() is not null)
             {
                 // The current lines are an aligned blank pair. Consume any additional formatted blank lines
                 // before the next non-blank mapped original line so the line mapping remains synchronized.
                 while (iFormatted + 1 < formattedText.Lines.Count &&
                     formattedText.Lines[iFormatted + 1].Span.Length == 0 &&
-                    (formattedLineInfo[iOriginal + 1].ProcessIndentation || formattedLineInfo[iOriginal + 1].ProcessFormatting) &&
-                    originalText.Lines[iOriginal + 1].GetFirstNonWhitespaceOffset() is not null)
+                    (formattedLineInfo[iOriginal + 1].ProcessIndentation || formattedLineInfo[iOriginal + 1].ProcessFormatting))
                 {
                     iFormatted++;
                     formattingChanges.Add(new TextChange(new(blankOriginalLine.EndIncludingLineBreak, 0), context.NewLineString));

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Formatting/DocumentFormattingTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Formatting/DocumentFormattingTest.cs
@@ -15852,6 +15852,113 @@ public class DocumentFormattingTest(ITestOutputHelper testOutput) : DocumentForm
                 """);
     }
 
+    [Fact]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/84601")]
+    public Task RazorCommentWithInternalBlankLine()
+    {
+        return RunFormattingTestAsync(
+            input: """
+                @if (true)
+                {
+                    @* Comment
+
+                    More comment *@
+                }
+                <div></div>
+                """,
+            htmlFormatted: """
+                @if (true)
+                {
+                    @* Comment
+
+                    More comment *@
+                }
+                <div></div>
+                """,
+            expected: """
+                @if (true)
+                {
+                    @* Comment
+
+                    More comment *@
+                }
+                <div></div>
+                """,
+            fileKind: RazorFileKind.Legacy,
+            validateHtmlFormattedMatchesWebTools: true);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/84601")]
+    public Task RazorCommentWithInternalBlankLine_NestedInHtml()
+    {
+        return RunFormattingTestAsync(
+            input: """
+                <div>
+                @* Comment
+
+                More comment *@
+                @if (true)
+                {
+                <span></span>
+                }
+                </div>
+                """,
+            htmlFormatted: """
+                <div>
+                    @* Comment
+
+                    More comment *@
+                    @if (true)
+                    {
+                    <span></span>
+                    }
+                </div>
+                """,
+            expected: """
+                <div>
+                    @* Comment
+
+                More comment *@
+                    @if (true)
+                    {
+                        <span></span>
+                    }
+                </div>
+                """,
+            fileKind: RazorFileKind.Legacy);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/roslyn/issues/84601")]
+    public Task WhitespaceOnlyLineBeforeCodeBlockClose()
+    {
+        return RunFormattingTestAsync(
+            input: """
+                @{
+                    Method();
+                  
+                }
+                <div></div>
+                """,
+            htmlFormatted: """
+                @{
+                    Method();
+
+                }
+                <div></div>
+                """,
+            expected: """
+                @{
+                    Method();
+                  
+                }
+                <div></div>
+                """,
+            fileKind: RazorFileKind.Legacy,
+            validateHtmlFormattedMatchesWebTools: true);
+    }
+
     private (string fileName, string contents)[] GetCheckBoxButtonComponentFiles()
         =>
         [


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/84601

A confluence of a couple of changes, missed a scenario where they overlap. Recent fixes to whitespace only line handling, and Razor comments, broke when there are whitespace only lines in comments.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85064)