### PR TITLE
Use length-based dispatch for small string switches

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/LengthBasedStringSwitchData.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/LengthBasedStringSwitchData.cs
@@ -126,8 +126,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        // Based on benchmarks, the previous hashcode-based approach arguably performs better
-        // when buckets have 6 candidates or more.
+        // Prefer length-based dispatch when it avoids either a hash-based switch or a linear
+        // sequence of comparisons without leaving more than five candidates in a final bucket.
         internal bool ShouldGenerateLengthBasedSwitch(int labelsCount)
         {
             // Hash-based dispatch is cheaper when a final string bucket has more than five candidates.

--- a/src/Compilers/CSharp/Portable/BoundTree/LengthBasedStringSwitchData.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/LengthBasedStringSwitchData.cs
@@ -130,10 +130,23 @@ namespace Microsoft.CodeAnalysis.CSharp
         // when buckets have 6 candidates or more.
         internal bool ShouldGenerateLengthBasedSwitch(int labelsCount)
         {
+            if (StringBasedJumpTables.Any(table => table.StringCaseLabels.Length > 5))
+            {
+                return false;
+            }
+
+            if (SwitchStringJumpTableEmitter.ShouldGenerateHashTableSwitch(labelsCount))
+            {
+                return true;
+            }
+
+            if (labelsCount < 3)
+            {
+                return false;
+            }
+
             // Smaller switches still benefit when a single length check can reject all cases.
-            return (SwitchStringJumpTableEmitter.ShouldGenerateHashTableSwitch(labelsCount) ||
-                    labelsCount >= 3 && LengthBasedJumpTable.LengthCaseLabels.Length == 1) &&
-                StringBasedJumpTables.All(t => t.StringCaseLabels.Length <= 5);
+            return LengthBasedJumpTable.LengthCaseLabels.Length == 1;
         }
 
         internal static LengthBasedStringSwitchData Create(ImmutableArray<(ConstantValue value, LabelSymbol label)> inputCases)

--- a/src/Compilers/CSharp/Portable/BoundTree/LengthBasedStringSwitchData.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/LengthBasedStringSwitchData.cs
@@ -130,22 +130,24 @@ namespace Microsoft.CodeAnalysis.CSharp
         // when buckets have 6 candidates or more.
         internal bool ShouldGenerateLengthBasedSwitch(int labelsCount)
         {
+            // Hash-based dispatch is cheaper when a final string bucket has more than five candidates.
             if (StringBasedJumpTables.Any(table => table.StringCaseLabels.Length > 5))
             {
                 return false;
             }
 
+            // Large switches already qualify for the existing length-based strategy.
             if (SwitchStringJumpTableEmitter.ShouldGenerateHashTableSwitch(labelsCount))
             {
                 return true;
             }
 
+            // Smaller switches need at least three cases, all sharing a single non-null string length.
             if (labelsCount < 3)
             {
                 return false;
             }
 
-            // Smaller switches still benefit when a single length check can reject all cases.
             return LengthBasedJumpTable.LengthCaseLabels.Length == 1;
         }
 

--- a/src/Compilers/CSharp/Portable/BoundTree/LengthBasedStringSwitchData.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/LengthBasedStringSwitchData.cs
@@ -143,6 +143,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // Smaller switches need at least three cases, all sharing a single non-null string length.
+            // This lets one length check send every differently sized input directly to the default case.
             return labelsCount >= 3 && LengthBasedJumpTable.LengthCaseLabels.Length == 1;
         }
 

--- a/src/Compilers/CSharp/Portable/BoundTree/LengthBasedStringSwitchData.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/LengthBasedStringSwitchData.cs
@@ -144,7 +144,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // Smaller switches need at least three cases, all sharing a single non-null string length.
             // This lets one length check send every differently sized input directly to the default case.
-            return labelsCount >= 3 && LengthBasedJumpTable.LengthCaseLabels.Length == 1;
+            int nonNullLabelsCount = labelsCount - (LengthBasedJumpTable.NullCaseLabel is null ? 0 : 1);
+            return nonNullLabelsCount >= 3 && LengthBasedJumpTable.LengthCaseLabels.Length == 1;
         }
 
         internal static LengthBasedStringSwitchData Create(ImmutableArray<(ConstantValue value, LabelSymbol label)> inputCases)

