### PR TITLE
Send $/progress notifications with named arguments

### DIFF
--- a/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/LspProgressConverterFactory.cs
+++ b/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/LspProgressConverterFactory.cs
@@ -1,0 +1,145 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// This is consumed as 'generated' code in a source package and therefore requires an explicit nullable enable
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
+using StreamJsonRpc;
+using StreamJsonRpc.Reflection;
+
+namespace Microsoft.CommonLanguageServerProtocol.Framework;
+
+/// <summary>
+/// Converts LSP progress tokens (for example <c>partialResultToken</c> and <c>workDoneToken</c>) into
+/// <see cref="IProgress{T}"/> instances that report using the <c>$/progress</c> notification shape the
+/// protocol requires.
+/// </summary>
+/// <remarks>
+/// StreamJsonRpc has built-in <see cref="IProgress{T}"/> support, but it only emits the named
+/// <c>{ token, value }</c> arguments LSP mandates while it can see the <see cref="JsonRpcMethodAttribute"/>
+/// of the method it is dispatching to. That is only true while StreamJsonRpc is binding typed method
+/// arguments itself. We deserialize request bodies manually instead (see
+/// <see cref="SystemTextJsonLanguageServer{TRequestContext}"/>) so that a single method name can support
+/// multiple language-specific handlers with different request types, and so that we control how
+/// deserialization failures are reported. By the time we read the request body that formatter state is
+/// gone, so StreamJsonRpc falls back to positional <c>[token, value]</c> arguments, which is off-spec.
+/// Owning the conversion here keeps manual deserialization while still producing a compliant notification.
+/// <para>
+/// Note that <see cref="JsonConverter{T}.Read"/> here isn't parsing a value - it is constructing the
+/// sender. We only register this on the options used to deserialize incoming requests, which creates the
+/// <see cref="IProgress{T}"/> instance later used to report progress to the client, and that is what we've
+/// fixed to use named arguments. The formatter's own options are left alone so that StreamJsonRpc keeps
+/// handling the reverse role, where the client sends progress notifications to us: StreamJsonRpc writes an
+/// <see cref="IProgress{T}"/> we send out as a token, and routes the resulting reports back to the original
+/// object.
+/// </para>
+/// </remarks>
+internal sealed class LspProgressConverterFactory : JsonConverterFactory
+{
+    private readonly JsonRpc _jsonRpc;
+
+    public LspProgressConverterFactory(JsonRpc jsonRpc)
+    {
+        _jsonRpc = jsonRpc;
+    }
+
+    public override bool CanConvert(Type typeToConvert)
+        => typeToConvert.IsGenericType && typeToConvert.GetGenericTypeDefinition() == typeof(IProgress<>);
+
+    public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+    {
+        var valueType = typeToConvert.GetGenericArguments()[0];
+        return (JsonConverter)Activator.CreateInstance(typeof(LspProgressConverter<>).MakeGenericType(valueType), _jsonRpc)!;
+    }
+}
+
+internal sealed class LspProgressConverter<T> : JsonConverter<IProgress<T>>
+{
+    private readonly JsonRpc _jsonRpc;
+
+    public LspProgressConverter(JsonRpc jsonRpc)
+    {
+        _jsonRpc = jsonRpc;
+    }
+
+    public override IProgress<T>? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.Null)
+        {
+            return null;
+        }
+
+        if (reader.TokenType is not JsonTokenType.String and not JsonTokenType.Number)
+        {
+            throw new JsonException($"Expected a string or integer progress token, but found '{reader.TokenType}'.");
+        }
+
+        // Retain the token exactly as the client sent it.  LSP allows a progress token to be either an
+        // integer or a string, and the notifications we send must echo back the same value.
+        using var document = JsonDocument.ParseValue(ref reader);
+        return new LspProgress(_jsonRpc, document.RootElement.Clone());
+    }
+
+    public override void Write(Utf8JsonWriter writer, IProgress<T> value, JsonSerializerOptions options)
+        => throw new NotSupportedException($"{nameof(LspProgressConverter<T>)} is only used to deserialize incoming requests.");
+
+    private sealed class LspProgress : IProgress<T>
+    {
+        private readonly JsonRpc _jsonRpc;
+        private readonly JsonElement _token;
+
+        public LspProgress(JsonRpc jsonRpc, JsonElement token)
+        {
+            _jsonRpc = jsonRpc;
+            _token = token;
+        }
+
+        public void Report(T value)
+        {
+            // Mirrors the named-arguments branch of streamjsonrpc's MessageFormatterProgressTracker.ProgressProxy<T>,
+            // which is what would run here if it were able to see that named arguments are required.
+            // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#progress
+            // requires $/progress to carry a named parameter object with 'token' and 'value' properties.
+            var arguments = new Dictionary<string, object?>
+            {
+                { "token", _token },
+                { "value", value },
+            };
+
+            // Unlike streamjsonrpc we declare the token as a JsonElement rather than its CLR type, since we
+            // hold onto the raw token to echo back whichever form (integer or string) the client sent.
+            var argumentDeclaredTypes = new Dictionary<string, Type>
+            {
+                { "token", typeof(JsonElement) },
+                { "value", typeof(T) },
+            };
+
+            var notifyTask = _jsonRpc.NotifyWithParameterObjectAsync(
+                MessageFormatterProgressTracker.ProgressRequestSpecialMethod, arguments, argumentDeclaredTypes);
+
+            // Progress notifications are fire and forget - trace failures (including the ObjectDisposedException
+            // raised when the connection is torn down mid-request) instead of faulting the request that produced
+            // them. Note that this is the only failure path: NotifyWithParameterObjectAsync reports errors by
+            // returning a faulted task rather than by throwing synchronously.
+            notifyTask.ContinueWith(
+                static (task, state) => ((JsonRpc)state!).TraceSource.TraceEvent(
+                    TraceEventType.Error,
+                    (int)JsonRpc.TraceEvents.ProgressNotificationError,
+                    "Failed to send progress update. {0}",
+                    task.Exception!.InnerException ?? task.Exception),
+                _jsonRpc,
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted,
+                TaskScheduler.Default).Forget();
+        }
+    }
+}

