### PR TITLE
Consider the type of file change when we process file changes

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/DefaultFileChangeWatcherTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/DefaultFileChangeWatcherTests.cs
@@ -524,12 +524,12 @@ public sealed class DefaultFileChangeWatcherTests : IDisposable
 
     private static FileChangeTask ListenForFileChangeAsync(IFileChangeContext context, string filePath)
     {
-        var eventSource = new TaskCompletionSource();
+        var eventSource = new TaskCompletionSource<FileChangeKind>();
 
-        context.FileChanged += (sender, path) =>
+        context.FileChanged += (sender, e) =>
         {
-            if (path == filePath)
-                eventSource.TrySetResult();
+            if (e.FilePath == filePath)
+                eventSource.TrySetResult(e.ChangeKind);
         };
 
         return new FileChangeTask(eventSource.Task, filePath);
@@ -538,7 +538,7 @@ public sealed class DefaultFileChangeWatcherTests : IDisposable
     /// <summary>
     /// Represents a wait for a single file change; includes the file path so failures are easy to understand which one didn't trigger.
     /// </summary>
-    private sealed record FileChangeTask(Task Task, string FilePath);
+    private sealed record FileChangeTask(Task<FileChangeKind> Task, string FilePath);
 
     [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83180")]
     public async Task FileCreated_InWatchedParentDirectory_RaisesFileChangedEvent()
@@ -558,6 +558,7 @@ public sealed class DefaultFileChangeWatcherTests : IDisposable
 
         // Wait for the event
         await AssertAllChangesFire([fileChangeTask], s_fileChangeTimeout);
+        Assert.Equal(FileChangeKind.Added, await fileChangeTask.Task);
     }
 
     [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83180")]
@@ -578,6 +579,7 @@ public sealed class DefaultFileChangeWatcherTests : IDisposable
 
         // Wait for the event
         await AssertAllChangesFire([fileChangeTask], s_fileChangeTimeout);
+        Assert.Equal(FileChangeKind.Changed, await fileChangeTask.Task);
     }
 
     [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83180")]
@@ -598,6 +600,7 @@ public sealed class DefaultFileChangeWatcherTests : IDisposable
 
         // Wait for the event
         await AssertAllChangesFire([fileChangeTask], s_fileChangeTimeout);
+        Assert.Equal(FileChangeKind.Removed, await fileChangeTask.Task);
     }
 
     [ConditionalFact(typeof(WindowsOnly), Reason = "https://github.com/dotnet/roslyn/issues/83180")]
@@ -991,7 +994,7 @@ public sealed class DefaultFileChangeWatcherTests : IDisposable
         var context1Events = new List<string>();
         var context2Received = ListenForFileChangeAsync(context2, filePath);
 
-        context1.FileChanged += (sender, path) => context1Events.Add(path);
+        context1.FileChanged += (sender, e) => context1Events.Add(e.FilePath);
 
         // Dispose context1 before creating file
         context1.Dispose();

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/LspFileChangeWatcherTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/LspFileChangeWatcherTests.cs
@@ -101,6 +101,40 @@ public sealed class LspFileChangeWatcherTests(ITestOutputHelper testOutputHelper
         AssertNoFileWatcherRegistration(dynamicCapabilitiesRpcTarget);
     }
 
+    [Theory]
+    [InlineData((int)FileChangeType.Created, (int)FileChangeKind.Added)]
+    [InlineData((int)FileChangeType.Changed, (int)FileChangeKind.Changed)]
+    [InlineData((int)FileChangeType.Deleted, (int)FileChangeKind.Removed)]
+    public async Task FileChangeNotificationIncludesChangeKind(int fileChangeType, int expectedChangeKind)
+    {
+        await using var testLspServer = await CreateLanguageServerAsync(_clientCapabilitiesWithFileWatcherSupport);
+        var lspFileChangeWatcher = AssertFileWatcherKind<LspFileChangeWatcher>(testLspServer);
+        var tempDirectory = TempRoot.CreateDirectory();
+        var filePath = Path.Combine(tempDirectory.Path, "File.cs");
+
+        using var context = lspFileChangeWatcher.CreateContext([new ProjectSystem.WatchedDirectory(tempDirectory.Path, extensionFilters: [])]);
+        var fileChangedSource = new TaskCompletionSource<FileChangedEventArgs>();
+        context.FileChanged += (_, e) => fileChangedSource.TrySetResult(e);
+
+        await testLspServer.ExecuteNotificationAsync(
+            Methods.WorkspaceDidChangeWatchedFilesName,
+            new DidChangeWatchedFilesParams
+            {
+                Changes =
+                [
+                    new FileEvent
+                    {
+                        Uri = ProtocolConversions.CreateAbsoluteDocumentUri(filePath),
+                        FileChangeType = (FileChangeType)fileChangeType,
+                    },
+                ],
+            });
+
+        var eventArgs = await fileChangedSource.Task;
+        Assert.Equal(filePath, eventArgs.FilePath);
+        Assert.Equal((FileChangeKind)expectedChangeKind, eventArgs.ChangeKind);
+    }
+
     private static T AssertFileWatcherKind<T>(TestLspServer server) where T : IFileChangeWatcher
     {
         var lspFileWatcher = server.GetRequiredLspService<IFileChangeWatcher>();

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/MiscellaneousFiles/FileBasedProgramsWorkspaceTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/MiscellaneousFiles/FileBasedProgramsWorkspaceTests.cs
@@ -873,9 +873,9 @@ public sealed class FileBasedProgramsWorkspaceTests(ITestOutputHelper testOutput
         var fileChangeWatcher = testLspServer.GetRequiredLspService<IFileChangeWatcher>();
         using var fileChangeContext = fileChangeWatcher.CreateContext([new WatchedDirectory(Path.GetDirectoryName(appCsFile.Path)!, extensionFilters: [])]);
         var fileChangeTcs = new TaskCompletionSource();
-        fileChangeContext.FileChanged += (_, path) =>
+        fileChangeContext.FileChanged += (_, e) =>
         {
-            if (path == appCsFile.Path)
+            if (e.FilePath == appCsFile.Path)
                 fileChangeTcs.TrySetResult();
         };
 

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileWatching/DefaultFileChangeWatcher.FileChangeContext.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileWatching/DefaultFileChangeWatcher.FileChangeContext.cs
@@ -47,7 +47,7 @@ internal sealed partial class DefaultFileChangeWatcher
                 _watchedDirectoriesWatches.Add(_owner.AcquireDirectoryWatch(watchedDirectory, this, includeSubdirectories: true));
         }
 
-        public event EventHandler<string>? FileChanged;
+        public event EventHandler<FileChangedEventArgs>? FileChanged;
 
         public IWatchedFile EnqueueWatchingFile(string filePath)
         {
@@ -102,10 +102,19 @@ internal sealed partial class DefaultFileChangeWatcher
             }
 
             if (shouldRaiseForNewPath)
-                FileChanged?.Invoke(this, e.FullPath);
+            {
+                var changeKind = e.ChangeType switch
+                {
+                    WatcherChangeTypes.Created or WatcherChangeTypes.Renamed => FileChangeKind.Added,
+                    WatcherChangeTypes.Deleted => FileChangeKind.Removed,
+                    _ => FileChangeKind.Changed,
+                };
+
+                FileChanged?.Invoke(this, new(e.FullPath, changeKind));
+            }
 
             if (shouldRaiseForOldPath)
-                FileChanged?.Invoke(this, ((RenamedEventArgs)e).OldFullPath);
+                FileChanged?.Invoke(this, new(((RenamedEventArgs)e).OldFullPath, FileChangeKind.Removed));
         }
 
         /// <summary>

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileWatching/LspFileChangeWatcher.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/FileWatching/LspFileChangeWatcher.cs
@@ -119,7 +119,7 @@ internal sealed class LspFileChangeWatcher : IFileChangeWatcher
                 // was the one that registered for this change, so we have to check paths to see if this one we should respond to.
                 if (WatchedDirectory.FilePathCoveredByWatchedDirectories(_watchedDirectories, filePath, s_stringComparison))
                 {
-                    FileChanged?.Invoke(this, filePath);
+                    FileChanged?.Invoke(this, new(filePath, GetFileChangeKind(changedFile.FileChangeType)));
                 }
                 else
                 {
@@ -130,12 +130,21 @@ internal sealed class LspFileChangeWatcher : IFileChangeWatcher
                     }
 
                     if (isFileWatched)
-                        FileChanged?.Invoke(this, filePath);
+                        FileChanged?.Invoke(this, new(filePath, GetFileChangeKind(changedFile.FileChangeType)));
                 }
             }
         }
 