--- a/src/Compilers/CSharp/Portable/BoundTree/LengthBasedStringSwitchData.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/LengthBasedStringSwitchData.cs
@@ -130,7 +130,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         // when buckets have 6 candidates or more.
         internal bool ShouldGenerateLengthBasedSwitch(int labelsCount)
         {
-            return SwitchStringJumpTableEmitter.ShouldGenerateHashTableSwitch(labelsCount) &&
+            // Smaller switches still benefit when a single length check can reject all cases.
+            return (SwitchStringJumpTableEmitter.ShouldGenerateHashTableSwitch(labelsCount) ||
+                    labelsCount >= 3 && LengthBasedJumpTable.LengthCaseLabels.Length == 1) &&
                 StringBasedJumpTables.All(t => t.StringCaseLabels.Length <= 5);
         }
 

--- a/src/Compilers/CSharp/Portable/BoundTree/LengthBasedStringSwitchData.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/LengthBasedStringSwitchData.cs
@@ -143,12 +143,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // Smaller switches need at least three cases, all sharing a single non-null string length.
-            if (labelsCount < 3)
-            {
-                return false;
-            }
-
-            return LengthBasedJumpTable.LengthCaseLabels.Length == 1;
+            return labelsCount >= 3 && LengthBasedJumpTable.LengthCaseLabels.Length == 1;
         }
 
         internal static LengthBasedStringSwitchData Create(ImmutableArray<(ConstantValue value, LabelSymbol label)> inputCases)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/PatternTests.cs
@@ -2541,53 +2541,71 @@ Closed Open -> Opened
             var compVerifier = CompileAndVerify(compilation);
             compVerifier.VerifyIL("Program.M1",
 @"{
-  // Code size       50 (0x32)
+  // Code size       55 (0x37)
   .maxstack  2
-  .locals init (string V_0)
+  .locals init (string V_0,
+                int V_1,
+                char V_2)
   IL_0000:  ldarg.1
   IL_0001:  stloc.0
   IL_0002:  ldloc.0
-  IL_0003:  ldstr      ""a""
-  IL_0008:  call       ""bool string.op_Equality(string, string)""
-  IL_000d:  brtrue.s   IL_0031
-  IL_000f:  ldloc.0
-  IL_0010:  ldstr      ""b""
-  IL_0015:  call       ""bool string.op_Equality(string, string)""
-  IL_001a:  brtrue.s   IL_0029
-  IL_001c:  ldloc.0
-  IL_001d:  ldstr      ""c""
-  IL_0022:  call       ""bool string.op_Equality(string, string)""
-  IL_0027:  pop
-  IL_0028:  ret
-  IL_0029:  ldarga.s   V_1
-  IL_002b:  call       ""bool Program.Mutate(ref string)""
-  IL_0030:  pop
-  IL_0031:  ret
+  IL_0003:  brfalse.s  IL_0036
+  IL_0005:  ldloc.0
+  IL_0006:  call       ""int string.Length.get""
+  IL_000b:  stloc.1
+  IL_000c:  ldloc.1
+  IL_000d:  ldc.i4.1
+  IL_000e:  bne.un.s   IL_0036
+  IL_0010:  ldloc.0
+  IL_0011:  ldc.i4.0
+  IL_0012:  call       ""char string.this[int].get""
+  IL_0017:  stloc.2
+  IL_0018:  ldloc.2
+  IL_0019:  ldc.i4.s   97
+  IL_001b:  sub
+  IL_001c:  switch    (
+        IL_0036,
+        IL_002e,
+        IL_0036)
+  IL_002d:  ret
+  IL_002e:  ldarga.s   V_1
+  IL_0030:  call       ""bool Program.Mutate(ref string)""
+  IL_0035:  pop
+  IL_0036:  ret
 }");
             compVerifier.VerifyIL("Program.M2",
 @"{
-  // Code size       49 (0x31)
+  // Code size       54 (0x36)
   .maxstack  2
-  .locals init (string V_0)
+  .locals init (string V_0,
+                int V_1,
+                char V_2)
   IL_0000:  ldarg.1
   IL_0001:  stloc.0
   IL_0002:  ldloc.0
-  IL_0003:  ldstr      ""a""
-  IL_0008:  call       ""bool string.op_Equality(string, string)""
-  IL_000d:  brtrue.s   IL_0030
-  IL_000f:  ldloc.0
-  IL_0010:  ldstr      ""b""
-  IL_0015:  call       ""bool string.op_Equality(string, string)""
-  IL_001a:  brtrue.s   IL_0029
-  IL_001c:  ldloc.0
-  IL_001d:  ldstr      ""c""
-  IL_0022:  call       ""bool string.op_Equality(string, string)""
-  IL_0027:  pop
-  IL_0028:  ret
-  IL_0029:  ldarg.1
-  IL_002a:  call       ""bool Program.Pure(string)""
-  IL_002f:  pop
-  IL_0030:  ret
+  IL_0003:  brfalse.s  IL_0035
+  IL_0005:  ldloc.0
+  IL_0006:  call       ""int string.Length.get""
+  IL_000b:  stloc.1
+  IL_000c:  ldloc.1
+  IL_000d:  ldc.i4.1
+  IL_000e:  bne.un.s   IL_0035
+  IL_0010:  ldloc.0
+  IL_0011:  ldc.i4.0
+  IL_0012:  call       ""char string.this[int].get""
+  IL_0017:  stloc.2
+  IL_0018:  ldloc.2
+  IL_0019:  ldc.i4.s   97
+  IL_001b:  sub
+  IL_001c:  switch    (
+        IL_0035,
+        IL_002e,
+        IL_0035)
+  IL_002d:  ret
+  IL_002e:  ldarg.1
+  IL_002f:  call       ""bool Program.Pure(string)""
+  IL_0034:  pop
+  IL_0035:  ret
 }");
         }
 