--- a/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/LspProgressConverterFactory.cs
+++ b/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/LspProgressConverterFactory.cs
@@ -94,13 +94,20 @@ internal sealed class LspProgressConverter<T> : JsonConverter<IProgress<T>>
 
     private sealed class LspProgress : IProgress<T>
     {
+        private static readonly IReadOnlyDictionary<string, Type> s_argumentDeclaredTypes =
+            new Dictionary<string, Type>
+            {
+                { "token", typeof(JsonElement) },
+                { "value", typeof(T) },
+            };
+
         private readonly JsonRpc _jsonRpc;
-        private readonly JsonElement _token;
+        private readonly object _boxedToken;
 
         public LspProgress(JsonRpc jsonRpc, JsonElement token)
         {
             _jsonRpc = jsonRpc;
-            _token = token;
+            _boxedToken = token;
         }
 
         public void Report(T value)
@@ -111,20 +118,14 @@ internal sealed class LspProgressConverter<T> : JsonConverter<IProgress<T>>
             // requires $/progress to carry a named parameter object with 'token' and 'value' properties.
             var arguments = new Dictionary<string, object?>
             {
-                { "token", _token },
+                { "token", _boxedToken },
                 { "value", value },
             };
 
             // Unlike streamjsonrpc we declare the token as a JsonElement rather than its CLR type, since we
             // hold onto the raw token to echo back whichever form (integer or string) the client sent.
-            var argumentDeclaredTypes = new Dictionary<string, Type>
-            {
-                { "token", typeof(JsonElement) },
-                { "value", typeof(T) },
-            };
-
             var notifyTask = _jsonRpc.NotifyWithParameterObjectAsync(
-                MessageFormatterProgressTracker.ProgressRequestSpecialMethod, arguments, argumentDeclaredTypes);
+                MessageFormatterProgressTracker.ProgressRequestSpecialMethod, arguments, s_argumentDeclaredTypes);
 
             // Progress notifications are fire and forget - trace failures (including the ObjectDisposedException
             // raised when the connection is torn down mid-request) instead of faulting the request that produced

