### PR TITLE
Update Helix Job Monitor to 11.0.0-beta.26427.10

### DIFF
--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -9,7 +9,7 @@
       "rollForward": false
     },
     "microsoft.dotnet.helix.jobmonitor": {
-      "version": "11.0.0-beta.26414.2",
+      "version": "11.0.0-beta.26427.10",
       "commands": [
         "dotnet-helix-job-monitor"
       ]

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -7,7 +7,7 @@ This file should be imported by eng/Versions.props
   <PropertyGroup>
     <!-- dotnet-arcade dependencies -->
     <MicrosoftDotNetArcadeSdkPackageVersion>11.0.0-beta.26421.2</MicrosoftDotNetArcadeSdkPackageVersion>
-    <MicrosoftDotNetHelixJobMonitorPackageVersion>11.0.0-beta.26421.2</MicrosoftDotNetHelixJobMonitorPackageVersion>
+    <MicrosoftDotNetHelixJobMonitorPackageVersion>11.0.0-beta.26427.10</MicrosoftDotNetHelixJobMonitorPackageVersion>
     <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26421.2</MicrosoftDotNetHelixSdkPackageVersion>
     <MicrosoftDotNetXliffTasksPackageVersion>11.0.0-beta.26421.2</MicrosoftDotNetXliffTasksPackageVersion>
     <!-- dotnet-dotnet dependencies -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -161,9 +161,9 @@
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>75901b60cccdcb56004d276c67f92f48f8f5c709</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.JobMonitor" Version="11.0.0-beta.26421.2">
+    <Dependency Name="Microsoft.DotNet.Helix.JobMonitor" Version="11.0.0-beta.26427.10">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>51abc19095ae366ecb773826993966dc8a1063eb</Sha>
+      <Sha>2cdfe99944d984749c8bdfc7d8d6a2589ed15d6d</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>


### PR DESCRIPTION
Updates the Helix Job Monitor tool plus dependency metadata to the fixed build.

Azure build: https://dev.azure.com/dnceng/internal/_build/results?buildId=3059358
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85070)