### PR TITLE
Support F# Document Outline via LSP textDocument/documentSymbol

### DIFF
--- a/src/LanguageServer/Protocol/Handler/Symbols/DocumentSymbolsHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/Symbols/DocumentSymbolsHandler.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
 using System.Threading;
@@ -47,10 +48,22 @@ internal sealed class DocumentSymbolsHandler() : ILspServiceDocumentRequestHandl
 
         if (useHierarchicalSymbols)
         {
-            var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-            var solutionExplorerSymbolTreeItemProvider = document.Project.Services.GetRequiredService<ISolutionExplorerSymbolTreeItemProvider>();
+            if (document.SupportsSyntaxTree)
+            {
+                var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+                var solutionExplorerSymbolTreeItemProvider = document.Project.Services.GetRequiredService<ISolutionExplorerSymbolTreeItemProvider>();
 
-            return GetDocumentSymbolsFromSolutionExplorer(document.Id, root, text, solutionExplorerSymbolTreeItemProvider, cancellationToken);
+                return GetDocumentSymbolsFromSolutionExplorer(document.Id, root, text, solutionExplorerSymbolTreeItemProvider, cancellationToken);
+            }
+
+            // Languages without a Roslyn syntax tree (e.g. F#) cannot use ISolutionExplorerSymbolTreeItemProvider.
+            // Fall back to whatever hierarchical data their navigation bar provider exposes, if any.
+            var navBarItemService = document.Project.Services.GetService<INavigationBarItemService>();
+            if (navBarItemService == null)
+                return Array.Empty<DocumentSymbol>();
+
+            var navBarItems = await navBarItemService.GetItemsAsync(document, supportsCodeGeneration: false, frozenPartialSemantics: false, cancellationToken).ConfigureAwait(false);
+            return GetDocumentSymbolsFromNavigationBarItems(navBarItems, text);
         }
         else
         {
@@ -114,6 +127,35 @@ internal sealed class DocumentSymbolsHandler() : ILspServiceDocumentRequestHandl
             Range = ProtocolConversions.TextSpanToRange(fullSpan, text),
             SelectionRange = ProtocolConversions.TextSpanToRange(selectionSpan, text),
             Children = children,
+        };
+    }
+
+    private static RoslynDocumentSymbol[] GetDocumentSymbolsFromNavigationBarItems(ImmutableArray<RoslynNavigationBarItem> items, SourceText text)
+    {
+        using var _ = ArrayBuilder<RoslynDocumentSymbol>.GetInstance(out var symbols);
+        foreach (var item in items)
+        {
+            if (item is RoslynNavigationBarItem.SymbolItem symbolItem && symbolItem.Location.InDocumentInfo != null)
+                symbols.Add(ConvertToDocumentSymbol(symbolItem, text));
+        }
+
+        return symbols.ToArray();
+    }
+
+    private static RoslynDocumentSymbol ConvertToDocumentSymbol(RoslynNavigationBarItem.SymbolItem item, SourceText text)
+    {
+        var (spans, navigationSpan) = item.Location.InDocumentInfo!.Value;
+        var fullSpan = spans[0];
+
+        return new RoslynDocumentSymbol
+        {
+            Name = GetDocumentSymbolName(item.Text),
+            Detail = item.Name,
+            Kind = ProtocolConversions.GlyphToSymbolKind(item.Glyph),
+            Glyph = (int)item.Glyph,
+            Range = ProtocolConversions.TextSpanToRange(fullSpan, text),
+            SelectionRange = ProtocolConversions.TextSpanToRange(navigationSpan, text),
+            Children = GetDocumentSymbolsFromNavigationBarItems(item.ChildItems, text),
         };
     }
 

