### PR TITLE
Prevent Introduce Constant crash in top-level lambdas

### DIFF
--- a/src/Features/CSharpTest/IntroduceVariable/IntroduceVariableTests.cs
+++ b/src/Features/CSharpTest/IntroduceVariable/IntroduceVariableTests.cs
@@ -8290,6 +8290,37 @@ namespace ConsoleApp1
             }
             """, new(index: 1, parseOptions: CSharpParseOptions.Default, options: ImplicitTypingEverywhere()));
 
+    [Fact, WorkItem("https://github.com/dotnet/vscode-csharp/issues/9300")]
+    public async Task TestIntroduceConstantInTopLevelLambda()
+    {
+        var code =
+            """
+            System.Action action = () =>
+            {
+                System.Console.WriteLine([|"/Access"|]);
+            };
+            """;
+
+        await TestExactActionSetOfferedAsync(
+            code,
+            [
+                string.Format(FeaturesResources.Introduce_local_constant_for_0, "\"/Access\""),
+                string.Format(FeaturesResources.Introduce_local_constant_for_all_occurrences_of_0, "\"/Access\""),
+            ],
+            new(parseOptions: TestOptions.Regular));
+
+        await TestAsync(
+            code,
+            """
+            System.Action action = () =>
+            {
+                const string {|Rename:Value|} = "/Access";
+                System.Console.WriteLine(Value);
+            };
+            """,
+            new(parseOptions: TestOptions.Regular));
+    }
+
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/47277")]
     public Task TestPreserveIndentationInLambda1()
         => TestInRegularAndScriptAsync(

--- a/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.State.cs
+++ b/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.State.cs
@@ -295,7 +295,7 @@ internal abstract partial class AbstractIntroduceVariableService<TService, TExpr
             return syntax != null && !syntax.OverlapsHiddenPosition(cancellationToken);
         }
 
-        private bool IsInTypeDeclarationOrValidCompilationUnit()
+        public bool IsInTypeDeclarationOrValidCompilationUnit()
         {
             if (Expression.GetAncestorOrThis<TTypeDeclarationSyntax>() != null)
             {

--- a/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.cs
+++ b/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.cs
@@ -232,6 +232,9 @@ internal abstract partial class AbstractIntroduceVariableService<TService, TExpr
 
     private bool CanGenerateIntoContainer(State state, CancellationToken cancellationToken)
     {
+        if (!state.IsInTypeDeclarationOrValidCompilationUnit())
+            return false;
+
         var destination = state.Expression.GetAncestor<TTypeDeclarationSyntax>() ?? state.Document.Root;
         if (!destination.OverlapsHiddenPosition(cancellationToken))
         {


### PR DESCRIPTION
Fixes dotnet/vscode-csharp#9300

## Summary
- prevent field-level Introduce Constant actions in regular top-level blocks that have no containing type
- preserve local constant actions and script-level field extraction
- add regression coverage for a block-bodied top-level lambda

## Validation
- built `Microsoft.CodeAnalysis.CSharp.Features.UnitTests.csproj`
- focused regression tests passed on `net10.0` and `net472`
- full C# Introduce Variable suite passed on `net10.0` (323 passed, 1 skipped)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85071)