### PR TITLE
Enforce `#nullable enable` in source packages

### DIFF
--- a/eng/targets/Imports.targets
+++ b/eng/targets/Imports.targets
@@ -106,7 +106,8 @@
       Updating a reference to this package to a newer version of the package may require changes in the referencing project.
       No compatibility guarantees are provided.
     </PackageDescription>
-    <!-- Files must individually enable nullable in source packages -->
+    <!-- Disable project-level nullable to catch packaged files without an explicit directive;
+      consumers may compile them in projects where nullable is disabled.  -->
     <Nullable>disable</Nullable>
   </PropertyGroup>
 

--- a/eng/targets/Imports.targets
+++ b/eng/targets/Imports.targets
@@ -106,6 +106,8 @@
       Updating a reference to this package to a newer version of the package may require changes in the referencing project.
       No compatibility guarantees are provided.
     </PackageDescription>
+    <!-- Files must individually enable nullable in source packages -->
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <!-- Include SourcePackage.editorconfig in all source packages. -->

--- a/src/Compilers/Shared/IBuildEnvironment.cs
+++ b/src/Compilers/Shared/IBuildEnvironment.cs
@@ -3,6 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/Compilers/Shared/StandardBuildEnvironment.cs
+++ b/src/Compilers/Shared/StandardBuildEnvironment.cs
@@ -3,6 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/NuGet/Directory.Build.props
+++ b/src/NuGet/Directory.Build.props
@@ -1,5 +1,5 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
-  <Import Project="$(RepositoryEngineeringDir)targets\PackageProject.props"/>
+  <Import Project="$(RepositoryEngineeringDir)targets\PackageProject.props" Condition="'$(IsSourcePackage)' != 'true'"/>
 </Project>

--- a/src/NuGet/Directory.Build.targets
+++ b/src/NuGet/Directory.Build.targets
@@ -1,5 +1,5 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />
-  <Import Project="$(RepositoryEngineeringDir)targets\PackageProject.targets" Condition="'$(TargetFramework)' != ''"/>
+  <Import Project="$(RepositoryEngineeringDir)targets\PackageProject.targets" Condition="'$(IsSourcePackage)' != 'true' and '$(TargetFramework)' != ''"/>
 </Project>


### PR DESCRIPTION
Fixes build failures in https://github.com/dotnet/dotnet/pull/8731

```
src\sdk\artifacts\.packages\microsoft.codeanalysis.buildclient\5.12.0-ci\contentFiles\cs\net10.0\IBuildEnvironment.cs(16,18): error CS8669: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context. Auto-generated code requires an explicit '#nullable' directive in source.
```

And ensures they don't happen in the future.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85067)