--- a/src/VisualStudio/ExternalAccess/Core/FSharp/Internal/Editor/FSharpDocumentSymbolNavigationBarItemService.cs
+++ b/src/VisualStudio/ExternalAccess/Core/FSharp/Internal/Editor/FSharpDocumentSymbolNavigationBarItemService.cs
@@ -1,0 +1,68 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Collections;
+using Microsoft.CodeAnalysis.ExternalAccess.FSharp.Editor;
+using Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.NavigationBar;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.ExternalAccess.FSharp.Internal.Editor;
+
+/// <summary>
+/// Feeds F# symbols into the Features/Core/Portable-layer <see cref="INavigationBarItemService"/>, the
+/// contract <see cref="Microsoft.CodeAnalysis.LanguageServer.Handler.DocumentSymbolsHandler"/> uses to answer
+/// textDocument/documentSymbol (and therefore what backs LSP-hosted UI such as the Document Outline tool
+/// window). This is separate from <see cref="Microsoft.CodeAnalysis.Editor.INavigationBarItemService"/>, which
+/// only drives the in-editor dropdown bar and lives in the WPF-dependent EditorFeatures layer that
+/// DocumentSymbolsHandler's portable project cannot reference.
+/// </summary>
+[Shared]
+[ExportLanguageService(typeof(INavigationBarItemService), LanguageNames.FSharp)]
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class FSharpDocumentSymbolNavigationBarItemService(
+    [Import(AllowDefault = true)] IFSharpNavigationBarItemService? service) : INavigationBarItemService
+{
+    private readonly IFSharpNavigationBarItemService? _service = service;
+
+    public async Task<ImmutableArray<RoslynNavigationBarItem>> GetItemsAsync(
+        Document document, bool supportsCodeGeneration, bool frozenPartialSemantics, CancellationToken cancellationToken)
+    {
+        if (_service == null)
+            return [];
+
+        var items = await _service.GetItemsAsync(document, cancellationToken).ConfigureAwait(false);
+        return items == null
+            ? []
+            : ConvertItems(items);
+    }
+
+    private static ImmutableArray<RoslynNavigationBarItem> ConvertItems(IList<FSharpNavigationBarItem> items)
+        => (items ?? SpecializedCollections.EmptyList<FSharpNavigationBarItem>()).SelectAsArray(x => x.Spans.Any(), ConvertToSymbolItem);
+
+    private static RoslynNavigationBarItem ConvertToSymbolItem(FSharpNavigationBarItem item)
+    {
+        var spans = item.Spans.ToImmutableArrayOrEmpty();
+        var location = new RoslynNavigationBarItem.SymbolItemLocation(inDocumentInfo: (spans, spans[0]), otherDocumentInfo: null);
+
+        return new RoslynNavigationBarItem.SymbolItem(
+            name: item.Text,
+            text: item.Text,
+            glyph: FSharpGlyphHelpers.ConvertTo(item.Glyph),
+            isObsolete: false,
+            location: location,
+            childItems: ConvertItems(item.ChildItems),
+            indent: item.Indent,
+            bolded: item.Bolded);
+    }
+}


### PR DESCRIPTION
F#'s `FSharpLanguageService` already inherits Roslyn's `AbstractLanguageService<,>`, so the Document Outline tool window (Ctrl+Alt+T) is already hosted for `.fs` files — it just renders empty. `DocumentSymbolsHandler`'s hierarchical branch unconditionally calls `GetRequiredSyntaxRootAsync` and `ISolutionExplorerSymbolTreeItemProvider`, neither of which F# supports, so the request fails silently for any language without a Roslyn syntax tree.

This makes that branch fall back to hierarchical data from the portable (Features/Core/Portable-layer) `Microsoft.CodeAnalysis.NavigationBar.INavigationBarItemService` when `document.SupportsSyntaxTree` is `false`, instead of throwing.

`FSharpDocumentSymbolNavigationBarItemService` (new, in `ExternalAccess.Core.FSharp`) implements that portable interface for `LanguageNames.FSharp`, reusing the same MEF-imported `IFSharpNavigationBarItemService` that already backs the classic F# navigation bar dropdown, converting `FSharpNavigationBarItem` to `RoslynNavigationBarItem.SymbolItem` recursively. This is a separate service from `Microsoft.CodeAnalysis.Editor.INavigationBarItemService` (the WPF/editor-layer interface driving the dropdown bar itself), since `DocumentSymbolsHandler` lives in the portable, non-WPF `Microsoft.CodeAnalysis.LanguageServer.Protocol` project and can't reference EditorFeatures.

Verified locally with `Build.cmd -Restore -Configuration Release -deployExtensions -launch`: opened an `.fs` file in the RoslynDev experimental hive, Ctrl+Alt+T now populates the Document Outline tree. Currently 2 levels deep (top-level declaration + members), matching what FCS's `Navigation.getNavigation` already exposes to the classic nav bar — going deeper would be a follow-up on the F# side.

cc @T-Gro

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85087)