--- a/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/SystemTextJsonLanguageServer.cs
+++ b/src/LanguageServer/Microsoft.CommonLanguageServerProtocol.Framework/SystemTextJsonLanguageServer.cs
@@ -19,10 +19,26 @@ internal abstract class SystemTextJsonLanguageServer<TRequestContext>(
     : AbstractLanguageServer<TRequestContext>(jsonRpc, typeRefResolver)
 {
     /// <summary>
-    /// JsonSerializer options used by streamjsonrpc (and for serializing / deserializing the requests to streamjsonrpc).
-    /// These options are specifically from the <see cref="StreamJsonRpc.SystemTextJsonFormatter"/> that added the exotic type converters.
+    /// JsonSerializer options used to deserialize incoming requests.
+    /// <para>
+    /// This is a copy of the options streamjsonrpc uses (which added the exotic type converters from
+    /// <see cref="StreamJsonRpc.SystemTextJsonFormatter"/>) with our own <see cref="IProgress{T}"/> support
+    /// layered on top - see <see cref="LspProgressConverterFactory"/> for why streamjsonrpc's cannot be used
+    /// here. We deliberately copy rather than mutate the formatter's options, so that everything else on this
+    /// connection (responses, notifications, and messages we originate) keeps streamjsonrpc's behavior.
+    /// </para>
     /// </summary>
-    private readonly JsonSerializerOptions _jsonSerializerOptions = options;
+    private readonly JsonSerializerOptions _jsonSerializerOptions = CreateRequestDeserializationOptions(options, jsonRpc);
+
+    private static JsonSerializerOptions CreateRequestDeserializationOptions(JsonSerializerOptions formatterOptions, JsonRpc jsonRpc)
+    {
+        var requestOptions = new JsonSerializerOptions(formatterOptions);
+
+        // Insert at the front - System.Text.Json uses the first converter in the list that can convert a
+        // type, and the copied options already contain streamjsonrpc's IProgress<T> converter.
+        requestOptions.Converters.Insert(0, new LspProgressConverterFactory(jsonRpc));
+        return requestOptions;
+    }
 
     public override TRequest DeserializeRequest<TRequest>(object? serializedRequest, RequestHandlerMetadata metadata)
     {

--- a/src/LanguageServer/ProtocolUnitTests/PartialResultProgressTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/PartialResultProgressTests.cs
@@ -1,0 +1,123 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.LanguageServer.Handler;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.LanguageServer.Protocol;
+using Roslyn.Test.Utilities;
+using StreamJsonRpc;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests;
+
+[UseExportProvider]
+public sealed class PartialResultProgressTests : AbstractLanguageServerProtocolTests
+{
+    private const string NumericToken = "42";
+    private const string StringToken = "partial-result-token";
+
+    public PartialResultProgressTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
+    {
+    }
+
+    protected override TestComposition Composition => base.Composition.AddParts(typeof(TestPartialResultHandler));
+
+    [Theory, CombinatorialData]
+    public async Task PartialResultsAreReportedWithNamedArguments(bool mutatingLspWorkspace, bool useStringToken)
+    {
+        var progressTarget = new ProgressCapturingTarget();
+        await using var testLspServer = await CreateTestLspServerAsync(string.Empty, mutatingLspWorkspace, new InitializationOptions
+        {
+            ClientTarget = progressTarget,
+            ServerKind = WellKnownLspServerKinds.CSharpVisualBasicLspServer,
+        });
+
+        var token = useStringToken ? $"\"{StringToken}\"" : NumericToken;
+        using var request = JsonDocument.Parse($$"""
+            {
+                "{{Methods.PartialResultTokenName}}": {{token}}
+            }
+            """);
+
+        await testLspServer.ExecutePreSerializedRequestAsync(TestPartialResultHandler.MethodName, request);
+
+        // Intentionally asserts on the raw JSON - deserializing it (or passing an IProgress<T> from the
+        // client) would let streamjsonrpc accept either named or positional arguments and hide the shape
+        // the spec requires.
+        var progressParams = await progressTarget.WaitForProgressAsync();
+        Assert.Equal(JsonValueKind.Object, progressParams.ValueKind);
+
+        var reportedToken = progressParams.GetProperty("token");
+        if (useStringToken)
+        {
+            Assert.Equal(StringToken, reportedToken.GetString());
+        }
+        else
+        {
+            Assert.Equal(int.Parse(NumericToken), reportedToken.GetInt32());
+        }
+
+        Assert.Equal(
+            TestPartialResultHandler.ReportedValue,
+            progressParams.GetProperty("value").EnumerateArray().Single().GetString());
+    }
+
+    /// <summary>
+    /// Captures the raw <c>$/progress</c> parameters rather than deserializing them, so that the test can
+    /// assert on the shape streamjsonrpc actually put on the wire.
+    /// </summary>
+    private sealed class ProgressCapturingTarget
+    {
+        private readonly TaskCompletionSource<JsonElement> _progressSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        [JsonRpcMethod(Methods.ProgressNotificationName, UseSingleObjectParameterDeserialization = true)]
+        public Task HandleProgressAsync(JsonElement progressParams, CancellationToken _)
+        {
+            // Clone as streamjsonrpc recycles the underlying document once the notification is handled.
+            _progressSource.TrySetResult(progressParams.Clone());
+            return Task.CompletedTask;
+        }
+
+        public Task<JsonElement> WaitForProgressAsync() => _progressSource.Task;
+    }
+
+    internal sealed class TestPartialResultParams : IPartialResultParams<string[]>
+    {
+        [JsonPropertyName(Methods.PartialResultTokenName)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public IProgress<string[]>? PartialResultToken { get; set; }
+    }
+
+    [ExportCSharpVisualBasicStatelessLspService(typeof(TestPartialResultHandler)), PartNotDiscoverable, Shared]
+    [Method(MethodName)]
+    internal sealed class TestPartialResultHandler : ILspServiceRequestHandler<TestPartialResultParams, string[]>
+    {
+        public const string MethodName = nameof(TestPartialResultHandler);
+        public const string ReportedValue = "partial result";
+
+        [ImportingConstructor]
+        [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+        public TestPartialResultHandler()
+        {
+        }
+
+        public bool MutatesSolutionState => false;
+        public bool RequiresLSPSolution => false;
+
+        public Task<string[]> HandleRequestAsync(TestPartialResultParams request, RequestContext context, CancellationToken cancellationToken)
+        {
+            request.PartialResultToken?.Report([ReportedValue]);
+            return Task.FromResult<string[]>([]);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #79939 

## The bug

The [LSP spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#progress) requires `$/progress` to carry a named parameter object:

```json
{ "method": "$/progress", "params": { "token": 17, "value": [ ... ] } }
```

Progress reported through a request's `partialResultToken` (or `workDoneToken`) was instead going out positionally:

```json
{ "method": "$/progress", "params": [ 17, [ ... ] ] }
```

This affects every handler that streams partial results — workspace symbols, find references, pull diagnostics, spell checking, and `textDocument/runTests` — plus every `workDoneToken` on the ~40 request types that declare one.

## Root cause

StreamJsonRpc has built-in `IProgress<T>` support, but its `ProgressProxy` only emits named arguments when it can see the `JsonRpcMethodAttribute` of the method being dispatched to. That state is only populated while StreamJsonRpc is binding typed method arguments itself.

We deserialize request bodies manually in `SystemTextJsonLanguageServer`, so that a single method name can support multiple language-specific handlers with different request types (XAML/TS), and so we control how deserialization failures are reported. Every handler is registered behind a generic `JsonElement` entry point, and we call `JsonSerializer.Deserialize<TRequest>` ourselves afterwards — by which point the formatter's method context has been cleared. StreamJsonRpc's converter therefore sees `ClientRequiresNamedArguments` as `false` and builds a proxy that reports positionally.

Setting `ClientRequiresNamedArguments = true` on the registration is *not* sufficient — I verified this against StreamJsonRpc 2.26.10; the manual deserialization still runs outside the tracking scope.

## The fix

Add an LSP-specific `IProgress<T>` converter, registered only on a **copy** of the serializer options used to deserialize incoming requests.

The key insight is that `Read` here isn't parsing a value — it's constructing the sender. The `IProgress<T>` it returns *is* the object a handler later calls `Report` on, and that call is what puts `$/progress` on the wire. So owning the conversion is what fixes the notifications we send, while still keeping manual deserialization and our own error handling.

The formatter's own options are deliberately left untouched, so StreamJsonRpc keeps handling the reverse role (routing progress reports back to an `IProgress<T>` *we* sent out), and so every other message on the connection is unaffected.

Retaining the raw token `JsonElement` also fixes **string progress tokens**, which could not round-trip before: StreamJsonRpc's inbound `$/progress` path assumes an integer token.

Work done progress is unaffected — `WorkDoneProgressManager` already builds the named parameter object explicitly, which is why #81233 fixed restore progress specifically without fixing the general case.

## Testing

The existing partial-result tests could not catch this: both ends of the connection are StreamJsonRpc, and its receiver accepts `token`/`value` by either name *or* position, so a positional notification still round-trips fine in-process. Only a non-StreamJsonRpc client (VS Code, nvim) sees the breakage.

`PartialResultProgressTests` therefore asserts on the **raw JSON** of the notification, covering both numeric and string tokens. Verified it fails without the product change:

```
Assert.Equal() Failure: Values differ
Expected: Object
Actual:   Array
```

Validation run:
- `PartialResultProgressTests`, `WorkDoneProgressTests`, `FindAllReferencesHandlerTests`, `WorkspaceSymbolsTests`, `SpellCheckTests` — 84 passed
- `Diagnostics` — 314 passed
- `Microsoft.CommonLanguageServerProtocol.Framework.UnitTests` — 27 passed (net10.0 + net472)

## Compatibility

Lower risk than the issue thread feared. VS's in-proc client is StreamJsonRpc, whose inbound handler reads the token via `TryGetArgumentByNameOrIndex("token", 0, ...)` — named arguments work there. Spec-compliant clients can only work *after* this change.

Worth a sanity check in VS and VS Code before merging, since this changes the wire format of a notification that has been sent this way since the beginning.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85076)