--- a/src/Compilers/CSharp/Test/Emit2/CodeGen/CodeGenLengthBasedSwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/CodeGen/CodeGenLengthBasedSwitchTests.cs
@@ -13,6 +13,50 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen;
 public class CodeGenLengthBasedSwitchTests : CSharpTestBase
 {
     [Fact]
+    public void SmallSwitchExclusions()
+    {
+        var source = """
+public static class C
+{
+    public static byte TwoSameLength(string str) => str switch
+    {
+        "one" => 1,
+        "two" => 2,
+        _ => 0
+    };
+
+    public static byte ThreeMixedLengths(string str) => str switch
+    {
+        "a" => 1,
+        "two" => 2,
+        "four" => 4,
+        _ => 0
+    };
+
+    public static byte NullAndTwoSameLength(string str) => str switch
+    {
+        null => 0,
+        "one" => 1,
+        "two" => 2,
+        _ => 3
+    };
+}
+""";
+        var verifier = CompileAndVerify(source, options: TestOptions.ReleaseDll);
+        verifyLinearDispatch("C.TwoSameLength");
+        verifyLinearDispatch("C.ThreeMixedLengths");
+        verifyLinearDispatch("C.NullAndTwoSameLength");
+
+        void verifyLinearDispatch(string methodName)
+        {
+            string il = verifier.VisualizeIL(methodName);
+            Assert.Contains("string.op_Equality", il, System.StringComparison.Ordinal);
+            Assert.DoesNotContain("string.Length.get", il, System.StringComparison.Ordinal);
+            Assert.DoesNotContain("string.this[int].get", il, System.StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
     public void SmallSwitchWithSingleLength()
     {
         var source = """

--- a/src/Compilers/CSharp/Test/Emit2/CodeGen/CodeGenLengthBasedSwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/CodeGen/CodeGenLengthBasedSwitchTests.cs
@@ -138,6 +138,95 @@ public static class C
 """);
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void SmallSwitchWithSingleLength_Span(bool useReadonly)
+    {
+        var keyType = useReadonly ? "System.ReadOnlySpan<char>" : "System.Span<char>";
+        var source = $$"""
+System.Console.Write($"{decode("one")} {decode("two")} {decode("six")} {decode("ten")} {decode("four")}");
+
+static byte decode(string input) => C.Decode(new {{keyType}}(input.ToCharArray()));
+
+public static class C
+{
+    public static byte Decode({{keyType}} str) => str switch
+    {
+        "one" => 1,
+        "two" => 2,
+        "six" => 6,
+        _ => 0
+    };
+}
+""";
+        var comp = CreateCompilationWithSpanAndMemoryExtensions(source, options: TestOptions.ReleaseExe);
+        comp.VerifyEmitDiagnostics();
+        var verifier = CompileAndVerify(comp, expectedOutput: "1 2 6 0 0", verify: Verification.Skipped);
+        var indexer = useReadonly ? $$"""ref readonly char {{keyType}}.this[int].get""" : $$"""ref char {{keyType}}.this[int].get""";
+        verifier.VerifyIL("C.Decode", $$"""
+{
+  // Code size      115 (0x73)
+  .maxstack  2
+  .locals init (byte V_0,
+                int V_1,
+                char V_2)
+  IL_0000:  ldarga.s   V_0
+  IL_0002:  call       "int {{keyType}}.Length.get"
+  IL_0007:  stloc.1
+  IL_0008:  ldloc.1
+  IL_0009:  ldc.i4.3
+  IL_000a:  bne.un.s   IL_006f
+  IL_000c:  ldarga.s   V_0
+  IL_000e:  ldc.i4.0
+  IL_000f:  call       "{{indexer}}"
+  IL_0014:  ldind.u2
+  IL_0015:  stloc.2
+  IL_0016:  ldloc.2
+  IL_0017:  ldc.i4.s   111
+  IL_0019:  beq.s      IL_0027
+  IL_001b:  ldloc.2
+  IL_001c:  ldc.i4.s   115
+  IL_001e:  beq.s      IL_004f
+  IL_0020:  ldloc.2
+  IL_0021:  ldc.i4.s   116
+  IL_0023:  beq.s      IL_003b
+  IL_0025:  br.s       IL_006f
+  IL_0027:  ldarg.0
+  IL_0028:  ldstr      "one"
+  IL_002d:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
+  IL_0032:  call       "bool System.MemoryExtensions.SequenceEqual<char>({{keyType}}, System.ReadOnlySpan<char>)"
+  IL_0037:  brtrue.s   IL_0063
+  IL_0039:  br.s       IL_006f
+  IL_003b:  ldarg.0
+  IL_003c:  ldstr      "two"
+  IL_0041:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
+  IL_0046:  call       "bool System.MemoryExtensions.SequenceEqual<char>({{keyType}}, System.ReadOnlySpan<char>)"
+  IL_004b:  brtrue.s   IL_0067
+  IL_004d:  br.s       IL_006f
+  IL_004f:  ldarg.0
+  IL_0050:  ldstr      "six"
+  IL_0055:  call       "System.ReadOnlySpan<char> System.MemoryExtensions.AsSpan(string)"
+  IL_005a:  call       "bool System.MemoryExtensions.SequenceEqual<char>({{keyType}}, System.ReadOnlySpan<char>)"
+  IL_005f:  brtrue.s   IL_006b
+  IL_0061:  br.s       IL_006f
+  IL_0063:  ldc.i4.1
+  IL_0064:  stloc.0
+  IL_0065:  br.s       IL_0071
+  IL_0067:  ldc.i4.2
+  IL_0068:  stloc.0
+  IL_0069:  br.s       IL_0071
+  IL_006b:  ldc.i4.6
+  IL_006c:  stloc.0
+  IL_006d:  br.s       IL_0071
+  IL_006f:  ldc.i4.0
+  IL_0070:  stloc.0
+  IL_0071:  ldloc.0
+  IL_0072:  ret
+}
+""");
+    }
+
     [Fact, WorkItem(56374, "https://github.com/dotnet/roslyn/issues/56374")]
     public void MixOfBucketSizes()
     {

--- a/src/Compilers/CSharp/Test/Emit2/CodeGen/CodeGenLengthBasedSwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Emit2/CodeGen/CodeGenLengthBasedSwitchTests.cs
@@ -12,6 +12,88 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen;
 
 public class CodeGenLengthBasedSwitchTests : CSharpTestBase
 {
+    [Fact]
+    public void SmallSwitchWithSingleLength()
+    {
+        var source = """
+System.Console.Write($"{C.Decode("one")} {C.Decode("two")} {C.Decode("six")} {C.Decode("ten")} {C.Decode("four")} {C.Decode(null)}");
+
+public static class C
+{
+    public static byte Decode(string str) => str switch
+    {
+        "one" => 1,
+        "two" => 2,
+        "six" => 6,
+        _ => 0
+    };
+}
+""";
+        var comp = CreateCompilation(source, options: TestOptions.ReleaseExe);
+        comp.VerifyEmitDiagnostics();
+        var verifier = CompileAndVerify(comp, expectedOutput: "1 2 6 0 0 0");
+        verifier.VerifyMemberInIL(PrivateImplementationDetails.SynthesizedStringHashFunctionName + "(string)", expected: false);
+        verifier.VerifyIL("C.Decode", """
+{
+  // Code size      100 (0x64)
+  .maxstack  2
+  .locals init (byte V_0,
+                int V_1,
+                char V_2)
+  IL_0000:  ldarg.0
+  IL_0001:  brfalse.s  IL_0060
+  IL_0003:  ldarg.0
+  IL_0004:  call       "int string.Length.get"
+  IL_0009:  stloc.1
+  IL_000a:  ldloc.1
+  IL_000b:  ldc.i4.3
+  IL_000c:  bne.un.s   IL_0060
+  IL_000e:  ldarg.0
+  IL_000f:  ldc.i4.0
+  IL_0010:  call       "char string.this[int].get"
+  IL_0015:  stloc.2
+  IL_0016:  ldloc.2
+  IL_0017:  ldc.i4.s   111
+  IL_0019:  beq.s      IL_0027
+  IL_001b:  ldloc.2
+  IL_001c:  ldc.i4.s   115
+  IL_001e:  beq.s      IL_0045
+  IL_0020:  ldloc.2
+  IL_0021:  ldc.i4.s   116
+  IL_0023:  beq.s      IL_0036
+  IL_0025:  br.s       IL_0060
+  IL_0027:  ldarg.0
+  IL_0028:  ldstr      "one"
+  IL_002d:  call       "bool string.op_Equality(string, string)"
+  IL_0032:  brtrue.s   IL_0054
+  IL_0034:  br.s       IL_0060
+  IL_0036:  ldarg.0
+  IL_0037:  ldstr      "two"
+  IL_003c:  call       "bool string.op_Equality(string, string)"
+  IL_0041:  brtrue.s   IL_0058
+  IL_0043:  br.s       IL_0060
+  IL_0045:  ldarg.0
+  IL_0046:  ldstr      "six"
+  IL_004b:  call       "bool string.op_Equality(string, string)"
+  IL_0050:  brtrue.s   IL_005c
+  IL_0052:  br.s       IL_0060
+  IL_0054:  ldc.i4.1
+  IL_0055:  stloc.0
+  IL_0056:  br.s       IL_0062
+  IL_0058:  ldc.i4.2
+  IL_0059:  stloc.0
+  IL_005a:  br.s       IL_0062
+  IL_005c:  ldc.i4.6
+  IL_005d:  stloc.0
+  IL_005e:  br.s       IL_0062
+  IL_0060:  ldc.i4.0
+  IL_0061:  stloc.0
+  IL_0062:  ldloc.0
+  IL_0063:  ret
+}
+""");
+    }
+
     [Fact, WorkItem(56374, "https://github.com/dotnet/roslyn/issues/56374")]
     public void MixOfBucketSizes()
     {


### PR DESCRIPTION
## Summary

#66081 added length- and character-based dispatch for large string switches, but the strategy is currently gated by the existing seven-case hash-switch threshold. Smaller switches therefore use a linear sequence of string comparisons even when every non-null literal has the same length.

This change enables the existing length-based strategy when:

- there are at least three non-null string literals; and
- all non-null string literals share one length.

Switches with multiple literal lengths keep the existing threshold and behavior.

The threshold applies to `string`, `Span<char>`, and `ReadOnlySpan<char>` switches.

## Example

```csharp
static byte Decode(string str) => str switch
{
    "one" => 1,
    "two" => 2,
    "six" => 6,
    _ => 0
};
```

## IL

Before, the compiler emits three sequential string comparisons:

```il
// Code size: 57 bytes
ldarg.0
ldstr      "one"
call       bool string.op_Equality(string, string)
brtrue     one
ldarg.0
ldstr      "two"
call       bool string.op_Equality(string, string)
brtrue     two
ldarg.0
ldstr      "six"
call       bool string.op_Equality(string, string)
brtrue     six
br         default
```
^ this feels suboptimal while we can easily rule out strings of any length other than 3.

After, null and mismatched lengths go directly to the default case before character dispatch:

```il
// Code size: 100 bytes
ldarg.0
brfalse    default
ldarg.0
call       int string.Length.get
ldc.i4.3
bne.un     default
ldarg.0
ldc.i4.0
call       char string.this[int].get
// dispatch 'o', 't', and 's' to the final equality checks
```

This explicitly trades code size for speed: IL grows from 57 to 100 bytes. On .NET 11 Preview 7 x64 FullOpts, native code grows only from 163 to 166 bytes. The BDN results below improve all mixed workloads, which makes the tradeoff acceptable for this narrowly gated case.

## Performance

The same `SwitchDecoder.Decode` source was compiled twice with this branch's Release compiler:

- **Before:** `/features:disable-length-based-switch`
- **After:** default compiler options

The two assemblies were referenced by one BenchmarkDotNet process and measured side-by-side. `Decode` was marked `NoInlining`; input construction happened in `GlobalSetup`; non-interned inputs were copied from the literals; and the mixed benchmarks used eight explicitly unrolled calls with `OperationsPerInvoke = 8`.

BenchmarkDotNet v0.16.0-preview.1, Windows 11, AMD Ryzen 9 7950X, .NET 11.0.0 Preview 7, x64 RyuJIT (`x86-64-v4`), default job. Ratio is **After / Before**.

### Individual inputs

| Input | Before | After | Ratio |
|---|---:|---:|---:|
| `null` | 2.444 ns ± 0.0478 ns | 1.728 ns ± 0.0342 ns | 0.71 |
| Different length (`"x"`) | 2.406 ns ± 0.0478 ns | 1.836 ns ± 0.0234 ns | 0.76 |
| Different length (`"four"`) | 2.379 ns ± 0.0472 ns | 1.677 ns ± 0.0273 ns | 0.71 |
| Same-length miss (`"ten"`) | 2.407 ns ± 0.0553 ns | 1.955 ns ± 0.0383 ns | 0.82 |
| First case, interned (`"one"`) | 1.903 ns ± 0.0368 ns | 1.790 ns ± 0.0508 ns | 0.94 |
| Last case, interned (`"six"`) | 2.269 ns ± 0.0916 ns | 1.977 ns ± 0.0495 ns | 0.88 |
| First case, non-interned (`"one"`) | 1.980 ns ± 0.0576 ns | 2.185 ns ± 0.0689 ns | 1.11 |
| Last case, non-interned (`"six"`) | 2.390 ns ± 0.0834 ns | 2.051 ns ± 0.0390 ns | 0.87 |

### Mixed workloads

| Workload | Before | After | Ratio |
|---|---:|---:|---:|
| Wrong-length inputs | 1.980 ns ± 0.0601 ns | 1.301 ns ± 0.0260 ns | 0.66 |
| Default-heavy | 1.814 ns ± 0.0422 ns | 1.400 ns ± 0.0278 ns | 0.78 |
| Balanced matches/misses | 1.985 ns ± 0.0424 ns | 1.625 ns ± 0.0322 ns | 0.82 |
| Matching inputs | 1.732 ns ± 0.0324 ns | 1.592 ns ± 0.0421 ns | 0.92 |

All mixed workloads improved. The only individual regression was the first non-interned matching case, at approximately 11%. All cases were allocation-free.

## Testing

Added execution and complete-IL tests for the optimized `string`, `Span<char>`, and `ReadOnlySpan<char>` cases, plus boundary tests verifying that two literals, three mixed-length literals, and `null` plus two literals retain linear dispatch.