-        public event EventHandler<string>? FileChanged;
+        private static FileChangeKind GetFileChangeKind(FileChangeType fileChangeType)
+            => fileChangeType switch
+            {
+                FileChangeType.Created => FileChangeKind.Added,
+                FileChangeType.Deleted => FileChangeKind.Removed,
+                FileChangeType.Changed => FileChangeKind.Changed,
+                _ => throw ExceptionUtilities.UnexpectedValue(fileChangeType),
+            };
+
+        public event EventHandler<FileChangedEventArgs>? FileChanged;
 
         public void Dispose()
         {

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LoadedProject.Target.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LoadedProject.Target.cs
@@ -55,14 +55,14 @@ internal sealed partial class LoadedProject
             _assetsFileChangeContext.FileChanged += AssetsFileChangeContext_FileChanged;
         }
 
-        private void AssetsFileChangeContext_FileChanged(object? sender, string filePath)
+        private void AssetsFileChangeContext_FileChanged(object? sender, FileChangedEventArgs e)
         {
             Shared.Utilities.IOUtilities.PerformIO(() =>
             {
                 // We only want to trigger design time build if the assets file content actually changed from the last time this handler was called.
                 // Sometimes we can get a change event where no content changed (e.g. for a failed restore).
                 // In such cases, proceeding with design-time build can put us in a restore loop (since the design-time build notices that assets are missing).
-                using var assetsFileStream = File.OpenRead(filePath);
+                using var assetsFileStream = File.OpenRead(e.FilePath);
                 var checksum = Checksum.Create(assetsFileStream);
                 if (_mostRecentProjectAssetsFileChecksum != checksum)
                 {

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LoadedProject.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LoadedProject.cs
@@ -69,7 +69,6 @@ internal sealed partial class LoadedProject : IAsyncDisposable
             if (_projectDirectory is not null)
             {
                 // We'll watch the directory for all source file changes
-                // TODO: we only should listen for add/removals here, but we can't specify such a filter now
                 _sourceFileCreatedOrDeletedChangeContext = fileWatcher.CreateContext([new(_projectDirectory, [".cs", ".cshtml", ".razor"])]);
                 _sourceFileCreatedOrDeletedChangeContext.FileChanged += SourceFileCreatedOrDeletedChangeContext_FileChanged;
             }
@@ -81,7 +80,7 @@ internal sealed partial class LoadedProject : IAsyncDisposable
     /// </summary>
     public event EventHandler? NeedsReload;
 
-    private void ProjectFileChangeContext_FileChanged(object? sender, string filePath)
+    private void ProjectFileChangeContext_FileChanged(object? sender, FileChangedEventArgs e)
     {
         NeedsReload?.Invoke(this, EventArgs.Empty);
     }
@@ -92,16 +91,20 @@ internal sealed partial class LoadedProject : IAsyncDisposable
     }
 
 #pragma warning disable VSTHRD100 // Avoid async void methods -- async void because it's being used by an event handler
-    private async void SourceFileCreatedOrDeletedChangeContext_FileChanged(object? sender, string filePath)
+    private async void SourceFileCreatedOrDeletedChangeContext_FileChanged(object? sender, FileChangedEventArgs e)
 #pragma warning restore VSTHRD100 // Avoid async void methods
     {
+        // We only need to handle file adds/removes -- the changes are handled in the ProjectSystemProjectFactory for us
+        if (e.ChangeKind == FileChangeKind.Changed)
+            return;
+
         bool needsReload = false;
 
         using (await _gate.DisposableWaitAsync())
         {
             foreach (var target in _targets)
             {
-                if (target.FilePathIsIncludedInFileGlobs(filePath))
+                if (target.FilePathIsIncludedInFileGlobs(e.FilePath))
                 {
                     needsReload = true;
                     break;

--- a/src/VisualStudio/Core/Def/ProjectSystem/FileChangeWatcher.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/FileChangeWatcher.cs
@@ -418,7 +418,7 @@ internal sealed class FileChangeWatcher : IFileChangeWatcher
             _fileChangeWatcher._taskQueue.AddWork(WatcherOperation.UnwatchFile(watchedFile));
         }
 
-        public event EventHandler<string>? FileChanged;
+        public event EventHandler<FileChangedEventArgs>? FileChanged;
 
         int IVsFreeThreadedFileChangeEvents.FilesChanged(uint cChanges, string[] rgpszFile, uint[] rggrfChange)
         {
@@ -428,7 +428,7 @@ internal sealed class FileChangeWatcher : IFileChangeWatcher
                 if ((fileChangeFlags & FileChangeTracker.DefaultFileChangeFlags) == 0)
                     continue;
 
-                FileChanged?.Invoke(this, rgpszFile[i]);
+                RaiseFileChanged(rgpszFile[i], fileChangeFlags);
             }
 
             return VSConstants.S_OK;
@@ -460,7 +460,7 @@ internal sealed class FileChangeWatcher : IFileChangeWatcher
                 if ((fileChangeFlags & FileChangeTracker.DefaultFileChangeFlags) == 0)
                     continue;
 
-                FileChanged?.Invoke(this, rgpszFile[i]);
+                RaiseFileChanged(rgpszFile[i], fileChangeFlags);
             }
 
             return VSConstants.S_OK;
@@ -505,10 +505,22 @@ internal sealed class FileChangeWatcher : IFileChangeWatcher
                 if ((fileChangeFlags & FileChangeTracker.DefaultFileChangeFlags) == 0)
                     continue;
 
-                FileChanged?.Invoke(this, rgpszFile[i]);
+                RaiseFileChanged(rgpszFile[i], fileChangeFlags);
             }
 
             return VSConstants.S_OK;
+        }
+
+        private void RaiseFileChanged(string filePath, _VSFILECHANGEFLAGS fileChangeFlags)
+        {
+            var changeKind = fileChangeFlags switch
+            {
+                _ when (fileChangeFlags & _VSFILECHANGEFLAGS.VSFILECHG_Add) != 0 => FileChangeKind.Added,
+                _ when (fileChangeFlags & _VSFILECHANGEFLAGS.VSFILECHG_Del) != 0 => FileChangeKind.Removed,
+                _ => FileChangeKind.Changed,
+            };
+
+            FileChanged?.Invoke(this, new(filePath, changeKind));
         }
 
         int IVsFreeThreadedFileChangeEvents.DirectoryChangedEx(string pszDirectory, string pszFile)

--- a/src/VisualStudio/Core/Def/ProjectSystem/RuleSets/VisualStudioRuleSetManager.RuleSetFile.cs
+++ b/src/VisualStudio/Core/Def/ProjectSystem/RuleSets/VisualStudioRuleSetManager.RuleSetFile.cs
@@ -170,7 +170,7 @@ internal sealed partial class VisualStudioRuleSetManager
             _ruleSetManager.StopTrackingRuleSetFile(this);
         }
 
-        private void IncludeUpdated(object sender, string fileChanged)
+        private void IncludeUpdated(object sender, FileChangedEventArgs e)
         {
             // The file change service is going to notify us of updates on the foreground thread.
             // This is going to cause us to drop our existing subscriptions and create new ones.

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/IFileChangeWatcher.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/IFileChangeWatcher.cs
@@ -81,13 +81,26 @@ internal interface IFileChangeContext : IDisposable
     /// Raised when a file has been changed. This may be a file watched explicitly by <see cref="EnqueueWatchingFile(string)"/> or it could be any
     /// file in the directory if the <see cref="IFileChangeContext"/> was watching a directory.
     /// </summary>
-    event EventHandler<string> FileChanged;
+    event EventHandler<FileChangedEventArgs> FileChanged;
 
     /// <summary>
     /// Starts watching a file but doesn't wait for the file watcher to be registered with the operating system. Good if you know
     /// you'll need a file watched (eventually) but it's not worth blocking yet.
     /// </summary>
     IWatchedFile EnqueueWatchingFile(string filePath);
+}
+
+internal sealed class FileChangedEventArgs(string filePath, FileChangeKind changeKind) : EventArgs
+{
+    public string FilePath { get; } = filePath;
+    public FileChangeKind ChangeKind { get; } = changeKind;
+}
+
+internal enum FileChangeKind
+{
+    Added,
+    Removed,
+    Changed
 }
 
 internal interface IWatchedFile : IDisposable

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ProjectSystemProject.cs
@@ -1042,9 +1042,9 @@ internal sealed partial class ProjectSystemProject
 
     #endregion
 
-    private void DocumentFileChangeContext_FileChanged(object? sender, string fullFilePath)
+    private void DocumentFileChangeContext_FileChanged(object? sender, FileChangedEventArgs e)
     {
-        _fileChangesToProcess.AddWork(fullFilePath);
+        _fileChangesToProcess.AddWork(e.FilePath);
     }
 
     private async ValueTask ProcessFileChangesAsync(ImmutableSegmentedList<string> filePaths, CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ReferenceFileChangeTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/ProjectSystem/ReferenceFileChangeTracker.cs
@@ -54,7 +54,7 @@ internal sealed class ReferenceFileChangeTracker : IDisposable
         _fileReferenceChangeContext = new Lazy<IFileChangeContext>(() =>
         {
             var fileReferenceChangeContext = fileChangeWatcher.CreateContext(GetAdditionalWatchedDirectories());
-            fileReferenceChangeContext.FileChanged += (s, e) => _workQueue.AddWork(e);
+            fileReferenceChangeContext.FileChanged += (s, e) => _workQueue.AddWork(e.FilePath);
             return fileReferenceChangeContext;
         });
 


### PR DESCRIPTION
Previously, we had a file watch for source files in the project directory so we could trigger design-time builds when the user created or deleted a file. This was also triggering on changes to existing files, even though we didn't need to do a new design time build for that. Since the code never threaded through what type of change it was, there was no option. This threads it through.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85091)