### PR TITLE
[breaking-change] Treat partial consistently as a modifier

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1639,19 +1639,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             if (this.IsUnambiguousAnonymousFunctionModifierListFollowedByOpenParen())
                 return false;
 
-            var nextToken = this.PeekToken(1);
+            using var _ = this.GetDisposableResetPoint(resetOnDispose: true);
+
+            this.EatToken();
 
             // '(' may start either the parameter list for a member named 'partial' or a tuple
             // return type. A tuple type followed by a member name proves that 'partial' is a modifier.
-            if (nextToken.Kind == SyntaxKind.OpenParenToken)
-            {
-                using var _ = this.GetDisposableResetPoint(resetOnDispose: true);
-                this.EatToken();
+            if (this.CurrentToken.Kind == SyntaxKind.OpenParenToken)
                 return this.IsTypeFollowedByMemberName();
-            }
 
             // If the next token does not prove that 'partial' is the member name, it is a modifier.
-            return !IsDefinitePartialMemberNameContinuation(nextToken.Kind);
+            return !IsDefinitePartialMemberNameContinuation(this.CurrentToken.Kind);
         }
 
         private static bool IsDefinitePartialMemberNameContinuation(SyntaxKind kind)

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1663,15 +1663,26 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         private static bool IsDefinitePartialMemberNameContinuation(SyntaxKind kind)
             => kind switch
             {
-                SyntaxKind.CommaToken => true,               // partial, other;
-                SyntaxKind.EqualsToken => true,              // partial = value;
-                SyntaxKind.EqualsGreaterThanToken => true,   // partial => value;
-                SyntaxKind.LessThanToken => true,             // partial<T>()
-                SyntaxKind.OpenBraceToken => true,            // partial { get; }
-                SyntaxKind.SemicolonToken => true,            // partial;
+                // A field name: partial, other;
+                SyntaxKind.CommaToken => true,
 
-                // '(' is not sufficient because it may start either the parameter list for a
-                // member named 'partial' or a tuple return type following a 'partial' modifier.
+                // An initialized field name: partial = value;
+                SyntaxKind.EqualsToken => true,
+
+                // An expression-bodied property name: partial => value;
+                SyntaxKind.EqualsGreaterThanToken => true,
+
+                // A generic method name: partial<T>()
+                SyntaxKind.LessThanToken => true,
+
+                // A property name: partial { get; }
+                SyntaxKind.OpenBraceToken => true,
+
+                // A field name: partial;
+                SyntaxKind.SemicolonToken => true,
+
+                // Note: 'partial(' is not sufficient to prove that 'partial' is a method or constructor
+                // name because '(' may instead start a tuple return type following the modifier.
                 _ => false,
             };
 

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1639,25 +1639,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             if (this.IsUnambiguousAnonymousFunctionModifierListFollowedByOpenParen())
                 return false;
 
-            using var _ = this.GetDisposableResetPoint(resetOnDispose: true);
-
-            this.EatToken();
+            var nextToken = this.PeekToken(1);
 
             // '(' may start either the parameter list for a member named 'partial' or a tuple
             // return type. A tuple type followed by a member name proves that 'partial' is a modifier.
-            if (this.CurrentToken.Kind == SyntaxKind.OpenParenToken)
+            if (nextToken.Kind == SyntaxKind.OpenParenToken)
             {
+                using var _ = this.GetDisposableResetPoint(resetOnDispose: true);
+                this.EatToken();
                 return this.IsTypeFollowedByMemberName();
             }
 
-            // These tokens prove that 'partial' is the member name.
-            if (IsDefinitePartialMemberNameContinuation(this.CurrentToken.Kind))
-            {
-                return false;
-            }
-
-            // Nothing proved that 'partial' was the member name, so it is a modifier.
-            return true;
+            // If the next token does not prove that 'partial' is the member name, it is a modifier.
+            return !IsDefinitePartialMemberNameContinuation(nextToken.Kind);
         }
 
         private static bool IsDefinitePartialMemberNameContinuation(SyntaxKind kind)

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1639,19 +1639,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             if (this.IsUnambiguousAnonymousFunctionModifierListFollowedByOpenParen())
                 return false;
 
+            // A leading 'partial' followed by a definite member-name continuation, such as
+            // 'partial;', 'partial =>', or 'partial<T>', names the member.
             if (this.IsCurrentTokenDefinitelyPartialMemberName())
                 return false;
+
+            // '(' may start either the parameter list for a member named 'partial' or a tuple
+            // return type. A tuple type followed by a member name proves that 'partial' is a modifier.
+            if (this.PeekToken(1).Kind != SyntaxKind.OpenParenToken)
+                return true;
 
             using var _ = this.GetDisposableResetPoint(resetOnDispose: true);
 
             this.EatToken();
-
-            // '(' may start either the parameter list for a member named 'partial' or a tuple
-            // return type. A tuple type followed by a member name proves that 'partial' is a modifier.
-            if (this.CurrentToken.Kind == SyntaxKind.OpenParenToken)
-                return this.IsTypeFollowedByMemberName();
-
-            return true;
+            return this.IsTypeFollowedByMemberName();
         }
 
         private bool IsCurrentTokenDefinitelyPartialMemberName()

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -875,8 +875,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 case SyntaxKind.NamespaceKeyword:
                     return true;
                 case SyntaxKind.IdentifierToken:
-                    // `onlyForTypeDeclarations: true`: A type member such as 'partial int M()' cannot start a namespace body.
-                    return this.IsCurrentTokenDefinitelyPartialModifier(onlyForTypeDeclarations: true);
+                    return this.IsCurrentTokenDefinitelyPartialModifier();
                 default:
                     return IsPossibleStartOfTypeDeclaration(this.CurrentToken.Kind);
             }
@@ -1369,9 +1368,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 switch (newMod)
                 {
                     case DeclarationModifiers.Partial:
-                        // `onlyForTypeDeclarations: false`: ParseModifiers is shared by types and members, such as
-                        // 'partial class C' and 'partial void M()'.
-                        if (!this.IsCurrentTokenDefinitelyPartialModifier(onlyForTypeDeclarations: false))
+                        if (!this.IsCurrentTokenDefinitelyPartialModifier())
                             return;
 
                         modTok = ConvertToKeyword(this.EatToken());
@@ -1520,10 +1517,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
             // If 'partial' starts a declaration, the preceding token is also a modifier,
             // as in 'closed partial ref struct'.
-            // `onlyForTypeDeclarations: false`: The preceding modifier may belong to either a type or a member, such as
-            // 'public partial class C' or 'public partial void M()'.
             if (!parsingStatementNotDeclaration &&
-                this.IsCurrentTokenDefinitelyPartialModifier(onlyForTypeDeclarations: false))
+                this.IsCurrentTokenDefinitelyPartialModifier())
             {
                 return true;
             }
@@ -1634,7 +1629,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         /// Determines whether the current token is definitely a <c>partial</c> modifier,
         /// including misplaced forms for binding to diagnose.
         /// </summary>
-        private bool IsCurrentTokenDefinitelyPartialModifier(bool onlyForTypeDeclarations)
+        private bool IsCurrentTokenDefinitelyPartialModifier()
         {
             if (this.CurrentToken.ContextualKind != SyntaxKind.PartialKeyword)
                 return false;
@@ -1644,86 +1639,35 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             if (this.IsUnambiguousAnonymousFunctionModifierListFollowedByOpenParen())
                 return false;
 
-            return isPartialModifierInTypeOrNamespaceDeclaration() ||
-                   isPartialModifierInMemberDeclaration();
+            using var _ = this.GetDisposableResetPoint(resetOnDispose: true);
 
-            bool isPartialModifierInTypeOrNamespaceDeclaration()
+            this.EatToken();
+
+            // '(' may start either the parameter list for a member named 'partial' or a tuple
+            // return type. A tuple type followed by a member name proves that 'partial' is a modifier.
+            if (this.CurrentToken.Kind == SyntaxKind.OpenParenToken)
             {
-                using var _ = this.GetDisposableResetPoint(resetOnDispose: true);
-
-                Debug.Assert(this.CurrentToken.ContextualKind == SyntaxKind.PartialKeyword);
-
-                // Type and namespace declarations are straightforward: skip the modifier list and
-                // require a well-known declaration keyword such as 'class', 'struct', or 'namespace'.
-                while (GetModifierExcludingScoped(this.CurrentToken) != DeclarationModifiers.None)
-                    this.EatToken();
-
-                return this.IsTypeOrNamespaceDeclarationStart();
-            }
-
-            bool isPartialModifierInMemberDeclaration()
-            {
-                if (onlyForTypeDeclarations)
-                    return false;
-
-                using var _ = this.GetDisposableResetPoint(resetOnDispose: true);
-
-                Debug.Assert(this.CurrentToken.ContextualKind == SyntaxKind.PartialKeyword);
-
-                // Consume the 'partial' and determine if what follows is definitively a member.
-                this.EatToken();
-
-                // With partial constructors enabled, 'partial Identifier(' starts a constructor.
-                // In earlier versions, 'partial' is the return type and the identifier is the member name.
-                if (isIdentifierFollowedByOpenParen(peekIndex: 0))
-                    return IsFeatureEnabled(MessageID.IDS_FeaturePartialEventsAndConstructors);
-
-                while (GetModifierExcludingScoped(this.CurrentToken) != DeclarationModifiers.None)
-                {
-                    // Before a non-contextual modifier, as in 'partial static', the initial
-                    // 'partial' is unambiguously a modifier.
-                    if (this.CurrentToken.Kind != SyntaxKind.IdentifierToken)
-                        return true;
-
-                    // A contextual modifier followed by 'Identifier(' either starts a method
-                    // return type, as in 'partial async C()', or is another modifier on a partial
-                    // constructor, as in 'partial partial C()'. Either way, the initial 'partial' is
-                    // a modifier. For the latter form in C# 14, scanning the second 'partial' as a type
-                    // reenters this helper and classifies it as a modifier, so IsTypeFollowedByMemberName()
-                    // returns false.
-                    if (isIdentifierFollowedByOpenParen(peekIndex: 1))
-                        return true;
-
-                    // A contextual modifier may otherwise be the member's return type, such as
-                    // the second 'partial' in 'partial partial P { get; }'.
-                    if (this.IsTypeFollowedByMemberName())
-                        return true;
-
-                    this.EatToken();
-                }
-
-                // No modifier-like token remains, so the current token must start the member itself.
-
-                // 'event' cannot begin another member form, so parse 'partial event' as an event in
-                // every language version. Binding reports the feature diagnostic when necessary.
-                if (this.CurrentToken.Kind == SyntaxKind.EventKeyword)
-                    return true;
-
-                // 'implicit' and 'explicit' can only start conversion operators, so 'partial' is a
-                // modifier even when the operator declaration is incomplete.
-                if (this.CurrentToken.Kind is SyntaxKind.ImplicitKeyword or SyntaxKind.ExplicitKeyword)
-                    return true;
-
-                // Otherwise, require a return type followed by a member name, as in 'partial int M()'.
                 return this.IsTypeFollowedByMemberName();
             }
 
-            bool isIdentifierFollowedByOpenParen(int peekIndex)
+            // These tokens prove that 'partial' is the member name.
+            if (IsDefinitePartialMemberNameContinuation(this.CurrentToken.Kind))
             {
-                return this.PeekToken(peekIndex).Kind == SyntaxKind.IdentifierToken &&
-                    this.PeekToken(peekIndex + 1).Kind == SyntaxKind.OpenParenToken;
+                return false;
             }
+
+            // Nothing proved that 'partial' was the member name, so it is a modifier.
+            return true;
         }
+
+        private static bool IsDefinitePartialMemberNameContinuation(SyntaxKind kind)
+            => kind is
+                SyntaxKind.CommaToken or
+                SyntaxKind.EqualsToken or
+                SyntaxKind.EqualsGreaterThanToken or
+                SyntaxKind.LessThanToken or
+                SyntaxKind.OpenBraceToken or
+                SyntaxKind.SemicolonToken;
 
         /// <summary>
         /// Checks for a type followed by a possible member name without advancing the parser.
@@ -2750,7 +2694,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                     return this.ParseTypeDeclaration(attributes, modifiers);
                 }
 
-                TypeSyntax type = ParseReturnType();
+                TypeSyntax type = ParseReturnTypeOrMissingTypeForPartialMemberName();
 
                 var afterTypeResetPoint = this.GetResetPoint();
 
@@ -3311,7 +3255,7 @@ parse_member_name:;
                 // Everything that's left -- methods, fields, properties, 
                 // indexers, and non-conversion operators -- starts with a type 
                 // (possibly void).
-                TypeSyntax type = ParseReturnType();
+                TypeSyntax type = ParseReturnTypeOrMissingTypeForPartialMemberName();
 
                 var afterTypeResetPoint = this.GetResetPoint();
 
@@ -3742,6 +3686,18 @@ parse_member_name:;
             var type = this.ParseTypeOrVoid();
             _termState = saveTerm;
             return type;
+        }
+
+        private TypeSyntax ParseReturnTypeOrMissingTypeForPartialMemberName()
+        {
+            if (this.CurrentToken.ContextualKind != SyntaxKind.PartialKeyword ||
+                !IsDefinitePartialMemberNameContinuation(this.PeekToken(1).Kind))
+            {
+                return ParseReturnType();
+            }
+
+            return _syntaxFactory.PredefinedType(
+                this.AddError(SyntaxFactory.MissingToken(SyntaxKind.VoidKeyword), ErrorCode.ERR_MemberNeedsType));
         }
 
         private bool IsEndOfReturnType()
@@ -6020,8 +5976,7 @@ parse_member_name:;
         {
             if (this.CurrentToken.Kind == SyntaxKind.IdentifierToken)
             {
-                if (!IsCurrentTokenDefinitelyPartialModifier(onlyForTypeDeclarations: false) &&
-                    !IsCurrentTokenQueryKeywordInQuery() &&
+                if (!IsCurrentTokenQueryKeywordInQuery() &&
                     !IsCurrentTokenWhereOfConstraintClause())
                 {
                     return true;
@@ -6061,13 +6016,7 @@ parse_member_name:;
             var ctk = this.CurrentToken.Kind;
             if (ctk == SyntaxKind.IdentifierToken)
             {
-                // Error tolerance for IntelliSense. Consider the following case: [EditorBrowsable( partial class Goo {
-                // } Because we're parsing an attribute argument we'll end up consuming the "partial" identifier and
-                // we'll eventually end up in a pretty confused state.  Because of that it becomes very difficult to
-                // show the correct parameter help in this case.  So, when we see "partial" we check if it's being used
-                // as an identifier or as a contextual keyword.  If it's the latter then we bail out.  See
-                // Bug: vswhidbey/542125
-                if (this.IsCurrentTokenDefinitelyPartialModifier(onlyForTypeDeclarations: false) || IsCurrentTokenQueryKeywordInQuery())
+                if (IsCurrentTokenQueryKeywordInQuery())
                 {
                     var result = CreateMissingIdentifierToken();
                     result = this.AddError(result, ErrorCode.ERR_InvalidExprTerm, this.CurrentToken.Text);
@@ -6163,8 +6112,7 @@ parse_member_name:;
                 _termState = saveTerm;
             }
 
-            if (this.IsCurrentTokenWhereOfConstraintClause() ||
-                this.IsCurrentTokenDefinitelyPartialModifier(onlyForTypeDeclarations: false))
+            if (this.IsCurrentTokenWhereOfConstraintClause())
             {
                 return _syntaxFactory.TypeParameter(
                     attrs,

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -3713,8 +3713,7 @@ parse_member_name:;
         {
             if (this.IsCurrentTokenDefinitelyPartialMemberName())
             {
-                return _syntaxFactory.PredefinedType(
-                    this.AddError(SyntaxFactory.MissingToken(SyntaxKind.VoidKeyword), ErrorCode.ERR_MemberNeedsType));
+                return this.AddError(this.CreateMissingIdentifierName(), ErrorCode.ERR_MemberNeedsType);
             }
 
             return ParseReturnType();

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1661,13 +1661,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         }
 
         private static bool IsDefinitePartialMemberNameContinuation(SyntaxKind kind)
-            => kind is
-                SyntaxKind.CommaToken or
-                SyntaxKind.EqualsToken or
-                SyntaxKind.EqualsGreaterThanToken or
-                SyntaxKind.LessThanToken or
-                SyntaxKind.OpenBraceToken or
-                SyntaxKind.SemicolonToken;
+            => kind switch
+            {
+                SyntaxKind.CommaToken => true,               // partial, other;
+                SyntaxKind.EqualsToken => true,              // partial = value;
+                SyntaxKind.EqualsGreaterThanToken => true,   // partial => value;
+                SyntaxKind.LessThanToken => true,             // partial<T>()
+                SyntaxKind.OpenBraceToken => true,            // partial { get; }
+                SyntaxKind.SemicolonToken => true,            // partial;
+
+                // '(' is not sufficient because it may start either the parameter list for a
+                // member named 'partial' or a tuple return type following a 'partial' modifier.
+                _ => false,
+            };
 
         /// <summary>
         /// Checks for a type followed by a possible member name without advancing the parser.
@@ -3688,16 +3694,20 @@ parse_member_name:;
             return type;
         }
 
+        /// <summary>
+        /// Leaves <c>partial</c> for member-name parsing when the following token proves it is the
+        /// member name. The missing return type lets the member parser retain the intended shape.
+        /// </summary>
         private TypeSyntax ParseReturnTypeOrMissingTypeForPartialMemberName()
         {
-            if (this.CurrentToken.ContextualKind != SyntaxKind.PartialKeyword ||
-                !IsDefinitePartialMemberNameContinuation(this.PeekToken(1).Kind))
+            if (this.CurrentToken.ContextualKind == SyntaxKind.PartialKeyword &&
+                IsDefinitePartialMemberNameContinuation(this.PeekToken(1).Kind))
             {
-                return ParseReturnType();
+                return _syntaxFactory.PredefinedType(
+                    this.AddError(SyntaxFactory.MissingToken(SyntaxKind.VoidKeyword), ErrorCode.ERR_MemberNeedsType));
             }
 
-            return _syntaxFactory.PredefinedType(
-                this.AddError(SyntaxFactory.MissingToken(SyntaxKind.VoidKeyword), ErrorCode.ERR_MemberNeedsType));
+            return ParseReturnType();
         }
 
         private bool IsEndOfReturnType()

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1639,6 +1639,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             if (this.IsUnambiguousAnonymousFunctionModifierListFollowedByOpenParen())
                 return false;
 
+            if (this.IsCurrentTokenDefinitelyPartialMemberName())
+                return false;
+
             using var _ = this.GetDisposableResetPoint(resetOnDispose: true);
 
             this.EatToken();
@@ -1648,12 +1651,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             if (this.CurrentToken.Kind == SyntaxKind.OpenParenToken)
                 return this.IsTypeFollowedByMemberName();
 
-            // If the next token does not prove that 'partial' is the member name, it is a modifier.
-            return !IsDefinitePartialMemberNameContinuation(this.CurrentToken.Kind);
+            return true;
         }
 
-        private static bool IsDefinitePartialMemberNameContinuation(SyntaxKind kind)
-            => kind switch
+        private bool IsCurrentTokenDefinitelyPartialMemberName()
+        {
+            if (this.CurrentToken.ContextualKind != SyntaxKind.PartialKeyword)
+                return false;
+
+            return this.PeekToken(1).Kind switch
             {
                 // A field name: partial, other;
                 SyntaxKind.CommaToken => true,
@@ -1677,6 +1683,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 // name because '(' may instead start a tuple return type following the modifier.
                 _ => false,
             };
+        }
 
         /// <summary>
         /// Checks for a type followed by a possible member name without advancing the parser.
@@ -3703,8 +3710,7 @@ parse_member_name:;
         /// </summary>
         private TypeSyntax ParseReturnTypeOrMissingTypeForPartialMemberName()
         {
-            if (this.CurrentToken.ContextualKind == SyntaxKind.PartialKeyword &&
-                IsDefinitePartialMemberNameContinuation(this.PeekToken(1).Kind))
+            if (this.IsCurrentTokenDefinitelyPartialMemberName())
             {
                 return _syntaxFactory.PredefinedType(
                     this.AddError(SyntaxFactory.MissingToken(SyntaxKind.VoidKeyword), ErrorCode.ERR_MemberNeedsType));

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/AccessorDeclarationParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/AccessorDeclarationParsingTests.cs
@@ -2659,7 +2659,13 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
     {
         const string source = "class C { int P { get; } partial unknown; }";
 
-        UsingDeclaration(source);
+        UsingDeclaration(source, options: null,
+            // (1,41): error CS1519: Invalid token ';' in a member declaration
+            // class C { int P { get; } partial unknown; }
+            Diagnostic(ErrorCode.ERR_InvalidMemberDecl, ";").WithArguments(";").WithLocation(1, 41),
+            // (1,41): error CS1519: Invalid token ';' in a member declaration
+            // class C { int P { get; } partial unknown; }
+            Diagnostic(ErrorCode.ERR_InvalidMemberDecl, ";").WithArguments(";").WithLocation(1, 41));
         N(SyntaxKind.ClassDeclaration);
         {
             N(SyntaxKind.ClassKeyword);
@@ -2683,20 +2689,13 @@ public sealed class AccessorDeclarationParsingTests(ITestOutputHelper output) : 
                     N(SyntaxKind.CloseBraceToken);
                 }
             }
-            N(SyntaxKind.FieldDeclaration);
+            N(SyntaxKind.IncompleteMember);
             {
-                N(SyntaxKind.VariableDeclaration);
+                N(SyntaxKind.PartialKeyword);
+                N(SyntaxKind.IdentifierName);
                 {
-                    N(SyntaxKind.IdentifierName);
-                    {
-                        N(SyntaxKind.IdentifierToken, "partial");
-                    }
-                    N(SyntaxKind.VariableDeclarator);
-                    {
-                        N(SyntaxKind.IdentifierToken, "unknown");
-                    }
+                    N(SyntaxKind.IdentifierToken, "unknown");
                 }
-                N(SyntaxKind.SemicolonToken);
             }
             N(SyntaxKind.CloseBraceToken);
         }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/AsyncParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/AsyncParsingTests.cs
@@ -1891,9 +1891,6 @@ class C
 {
     async partial int operator
 ",
-                // (4,19): error CS1519: Invalid token 'int' in class, record, struct, or interface member declaration
-                //     async partial int operator
-                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "int").WithArguments("int").WithLocation(4, 19),
                 // (5,1): error CS1037: Overloadable operator expected
                 // 
                 Diagnostic(ErrorCode.ERR_OvlOperatorExpected, "").WithLocation(5, 1),
@@ -1916,16 +1913,10 @@ class C
                     N(SyntaxKind.ClassKeyword);
                     N(SyntaxKind.IdentifierToken, "C");
                     N(SyntaxKind.OpenBraceToken);
-                    N(SyntaxKind.IncompleteMember);
-                    {
-                        N(SyntaxKind.AsyncKeyword);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken, "partial");
-                        }
-                    }
                     N(SyntaxKind.OperatorDeclaration);
                     {
+                        N(SyntaxKind.AsyncKeyword);
+                        N(SyntaxKind.PartialKeyword);
                         N(SyntaxKind.PredefinedType);
                         {
                             N(SyntaxKind.IntKeyword);

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationParsingTests.cs
@@ -13373,18 +13373,15 @@ I1(x);";
                 // (1,10): error CS1001: Identifier expected
                 // class C<[] partial class D { }
                 Diagnostic(ErrorCode.ERR_IdentifierExpected, "]").WithLocation(1, 10),
-                // (1,12): error CS1001: Identifier expected
+                // (1,20): error CS1003: Syntax error, '>' expected
                 // class C<[] partial class D { }
-                Diagnostic(ErrorCode.ERR_IdentifierExpected, "partial").WithLocation(1, 12),
-                // (1,12): error CS1003: Syntax error, '>' expected
+                Diagnostic(ErrorCode.ERR_SyntaxError, "class").WithArguments(">").WithLocation(1, 20),
+                // (1,20): error CS1514: { expected
                 // class C<[] partial class D { }
-                Diagnostic(ErrorCode.ERR_SyntaxError, "partial").WithArguments(">").WithLocation(1, 12),
-                // (1,12): error CS1514: { expected
+                Diagnostic(ErrorCode.ERR_LbraceExpected, "class").WithLocation(1, 20),
+                // (1,20): error CS1513: } expected
                 // class C<[] partial class D { }
-                Diagnostic(ErrorCode.ERR_LbraceExpected, "partial").WithLocation(1, 12),
-                // (1,12): error CS1513: } expected
-                // class C<[] partial class D { }
-                Diagnostic(ErrorCode.ERR_RbraceExpected, "partial").WithLocation(1, 12));
+                Diagnostic(ErrorCode.ERR_RbraceExpected, "class").WithLocation(1, 20));
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -13409,7 +13406,7 @@ I1(x);";
                                 }
                                 N(SyntaxKind.CloseBracketToken);
                             }
-                            M(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "partial");
                         }
                         M(SyntaxKind.GreaterThanToken);
                     }
@@ -13418,7 +13415,6 @@ I1(x);";
                 }
                 N(SyntaxKind.ClassDeclaration);
                 {
-                    N(SyntaxKind.PartialKeyword);
                     N(SyntaxKind.ClassKeyword);
                     N(SyntaxKind.IdentifierToken, "D");
                     N(SyntaxKind.OpenBraceToken);

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/MemberDeclarationParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/MemberDeclarationParsingTests.cs
@@ -13749,25 +13749,14 @@ public class Class
         {
             foreach (var options in new[] { TestOptions.RegularPreview, TestOptions.Regular14, TestOptions.Regular13 })
             {
-                UsingDeclaration("partial C operator " + op + "(C x) => x;", options,
-                    // (1,11): error CS1003: Syntax error, '.' expected
-                    // partial C operator %=(C x) => x;
-                    Diagnostic(ErrorCode.ERR_SyntaxError, "operator").WithArguments(".").WithLocation(1, 11)
-                    );
+                UsingDeclaration("partial C operator " + op + "(C x) => x;", options);
 
                 N(SyntaxKind.OperatorDeclaration);
                 {
+                    N(SyntaxKind.PartialKeyword);
                     N(SyntaxKind.IdentifierName);
                     {
-                        N(SyntaxKind.IdentifierToken, "partial");
-                    }
-                    N(SyntaxKind.ExplicitInterfaceSpecifier);
-                    {
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken, "C");
-                        }
-                        M(SyntaxKind.DotToken);
+                        N(SyntaxKind.IdentifierToken, "C");
                     }
                     N(SyntaxKind.OperatorKeyword);
                     N(opToken);
@@ -13799,25 +13788,49 @@ public class Class
         }
 
         [Theory]
-        [CombinatorialData]
-        public void CompoundAssignmentDeclaration_20_Partial([CombinatorialValues("+=", "-=", "*=", "/=", "%=", "&=", "|=", "^=", "<<=", ">>=", ">>>=")] string op)
+        [InlineData("+=", SyntaxKind.PlusEqualsToken)]
+        [InlineData("-=", SyntaxKind.MinusEqualsToken)]
+        [InlineData("*=", SyntaxKind.AsteriskEqualsToken)]
+        [InlineData("/=", SyntaxKind.SlashEqualsToken)]
+        [InlineData("%=", SyntaxKind.PercentEqualsToken)]
+        [InlineData("&=", SyntaxKind.AmpersandEqualsToken)]
+        [InlineData("|=", SyntaxKind.BarEqualsToken)]
+        [InlineData("^=", SyntaxKind.CaretEqualsToken)]
+        [InlineData("<<=", SyntaxKind.LessThanLessThanEqualsToken)]
+        [InlineData(">>=", SyntaxKind.GreaterThanGreaterThanEqualsToken)]
+        [InlineData(">>>=", SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken)]
+        public void CompoundAssignmentDeclaration_20_Partial(string op, SyntaxKind opToken)
         {
             foreach (var options in new[] { TestOptions.RegularPreview, TestOptions.Regular14, TestOptions.Regular13 })
             {
-                UsingDeclaration("partial void operator " + op + "(C x) {}", options,
-                    // (1,1): error CS1073: Unexpected token 'void'
-                    // partial void operator +=(C x) {}
-                    Diagnostic(ErrorCode.ERR_UnexpectedToken, "partial").WithArguments("void").WithLocation(1, 1),
-                    // (1,9): error CS1519: Invalid token 'void' in a member declaration
-                    // partial void operator +=(C x) {}
-                    Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "void").WithArguments("void").WithLocation(1, 9)
-                    );
+                UsingDeclaration("partial void operator " + op + "(C x) {}", options);
 
-                N(SyntaxKind.IncompleteMember);
+                N(SyntaxKind.OperatorDeclaration);
                 {
-                    N(SyntaxKind.IdentifierName);
+                    N(SyntaxKind.PartialKeyword);
+                    N(SyntaxKind.PredefinedType);
                     {
-                        N(SyntaxKind.IdentifierToken, "partial");
+                        N(SyntaxKind.VoidKeyword);
+                    }
+                    N(SyntaxKind.OperatorKeyword);
+                    N(opToken);
+                    N(SyntaxKind.ParameterList);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.Parameter);
+                        {
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "C");
+                            }
+                            N(SyntaxKind.IdentifierToken, "x");
+                        }
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                    N(SyntaxKind.Block);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.CloseBraceToken);
                     }
                 }
                 EOF();
@@ -13831,25 +13844,14 @@ public class Class
         {
             foreach (var options in new[] { TestOptions.RegularPreview, TestOptions.Regular14, TestOptions.Regular13 })
             {
-                UsingDeclaration("partial C operator " + op + "() => x;", options,
-                    // (1,11): error CS1003: Syntax error, '.' expected
-                    // partial C operator ++() => x;
-                    Diagnostic(ErrorCode.ERR_SyntaxError, "operator").WithArguments(".").WithLocation(1, 11)
-                    );
+                UsingDeclaration("partial C operator " + op + "() => x;", options);
 
                 N(SyntaxKind.OperatorDeclaration);
                 {
+                    N(SyntaxKind.PartialKeyword);
                     N(SyntaxKind.IdentifierName);
                     {
-                        N(SyntaxKind.IdentifierToken, "partial");
-                    }
-                    N(SyntaxKind.ExplicitInterfaceSpecifier);
-                    {
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken, "C");
-                        }
-                        M(SyntaxKind.DotToken);
+                        N(SyntaxKind.IdentifierToken, "C");
                     }
                     N(SyntaxKind.OperatorKeyword);
                     N(opToken);
@@ -13873,25 +13875,32 @@ public class Class
         }
 
         [Theory]
-        [CombinatorialData]
-        public void IncrementDeclaration_02_Partial([CombinatorialValues("++", "--")] string op)
+        [InlineData("++", SyntaxKind.PlusPlusToken)]
+        [InlineData("--", SyntaxKind.MinusMinusToken)]
+        public void IncrementDeclaration_02_Partial(string op, SyntaxKind opToken)
         {
             foreach (var options in new[] { TestOptions.RegularPreview, TestOptions.Regular14, TestOptions.Regular13 })
             {
-                UsingDeclaration("partial void operator " + op + "() {}", options,
-                    // (1,1): error CS1073: Unexpected token 'void'
-                    // partial void operator ++() {}
-                    Diagnostic(ErrorCode.ERR_UnexpectedToken, "partial").WithArguments("void").WithLocation(1, 1),
-                    // (1,9): error CS1519: Invalid token 'void' in a member declaration
-                    // partial void operator ++() {}
-                    Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "void").WithArguments("void").WithLocation(1, 9)
-                    );
+                UsingDeclaration("partial void operator " + op + "() {}", options);
 
-                N(SyntaxKind.IncompleteMember);
+                N(SyntaxKind.OperatorDeclaration);
                 {
-                    N(SyntaxKind.IdentifierName);
+                    N(SyntaxKind.PartialKeyword);
+                    N(SyntaxKind.PredefinedType);
                     {
-                        N(SyntaxKind.IdentifierToken, "partial");
+                        N(SyntaxKind.VoidKeyword);
+                    }
+                    N(SyntaxKind.OperatorKeyword);
+                    N(opToken);
+                    N(SyntaxKind.ParameterList);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                    N(SyntaxKind.Block);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.CloseBraceToken);
                     }
                 }
                 EOF();

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ModifierParserRecoveryTests.Partial.AlwaysModifier.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ModifierParserRecoveryTests.Partial.AlwaysModifier.cs
@@ -1513,9 +1513,9 @@ public sealed partial class ModifierParserRecoveryTests
             Diagnostic(ErrorCode.ERR_MemberNeedsType, "partial").WithLocation(1, 1));
         N(SyntaxKind.MethodDeclaration);
         {
-            M(SyntaxKind.PredefinedType);
+            M(SyntaxKind.IdentifierName);
             {
-                M(SyntaxKind.VoidKeyword);
+                M(SyntaxKind.IdentifierToken);
             }
             N(SyntaxKind.IdentifierToken, "partial");
             N(SyntaxKind.TypeParameterList);
@@ -1570,9 +1570,9 @@ public sealed partial class ModifierParserRecoveryTests
             Diagnostic(ErrorCode.ERR_CloseParenExpected, ";").WithLocation(1, 15));
         N(SyntaxKind.MethodDeclaration);
         {
-            M(SyntaxKind.PredefinedType);
+            M(SyntaxKind.IdentifierName);
             {
-                M(SyntaxKind.VoidKeyword);
+                M(SyntaxKind.IdentifierToken);
             }
             N(SyntaxKind.IdentifierToken, "partial");
             N(SyntaxKind.TypeParameterList);
@@ -1640,9 +1640,9 @@ public sealed partial class ModifierParserRecoveryTests
         {
             N(SyntaxKind.VariableDeclaration);
             {
-                M(SyntaxKind.PredefinedType);
+                M(SyntaxKind.IdentifierName);
                 {
-                    M(SyntaxKind.VoidKeyword);
+                    M(SyntaxKind.IdentifierToken);
                 }
                 N(SyntaxKind.VariableDeclarator);
                 {
@@ -1667,9 +1667,9 @@ public sealed partial class ModifierParserRecoveryTests
         {
             N(SyntaxKind.VariableDeclaration);
             {
-                M(SyntaxKind.PredefinedType);
+                M(SyntaxKind.IdentifierName);
                 {
-                    M(SyntaxKind.VoidKeyword);
+                    M(SyntaxKind.IdentifierToken);
                 }
                 N(SyntaxKind.VariableDeclarator);
                 {
@@ -1700,9 +1700,9 @@ public sealed partial class ModifierParserRecoveryTests
             Diagnostic(ErrorCode.ERR_MemberNeedsType, "partial").WithLocation(1, 1));
         N(SyntaxKind.PropertyDeclaration);
         {
-            M(SyntaxKind.PredefinedType);
+            M(SyntaxKind.IdentifierName);
             {
-                M(SyntaxKind.VoidKeyword);
+                M(SyntaxKind.IdentifierToken);
             }
             N(SyntaxKind.IdentifierToken, "partial");
             N(SyntaxKind.ArrowExpressionClause);
@@ -1729,9 +1729,9 @@ public sealed partial class ModifierParserRecoveryTests
             Diagnostic(ErrorCode.ERR_MemberNeedsType, "partial").WithLocation(1, 1));
         N(SyntaxKind.PropertyDeclaration);
         {
-            M(SyntaxKind.PredefinedType);
+            M(SyntaxKind.IdentifierName);
             {
-                M(SyntaxKind.VoidKeyword);
+                M(SyntaxKind.IdentifierToken);
             }
             N(SyntaxKind.IdentifierToken, "partial");
             N(SyntaxKind.AccessorList);
@@ -1761,9 +1761,9 @@ public sealed partial class ModifierParserRecoveryTests
         {
             N(SyntaxKind.VariableDeclaration);
             {
-                M(SyntaxKind.PredefinedType);
+                M(SyntaxKind.IdentifierName);
                 {
-                    M(SyntaxKind.VoidKeyword);
+                    M(SyntaxKind.IdentifierToken);
                 }
                 N(SyntaxKind.VariableDeclarator);
                 {

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ModifierParserRecoveryTests.Partial.AlwaysModifier.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ModifierParserRecoveryTests.Partial.AlwaysModifier.cs
@@ -1,0 +1,1897 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests;
+
+public sealed partial class ModifierParserRecoveryTests
+{
+    [Fact]
+    public void PartialBeforeIntMethod()
+    {
+        UsingDeclaration("""partial int M();""");
+        N(SyntaxKind.MethodDeclaration);
+        {
+            N(SyntaxKind.PartialKeyword);
+            N(SyntaxKind.PredefinedType);
+            {
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "M");
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PublicPartialBeforeIntMethod()
+    {
+        UsingDeclaration("""public partial int M();""");
+        N(SyntaxKind.MethodDeclaration);
+        {
+            N(SyntaxKind.PublicKeyword);
+            N(SyntaxKind.PartialKeyword);
+            N(SyntaxKind.PredefinedType);
+            {
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "M");
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialPublicBeforeIntMethod()
+    {
+        UsingDeclaration("""partial public int M();""");
+        N(SyntaxKind.MethodDeclaration);
+        {
+            N(SyntaxKind.PartialKeyword);
+            N(SyntaxKind.PublicKeyword);
+            N(SyntaxKind.PredefinedType);
+            {
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "M");
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void AsyncPartialBeforeIntMethod()
+    {
+        UsingDeclaration("""async partial int M();""");
+        N(SyntaxKind.MethodDeclaration);
+        {
+            N(SyntaxKind.AsyncKeyword);
+            N(SyntaxKind.PartialKeyword);
+            N(SyntaxKind.PredefinedType);
+            {
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "M");
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialAsyncBeforeIntMethod()
+    {
+        UsingDeclaration("""partial async int M();""");
+        N(SyntaxKind.MethodDeclaration);
+        {
+            N(SyntaxKind.PartialKeyword);
+            N(SyntaxKind.AsyncKeyword);
+            N(SyntaxKind.PredefinedType);
+            {
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "M");
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PublicAsyncPartialBeforeIntMethod()
+    {
+        UsingDeclaration("""public async partial int M();""");
+        N(SyntaxKind.MethodDeclaration);
+        {
+            N(SyntaxKind.PublicKeyword);
+            N(SyntaxKind.AsyncKeyword);
+            N(SyntaxKind.PartialKeyword);
+            N(SyntaxKind.PredefinedType);
+            {
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "M");
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PublicPartialAsyncBeforeIntMethod()
+    {
+        UsingDeclaration("""public partial async int M();""");
+        N(SyntaxKind.MethodDeclaration);
+        {
+            N(SyntaxKind.PublicKeyword);
+            N(SyntaxKind.PartialKeyword);
+            N(SyntaxKind.AsyncKeyword);
+            N(SyntaxKind.PredefinedType);
+            {
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "M");
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void AsyncPublicPartialBeforeIntMethod()
+    {
+        UsingDeclaration("""async public partial int M();""");
+        N(SyntaxKind.MethodDeclaration);
+        {
+            N(SyntaxKind.AsyncKeyword);
+            N(SyntaxKind.PublicKeyword);
+            N(SyntaxKind.PartialKeyword);
+            N(SyntaxKind.PredefinedType);
+            {
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "M");
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void AsyncPartialPublicBeforeIntMethod()
+    {
+        UsingDeclaration("""async partial public int M();""");
+        N(SyntaxKind.MethodDeclaration);
+        {
+            N(SyntaxKind.AsyncKeyword);
+            N(SyntaxKind.PartialKeyword);
+            N(SyntaxKind.PublicKeyword);
+            N(SyntaxKind.PredefinedType);
+            {
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "M");
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialPublicAsyncBeforeIntMethod()
+    {
+        UsingDeclaration("""partial public async int M();""");
+        N(SyntaxKind.MethodDeclaration);
+        {
+            N(SyntaxKind.PartialKeyword);
+            N(SyntaxKind.PublicKeyword);
+            N(SyntaxKind.AsyncKeyword);
+            N(SyntaxKind.PredefinedType);
+            {
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "M");
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialAsyncPublicBeforeIntMethod()
+    {
+        UsingDeclaration("""partial async public int M();""");
+        N(SyntaxKind.MethodDeclaration);
+        {
+            N(SyntaxKind.PartialKeyword);
+            N(SyntaxKind.AsyncKeyword);
+            N(SyntaxKind.PublicKeyword);
+            N(SyntaxKind.PredefinedType);
+            {
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "M");
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialBeforeTupleReturningMethod()
+    {
+        UsingDeclaration("""partial (int x, int y) M();""");
+        N(SyntaxKind.MethodDeclaration);
+        {
+            N(SyntaxKind.PartialKeyword);
+            N(SyntaxKind.TupleType);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.TupleElement);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "x");
+                }
+                N(SyntaxKind.CommaToken);
+                N(SyntaxKind.TupleElement);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "y");
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.IdentifierToken, "M");
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PublicPartialBeforeTupleReturningMethod()
+    {
+        UsingDeclaration("""public partial (int x, int y) M();""");
+        N(SyntaxKind.MethodDeclaration);
+        {
+            N(SyntaxKind.PublicKeyword);
+            N(SyntaxKind.PartialKeyword);
+            N(SyntaxKind.TupleType);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.TupleElement);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "x");
+                }
+                N(SyntaxKind.CommaToken);
+                N(SyntaxKind.TupleElement);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "y");
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.IdentifierToken, "M");
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialPublicBeforeTupleReturningMethod()
+    {
+        UsingDeclaration("""partial public (int x, int y) M();""");
+        N(SyntaxKind.MethodDeclaration);
+        {
+            N(SyntaxKind.PartialKeyword);
+            N(SyntaxKind.PublicKeyword);
+            N(SyntaxKind.TupleType);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.TupleElement);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "x");
+                }
+                N(SyntaxKind.CommaToken);
+                N(SyntaxKind.TupleElement);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "y");
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.IdentifierToken, "M");
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void AsyncPartialBeforeTupleReturningMethod()
+    {
+        UsingDeclaration("""async partial (int x, int y) M();""");
+        N(SyntaxKind.MethodDeclaration);
+        {
+            N(SyntaxKind.AsyncKeyword);
+            N(SyntaxKind.PartialKeyword);
+            N(SyntaxKind.TupleType);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.TupleElement);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "x");
+                }
+                N(SyntaxKind.CommaToken);
+                N(SyntaxKind.TupleElement);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "y");
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.IdentifierToken, "M");
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialAsyncBeforeTupleReturningMethod()
+    {
+        UsingDeclaration("""partial async (int x, int y) M();""");
+        N(SyntaxKind.MethodDeclaration);
+        {
+            N(SyntaxKind.PartialKeyword);
+            N(SyntaxKind.AsyncKeyword);
+            N(SyntaxKind.TupleType);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.TupleElement);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "x");
+                }
+                N(SyntaxKind.CommaToken);
+                N(SyntaxKind.TupleElement);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "y");
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.IdentifierToken, "M");
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PublicAsyncPartialBeforeTupleReturningMethod()
+    {
+        UsingDeclaration("""public async partial (int x, int y) M();""");
+        N(SyntaxKind.MethodDeclaration);
+        {
+            N(SyntaxKind.PublicKeyword);
+            N(SyntaxKind.AsyncKeyword);
+            N(SyntaxKind.PartialKeyword);
+            N(SyntaxKind.TupleType);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.TupleElement);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "x");
+                }
+                N(SyntaxKind.CommaToken);
+                N(SyntaxKind.TupleElement);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "y");
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.IdentifierToken, "M");
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PublicPartialAsyncBeforeTupleReturningMethod()
+    {
+        UsingDeclaration("""public partial async (int x, int y) M();""");
+        N(SyntaxKind.MethodDeclaration);
+        {
+            N(SyntaxKind.PublicKeyword);
+            N(SyntaxKind.PartialKeyword);
+            N(SyntaxKind.AsyncKeyword);
+            N(SyntaxKind.TupleType);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.TupleElement);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "x");
+                }
+                N(SyntaxKind.CommaToken);
+                N(SyntaxKind.TupleElement);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "y");
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.IdentifierToken, "M");
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void AsyncPublicPartialBeforeTupleReturningMethod()
+    {
+        UsingDeclaration("""async public partial (int x, int y) M();""");
+        N(SyntaxKind.MethodDeclaration);
+        {
+            N(SyntaxKind.AsyncKeyword);
+            N(SyntaxKind.PublicKeyword);
+            N(SyntaxKind.PartialKeyword);
+            N(SyntaxKind.TupleType);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.TupleElement);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "x");
+                }
+                N(SyntaxKind.CommaToken);
+                N(SyntaxKind.TupleElement);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "y");
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.IdentifierToken, "M");
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void AsyncPartialPublicBeforeTupleReturningMethod()
+    {
+        UsingDeclaration("""async partial public (int x, int y) M();""");
+        N(SyntaxKind.MethodDeclaration);
+        {
+            N(SyntaxKind.AsyncKeyword);
+            N(SyntaxKind.PartialKeyword);
+            N(SyntaxKind.PublicKeyword);
+            N(SyntaxKind.TupleType);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.TupleElement);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "x");
+                }
+                N(SyntaxKind.CommaToken);
+                N(SyntaxKind.TupleElement);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "y");
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.IdentifierToken, "M");
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialPublicAsyncBeforeTupleReturningMethod()
+    {
+        UsingDeclaration("""partial public async (int x, int y) M();""");
+        N(SyntaxKind.MethodDeclaration);
+        {
+            N(SyntaxKind.PartialKeyword);
+            N(SyntaxKind.PublicKeyword);
+            N(SyntaxKind.AsyncKeyword);
+            N(SyntaxKind.TupleType);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.TupleElement);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "x");
+                }
+                N(SyntaxKind.CommaToken);
+                N(SyntaxKind.TupleElement);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "y");
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.IdentifierToken, "M");
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialAsyncPublicBeforeTupleReturningMethod()
+    {
+        UsingDeclaration("""partial async public (int x, int y) M();""");
+        N(SyntaxKind.MethodDeclaration);
+        {
+            N(SyntaxKind.PartialKeyword);
+            N(SyntaxKind.AsyncKeyword);
+            N(SyntaxKind.PublicKeyword);
+            N(SyntaxKind.TupleType);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.TupleElement);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "x");
+                }
+                N(SyntaxKind.CommaToken);
+                N(SyntaxKind.TupleElement);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "y");
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.IdentifierToken, "M");
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialBeforeNestedTupleReturningMethod()
+    {
+        UsingDeclaration("""partial ((int x, int y) left, int right) M();""");
+        N(SyntaxKind.MethodDeclaration);
+        {
+            N(SyntaxKind.PartialKeyword);
+            N(SyntaxKind.TupleType);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.TupleElement);
+                {
+                    N(SyntaxKind.TupleType);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.TupleElement);
+                        {
+                            N(SyntaxKind.PredefinedType);
+                            {
+                                N(SyntaxKind.IntKeyword);
+                            }
+                            N(SyntaxKind.IdentifierToken, "x");
+                        }
+                        N(SyntaxKind.CommaToken);
+                        N(SyntaxKind.TupleElement);
+                        {
+                            N(SyntaxKind.PredefinedType);
+                            {
+                                N(SyntaxKind.IntKeyword);
+                            }
+                            N(SyntaxKind.IdentifierToken, "y");
+                        }
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                    N(SyntaxKind.IdentifierToken, "left");
+                }
+                N(SyntaxKind.CommaToken);
+                N(SyntaxKind.TupleElement);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "right");
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.IdentifierToken, "M");
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialBeforeRefTupleReturningMethod()
+    {
+        UsingDeclaration("""partial ref (int x, int y) M();""");
+        N(SyntaxKind.MethodDeclaration);
+        {
+            N(SyntaxKind.PartialKeyword);
+            N(SyntaxKind.RefType);
+            {
+                N(SyntaxKind.RefKeyword);
+                N(SyntaxKind.TupleType);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.TupleElement);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.IntKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "x");
+                    }
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.TupleElement);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.IntKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "y");
+                    }
+                    N(SyntaxKind.CloseParenToken);
+                }
+            }
+            N(SyntaxKind.IdentifierToken, "M");
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialBeforeField()
+    {
+        UsingDeclaration("""partial int F;""");
+        N(SyntaxKind.FieldDeclaration);
+        {
+            N(SyntaxKind.PartialKeyword);
+            N(SyntaxKind.VariableDeclaration);
+            {
+                N(SyntaxKind.PredefinedType);
+                {
+                    N(SyntaxKind.IntKeyword);
+                }
+                N(SyntaxKind.VariableDeclarator);
+                {
+                    N(SyntaxKind.IdentifierToken, "F");
+                }
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialBeforeProperty()
+    {
+        UsingDeclaration("""partial int P { get; }""");
+        N(SyntaxKind.PropertyDeclaration);
+        {
+            N(SyntaxKind.PartialKeyword);
+            N(SyntaxKind.PredefinedType);
+            {
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "P");
+            N(SyntaxKind.AccessorList);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.GetAccessorDeclaration);
+                {
+                    N(SyntaxKind.GetKeyword);
+                    N(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialBeforeIndexer()
+    {
+        UsingDeclaration("""partial int this[int i] { get; }""");
+        N(SyntaxKind.IndexerDeclaration);
+        {
+            N(SyntaxKind.PartialKeyword);
+            N(SyntaxKind.PredefinedType);
+            {
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.ThisKeyword);
+            N(SyntaxKind.BracketedParameterList);
+            {
+                N(SyntaxKind.OpenBracketToken);
+                N(SyntaxKind.Parameter);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "i");
+                }
+                N(SyntaxKind.CloseBracketToken);
+            }
+            N(SyntaxKind.AccessorList);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.GetAccessorDeclaration);
+                {
+                    N(SyntaxKind.GetKeyword);
+                    N(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialBeforeOperator()
+    {
+        UsingDeclaration(
+            """partial int operator +(C value) => value;""",
+            null,
+            // (1,1): error CS1073: Unexpected token 'int'
+            // partial int operator +(C value) => value;
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "partial").WithArguments("int").WithLocation(1, 1),
+            // (1,9): error CS1519: Invalid token 'int' in a member declaration
+            // partial int operator +(C value) => value;
+            Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "int").WithArguments("int").WithLocation(1, 9));
+        N(SyntaxKind.IncompleteMember);
+        {
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "partial");
+            }
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialBeforeConversionOperator()
+    {
+        UsingDeclaration("""partial implicit operator int(C value) => 0;""");
+        N(SyntaxKind.ConversionOperatorDeclaration);
+        {
+            N(SyntaxKind.PartialKeyword);
+            N(SyntaxKind.ImplicitKeyword);
+            N(SyntaxKind.OperatorKeyword);
+            N(SyntaxKind.PredefinedType);
+            {
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.Parameter);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "C");
+                    }
+                    N(SyntaxKind.IdentifierToken, "value");
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.ArrowExpressionClause);
+            {
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.NumericLiteralExpression);
+                {
+                    N(SyntaxKind.NumericLiteralToken, "0");
+                }
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialBeforeDestructor()
+    {
+        UsingDeclaration(
+            """partial ~C() { }""",
+            null,
+            // (1,1): error CS1073: Unexpected token '~'
+            // partial ~C() { }
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "partial").WithArguments("~").WithLocation(1, 1),
+            // (1,9): error CS1519: Invalid token '~' in a member declaration
+            // partial ~C() { }
+            Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "~").WithArguments("~").WithLocation(1, 9));
+        N(SyntaxKind.IncompleteMember);
+        {
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "partial");
+            }
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialBeforeConstField()
+    {
+        UsingDeclaration(
+            """partial const int F = 0;""",
+            null,
+            // (1,1): error CS1073: Unexpected token 'const'
+            // partial const int F = 0;
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "partial").WithArguments("const").WithLocation(1, 1),
+            // (1,9): error CS1519: Invalid token 'const' in a member declaration
+            // partial const int F = 0;
+            Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "const").WithArguments("const").WithLocation(1, 9));
+        N(SyntaxKind.IncompleteMember);
+        {
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "partial");
+            }
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialBeforeEventField()
+    {
+        UsingDeclaration("""partial event System.Action E;""");
+        N(SyntaxKind.EventFieldDeclaration);
+        {
+            N(SyntaxKind.PartialKeyword);
+            N(SyntaxKind.EventKeyword);
+            N(SyntaxKind.VariableDeclaration);
+            {
+                N(SyntaxKind.QualifiedName);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "System");
+                    }
+                    N(SyntaxKind.DotToken);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "Action");
+                    }
+                }
+                N(SyntaxKind.VariableDeclarator);
+                {
+                    N(SyntaxKind.IdentifierToken, "E");
+                }
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialBeforeNestedClass()
+    {
+        UsingDeclaration("""partial class N { }""");
+        N(SyntaxKind.ClassDeclaration);
+        {
+            N(SyntaxKind.PartialKeyword);
+            N(SyntaxKind.ClassKeyword);
+            N(SyntaxKind.IdentifierToken, "N");
+            N(SyntaxKind.OpenBraceToken);
+            N(SyntaxKind.CloseBraceToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialBeforeDelegate()
+    {
+        UsingDeclaration("""partial delegate void D();""");
+        N(SyntaxKind.DelegateDeclaration);
+        {
+            N(SyntaxKind.PartialKeyword);
+            N(SyntaxKind.DelegateKeyword);
+            N(SyntaxKind.PredefinedType);
+            {
+                N(SyntaxKind.VoidKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "D");
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialModifierBeforeArrayTypeWithMissingElementType()
+    {
+        UsingDeclaration("""partial[] M();""");
+        N(SyntaxKind.MethodDeclaration);
+        {
+            N(SyntaxKind.ArrayType);
+            {
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "partial");
+                }
+                N(SyntaxKind.ArrayRankSpecifier);
+                {
+                    N(SyntaxKind.OpenBracketToken);
+                    N(SyntaxKind.OmittedArraySizeExpression);
+                    {
+                        N(SyntaxKind.OmittedArraySizeExpressionToken);
+                    }
+                    N(SyntaxKind.CloseBracketToken);
+                }
+            }
+            N(SyntaxKind.IdentifierToken, "M");
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialModifierBeforeJaggedArrayTypeWithMissingElementType()
+    {
+        UsingDeclaration("""partial[][] M();""");
+        N(SyntaxKind.MethodDeclaration);
+        {
+            N(SyntaxKind.ArrayType);
+            {
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "partial");
+                }
+                N(SyntaxKind.ArrayRankSpecifier);
+                {
+                    N(SyntaxKind.OpenBracketToken);
+                    N(SyntaxKind.OmittedArraySizeExpression);
+                    {
+                        N(SyntaxKind.OmittedArraySizeExpressionToken);
+                    }
+                    N(SyntaxKind.CloseBracketToken);
+                }
+                N(SyntaxKind.ArrayRankSpecifier);
+                {
+                    N(SyntaxKind.OpenBracketToken);
+                    N(SyntaxKind.OmittedArraySizeExpression);
+                    {
+                        N(SyntaxKind.OmittedArraySizeExpressionToken);
+                    }
+                    N(SyntaxKind.CloseBracketToken);
+                }
+            }
+            N(SyntaxKind.IdentifierToken, "M");
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialModifierBeforeNullableTypeWithMissingElementType()
+    {
+        UsingDeclaration("""partial? M();""");
+        N(SyntaxKind.MethodDeclaration);
+        {
+            N(SyntaxKind.NullableType);
+            {
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "partial");
+                }
+                N(SyntaxKind.QuestionToken);
+            }
+            N(SyntaxKind.IdentifierToken, "M");
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialModifierBeforePointerTypeWithMissingElementType()
+    {
+        UsingDeclaration("""partial* M();""");
+        N(SyntaxKind.MethodDeclaration);
+        {
+            N(SyntaxKind.PointerType);
+            {
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "partial");
+                }
+                N(SyntaxKind.AsteriskToken);
+            }
+            N(SyntaxKind.IdentifierToken, "M");
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialModifierBeforeDotProducesIncompleteMember()
+    {
+        UsingDeclaration("""partial.N M();""");
+        N(SyntaxKind.MethodDeclaration);
+        {
+            N(SyntaxKind.QualifiedName);
+            {
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "partial");
+                }
+                N(SyntaxKind.DotToken);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "N");
+                }
+            }
+            N(SyntaxKind.IdentifierToken, "M");
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialModifierBeforeAliasQualifiedTypeWithMissingAlias()
+    {
+        UsingDeclaration(
+            """partial::N M();""",
+            null,
+            // (1,8): error CS1001: Identifier expected
+            // partial::N M();
+            Diagnostic(ErrorCode.ERR_IdentifierExpected, "::").WithLocation(1, 8));
+        N(SyntaxKind.MethodDeclaration);
+        {
+            N(SyntaxKind.PartialKeyword);
+            N(SyntaxKind.AliasQualifiedName);
+            {
+                M(SyntaxKind.IdentifierName);
+                {
+                    M(SyntaxKind.IdentifierToken);
+                }
+                N(SyntaxKind.ColonColonToken);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "N");
+                }
+            }
+            N(SyntaxKind.IdentifierToken, "M");
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialModifierBeforeAsyncTypeProducesIncompleteMember()
+    {
+        UsingDeclaration("""partial async;""");
+        N(SyntaxKind.FieldDeclaration);
+        {
+            N(SyntaxKind.VariableDeclaration);
+            {
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "partial");
+                }
+                N(SyntaxKind.VariableDeclarator);
+                {
+                    N(SyntaxKind.IdentifierToken, "async");
+                }
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialModifierBeforeRequiredModifierWithMissingTypeAndName()
+    {
+        UsingDeclaration("""partial required => value;""");
+        N(SyntaxKind.PropertyDeclaration);
+        {
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "partial");
+            }
+            N(SyntaxKind.IdentifierToken, "required");
+            N(SyntaxKind.ArrowExpressionClause);
+            {
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "value");
+                }
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialModifierBeforeFileModifierWithMissingTypeAndName()
+    {
+        UsingDeclaration("""partial file { get; }""");
+        N(SyntaxKind.PropertyDeclaration);
+        {
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "partial");
+            }
+            N(SyntaxKind.IdentifierToken, "file");
+            N(SyntaxKind.AccessorList);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.GetAccessorDeclaration);
+                {
+                    N(SyntaxKind.GetKeyword);
+                    N(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialModifierBeforeGenericTypeProducesIncompleteMember()
+    {
+        UsingDeclaration("""partial safe<T>() { }""");
+        N(SyntaxKind.MethodDeclaration);
+        {
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "partial");
+            }
+            N(SyntaxKind.IdentifierToken, "safe");
+            N(SyntaxKind.TypeParameterList);
+            {
+                N(SyntaxKind.LessThanToken);
+                N(SyntaxKind.TypeParameter);
+                {
+                    N(SyntaxKind.IdentifierToken, "T");
+                }
+                N(SyntaxKind.GreaterThanToken);
+            }
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.Block);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.CloseBraceToken);
+            }
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialConstructorWithoutParameters()
+    {
+        UsingDeclaration("""partial() { }""");
+        N(SyntaxKind.ConstructorDeclaration);
+        {
+            N(SyntaxKind.IdentifierToken, "partial");
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.Block);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.CloseBraceToken);
+            }
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialConstructorWithParameters()
+    {
+        UsingDeclaration("""partial(int x, int y) { }""");
+        N(SyntaxKind.ConstructorDeclaration);
+        {
+            N(SyntaxKind.IdentifierToken, "partial");
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.Parameter);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "x");
+                }
+                N(SyntaxKind.CommaToken);
+                N(SyntaxKind.Parameter);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "y");
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.Block);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.CloseBraceToken);
+            }
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialGenericMethodWithoutReturnType()
+    {
+        UsingDeclaration(
+            """partial<T>() { }""",
+            null,
+            // (1,1): error CS1073: Unexpected token '('
+            // partial<T>() { }
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "partial<T>").WithArguments("(").WithLocation(1, 1),
+            // (1,11): error CS1519: Invalid token '(' in a member declaration
+            // partial<T>() { }
+            Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "(").WithArguments("(").WithLocation(1, 11));
+        N(SyntaxKind.IncompleteMember);
+        {
+            N(SyntaxKind.GenericName);
+            {
+                N(SyntaxKind.IdentifierToken, "partial");
+                N(SyntaxKind.TypeArgumentList);
+                {
+                    N(SyntaxKind.LessThanToken);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "T");
+                    }
+                    N(SyntaxKind.GreaterThanToken);
+                }
+            }
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialGenericMethodNameFollowedByMalformedParameter()
+    {
+        UsingDeclaration("""partial<T> M();""");
+        N(SyntaxKind.MethodDeclaration);
+        {
+            N(SyntaxKind.GenericName);
+            {
+                N(SyntaxKind.IdentifierToken, "partial");
+                N(SyntaxKind.TypeArgumentList);
+                {
+                    N(SyntaxKind.LessThanToken);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "T");
+                    }
+                    N(SyntaxKind.GreaterThanToken);
+                }
+            }
+            N(SyntaxKind.IdentifierToken, "M");
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialFieldName()
+    {
+        UsingDeclaration(
+            """partial;""",
+            null,
+            // (1,1): error CS1073: Unexpected token ';'
+            // partial;
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "partial").WithArguments(";").WithLocation(1, 1),
+            // (1,8): error CS1519: Invalid token ';' in a member declaration
+            // partial;
+            Diagnostic(ErrorCode.ERR_InvalidMemberDecl, ";").WithArguments(";").WithLocation(1, 8));
+        N(SyntaxKind.IncompleteMember);
+        {
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "partial");
+            }
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialInitializedFieldName()
+    {
+        UsingDeclaration(
+            """partial = null;""",
+            null,
+            // (1,1): error CS1073: Unexpected token '='
+            // partial = null;
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "partial").WithArguments("=").WithLocation(1, 1),
+            // (1,9): error CS1519: Invalid token '=' in a member declaration
+            // partial = null;
+            Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "=").WithArguments("=").WithLocation(1, 9));
+        N(SyntaxKind.IncompleteMember);
+        {
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "partial");
+            }
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialExpressionBodiedPropertyName()
+    {
+        UsingDeclaration(
+            """partial => null;""",
+            null,
+            // (1,1): error CS1073: Unexpected token '=>'
+            // partial => null;
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "partial").WithArguments("=>").WithLocation(1, 1),
+            // (1,9): error CS1519: Invalid token '=>' in a member declaration
+            // partial => null;
+            Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "=>").WithArguments("=>").WithLocation(1, 9));
+        N(SyntaxKind.IncompleteMember);
+        {
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "partial");
+            }
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialPropertyName()
+    {
+        UsingDeclaration(
+            """partial { get; }""",
+            null,
+            // (1,1): error CS1073: Unexpected token '{'
+            // partial { get; }
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "partial").WithArguments("{").WithLocation(1, 1),
+            // (1,9): error CS1519: Invalid token '{' in a member declaration
+            // partial { get; }
+            Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "{").WithArguments("{").WithLocation(1, 9));
+        N(SyntaxKind.IncompleteMember);
+        {
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "partial");
+            }
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialFirstVariableName()
+    {
+        UsingDeclaration(
+            """partial, other;""",
+            null,
+            // (1,1): error CS1073: Unexpected token ','
+            // partial, other;
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "partial").WithArguments(",").WithLocation(1, 1),
+            // (1,8): error CS1519: Invalid token ',' in a member declaration
+            // partial, other;
+            Diagnostic(ErrorCode.ERR_InvalidMemberDecl, ",").WithArguments(",").WithLocation(1, 8));
+        N(SyntaxKind.IncompleteMember);
+        {
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "partial");
+            }
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialMethodName()
+    {
+        UsingDeclaration("""int partial();""");
+        N(SyntaxKind.MethodDeclaration);
+        {
+            N(SyntaxKind.PredefinedType);
+            {
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "partial");
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialGenericMethodName()
+    {
+        UsingDeclaration("""int partial<T>();""");
+        N(SyntaxKind.MethodDeclaration);
+        {
+            N(SyntaxKind.PredefinedType);
+            {
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "partial");
+            N(SyntaxKind.TypeParameterList);
+            {
+                N(SyntaxKind.LessThanToken);
+                N(SyntaxKind.TypeParameter);
+                {
+                    N(SyntaxKind.IdentifierToken, "T");
+                }
+                N(SyntaxKind.GreaterThanToken);
+            }
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialVariableName()
+    {
+        UsingDeclaration("""int partial;""");
+        N(SyntaxKind.FieldDeclaration);
+        {
+            N(SyntaxKind.VariableDeclaration);
+            {
+                N(SyntaxKind.PredefinedType);
+                {
+                    N(SyntaxKind.IntKeyword);
+                }
+                N(SyntaxKind.VariableDeclarator);
+                {
+                    N(SyntaxKind.IdentifierToken, "partial");
+                }
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialInitializedVariableName()
+    {
+        UsingDeclaration("""int partial = 0;""");
+        N(SyntaxKind.FieldDeclaration);
+        {
+            N(SyntaxKind.VariableDeclaration);
+            {
+                N(SyntaxKind.PredefinedType);
+                {
+                    N(SyntaxKind.IntKeyword);
+                }
+                N(SyntaxKind.VariableDeclarator);
+                {
+                    N(SyntaxKind.IdentifierToken, "partial");
+                    N(SyntaxKind.EqualsValueClause);
+                    {
+                        N(SyntaxKind.EqualsToken);
+                        N(SyntaxKind.NumericLiteralExpression);
+                        {
+                            N(SyntaxKind.NumericLiteralToken, "0");
+                        }
+                    }
+                }
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialExpressionBodiedPropertyAfterType()
+    {
+        UsingDeclaration("""int partial => 0;""");
+        N(SyntaxKind.PropertyDeclaration);
+        {
+            N(SyntaxKind.PredefinedType);
+            {
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "partial");
+            N(SyntaxKind.ArrowExpressionClause);
+            {
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.NumericLiteralExpression);
+                {
+                    N(SyntaxKind.NumericLiteralToken, "0");
+                }
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialPropertyAfterType()
+    {
+        UsingDeclaration("""int partial { get; }""");
+        N(SyntaxKind.PropertyDeclaration);
+        {
+            N(SyntaxKind.PredefinedType);
+            {
+                N(SyntaxKind.IntKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "partial");
+            N(SyntaxKind.AccessorList);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.GetAccessorDeclaration);
+                {
+                    N(SyntaxKind.GetKeyword);
+                    N(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialAsGenericTypeArgument()
+    {
+        UsingDeclaration("""G<partial> M();""");
+        N(SyntaxKind.MethodDeclaration);
+        {
+            N(SyntaxKind.GenericName);
+            {
+                N(SyntaxKind.IdentifierToken, "G");
+                N(SyntaxKind.TypeArgumentList);
+                {
+                    N(SyntaxKind.LessThanToken);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "partial");
+                    }
+                    N(SyntaxKind.GreaterThanToken);
+                }
+            }
+            N(SyntaxKind.IdentifierToken, "M");
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialAsTupleElementType()
+    {
+        UsingDeclaration("""(partial value, int count) M();""");
+        N(SyntaxKind.MethodDeclaration);
+        {
+            N(SyntaxKind.TupleType);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.TupleElement);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "partial");
+                    }
+                    N(SyntaxKind.IdentifierToken, "value");
+                }
+                N(SyntaxKind.CommaToken);
+                N(SyntaxKind.TupleElement);
+                {
+                    N(SyntaxKind.PredefinedType);
+                    {
+                        N(SyntaxKind.IntKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "count");
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.IdentifierToken, "M");
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialAsFunctionPointerParameterType()
+    {
+        UsingDeclaration("""delegate*<partial, void> M();""");
+        N(SyntaxKind.MethodDeclaration);
+        {
+            N(SyntaxKind.FunctionPointerType);
+            {
+                N(SyntaxKind.DelegateKeyword);
+                N(SyntaxKind.AsteriskToken);
+                N(SyntaxKind.FunctionPointerParameterList);
+                {
+                    N(SyntaxKind.LessThanToken);
+                    N(SyntaxKind.FunctionPointerParameter);
+                    {
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "partial");
+                        }
+                    }
+                    N(SyntaxKind.CommaToken);
+                    N(SyntaxKind.FunctionPointerParameter);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.VoidKeyword);
+                        }
+                    }
+                    N(SyntaxKind.GreaterThanToken);
+                }
+            }
+            N(SyntaxKind.IdentifierToken, "M");
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialAsRefReturnElementType()
+    {
+        UsingDeclaration("""ref partial M();""");
+        N(SyntaxKind.ConstructorDeclaration);
+        {
+            N(SyntaxKind.RefKeyword);
+            N(SyntaxKind.PartialKeyword);
+            N(SyntaxKind.IdentifierToken, "M");
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+}

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ModifierParserRecoveryTests.Partial.AlwaysModifier.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ModifierParserRecoveryTests.Partial.AlwaysModifier.cs
@@ -916,21 +916,38 @@ public sealed partial class ModifierParserRecoveryTests
     [Fact]
     public void PartialBeforeOperator()
     {
-        UsingDeclaration(
-            """partial int operator +(C value) => value;""",
-            null,
-            // (1,1): error CS1073: Unexpected token 'int'
-            // partial int operator +(C value) => value;
-            Diagnostic(ErrorCode.ERR_UnexpectedToken, "partial").WithArguments("int").WithLocation(1, 1),
-            // (1,9): error CS1519: Invalid token 'int' in a member declaration
-            // partial int operator +(C value) => value;
-            Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "int").WithArguments("int").WithLocation(1, 9));
-        N(SyntaxKind.IncompleteMember);
+        UsingDeclaration("""partial int operator +(C value) => value;""");
+        N(SyntaxKind.OperatorDeclaration);
         {
-            N(SyntaxKind.IdentifierName);
+            N(SyntaxKind.PartialKeyword);
+            N(SyntaxKind.PredefinedType);
             {
-                N(SyntaxKind.IdentifierToken, "partial");
+                N(SyntaxKind.IntKeyword);
             }
+            N(SyntaxKind.OperatorKeyword);
+            N(SyntaxKind.PlusToken);
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.Parameter);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "C");
+                    }
+                    N(SyntaxKind.IdentifierToken, "value");
+                }
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.ArrowExpressionClause);
+            {
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "value");
+                }
+            }
+            N(SyntaxKind.SemicolonToken);
         }
         EOF();
     }
@@ -977,20 +994,21 @@ public sealed partial class ModifierParserRecoveryTests
     [Fact]
     public void PartialBeforeDestructor()
     {
-        UsingDeclaration(
-            """partial ~C() { }""",
-            null,
-            // (1,1): error CS1073: Unexpected token '~'
-            // partial ~C() { }
-            Diagnostic(ErrorCode.ERR_UnexpectedToken, "partial").WithArguments("~").WithLocation(1, 1),
-            // (1,9): error CS1519: Invalid token '~' in a member declaration
-            // partial ~C() { }
-            Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "~").WithArguments("~").WithLocation(1, 9));
-        N(SyntaxKind.IncompleteMember);
+        UsingDeclaration("""partial ~C() { }""");
+        N(SyntaxKind.DestructorDeclaration);
         {
-            N(SyntaxKind.IdentifierName);
+            N(SyntaxKind.PartialKeyword);
+            N(SyntaxKind.TildeToken);
+            N(SyntaxKind.IdentifierToken, "C");
+            N(SyntaxKind.ParameterList);
             {
-                N(SyntaxKind.IdentifierToken, "partial");
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.Block);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.CloseBraceToken);
             }
         }
         EOF();
@@ -999,21 +1017,31 @@ public sealed partial class ModifierParserRecoveryTests
     [Fact]
     public void PartialBeforeConstField()
     {
-        UsingDeclaration(
-            """partial const int F = 0;""",
-            null,
-            // (1,1): error CS1073: Unexpected token 'const'
-            // partial const int F = 0;
-            Diagnostic(ErrorCode.ERR_UnexpectedToken, "partial").WithArguments("const").WithLocation(1, 1),
-            // (1,9): error CS1519: Invalid token 'const' in a member declaration
-            // partial const int F = 0;
-            Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "const").WithArguments("const").WithLocation(1, 9));
-        N(SyntaxKind.IncompleteMember);
+        UsingDeclaration("""partial const int F = 0;""");
+        N(SyntaxKind.FieldDeclaration);
         {
-            N(SyntaxKind.IdentifierName);
+            N(SyntaxKind.PartialKeyword);
+            N(SyntaxKind.ConstKeyword);
+            N(SyntaxKind.VariableDeclaration);
             {
-                N(SyntaxKind.IdentifierToken, "partial");
+                N(SyntaxKind.PredefinedType);
+                {
+                    N(SyntaxKind.IntKeyword);
+                }
+                N(SyntaxKind.VariableDeclarator);
+                {
+                    N(SyntaxKind.IdentifierToken, "F");
+                    N(SyntaxKind.EqualsValueClause);
+                    {
+                        N(SyntaxKind.EqualsToken);
+                        N(SyntaxKind.NumericLiteralExpression);
+                        {
+                            N(SyntaxKind.NumericLiteralToken, "0");
+                        }
+                    }
+                }
             }
+            N(SyntaxKind.SemicolonToken);
         }
         EOF();
     }
@@ -1091,14 +1119,20 @@ public sealed partial class ModifierParserRecoveryTests
     [Fact]
     public void PartialModifierBeforeArrayTypeWithMissingElementType()
     {
-        UsingDeclaration("""partial[] M();""");
+        UsingDeclaration(
+            """partial[] M();""",
+            null,
+            // (1,8): error CS1031: Type expected
+            // partial[] M();
+            Diagnostic(ErrorCode.ERR_TypeExpected, "[").WithLocation(1, 8));
         N(SyntaxKind.MethodDeclaration);
         {
+            N(SyntaxKind.PartialKeyword);
             N(SyntaxKind.ArrayType);
             {
-                N(SyntaxKind.IdentifierName);
+                M(SyntaxKind.IdentifierName);
                 {
-                    N(SyntaxKind.IdentifierToken, "partial");
+                    M(SyntaxKind.IdentifierToken);
                 }
                 N(SyntaxKind.ArrayRankSpecifier);
                 {
@@ -1124,14 +1158,20 @@ public sealed partial class ModifierParserRecoveryTests
     [Fact]
     public void PartialModifierBeforeJaggedArrayTypeWithMissingElementType()
     {
-        UsingDeclaration("""partial[][] M();""");
+        UsingDeclaration(
+            """partial[][] M();""",
+            null,
+            // (1,8): error CS1031: Type expected
+            // partial[][] M();
+            Diagnostic(ErrorCode.ERR_TypeExpected, "[").WithLocation(1, 8));
         N(SyntaxKind.MethodDeclaration);
         {
+            N(SyntaxKind.PartialKeyword);
             N(SyntaxKind.ArrayType);
             {
-                N(SyntaxKind.IdentifierName);
+                M(SyntaxKind.IdentifierName);
                 {
-                    N(SyntaxKind.IdentifierToken, "partial");
+                    M(SyntaxKind.IdentifierToken);
                 }
                 N(SyntaxKind.ArrayRankSpecifier);
                 {
@@ -1166,14 +1206,20 @@ public sealed partial class ModifierParserRecoveryTests
     [Fact]
     public void PartialModifierBeforeNullableTypeWithMissingElementType()
     {
-        UsingDeclaration("""partial? M();""");
+        UsingDeclaration(
+            """partial? M();""",
+            null,
+            // (1,8): error CS1031: Type expected
+            // partial? M();
+            Diagnostic(ErrorCode.ERR_TypeExpected, "?").WithLocation(1, 8));
         N(SyntaxKind.MethodDeclaration);
         {
+            N(SyntaxKind.PartialKeyword);
             N(SyntaxKind.NullableType);
             {
-                N(SyntaxKind.IdentifierName);
+                M(SyntaxKind.IdentifierName);
                 {
-                    N(SyntaxKind.IdentifierToken, "partial");
+                    M(SyntaxKind.IdentifierToken);
                 }
                 N(SyntaxKind.QuestionToken);
             }
@@ -1191,14 +1237,20 @@ public sealed partial class ModifierParserRecoveryTests
     [Fact]
     public void PartialModifierBeforePointerTypeWithMissingElementType()
     {
-        UsingDeclaration("""partial* M();""");
+        UsingDeclaration(
+            """partial* M();""",
+            null,
+            // (1,8): error CS1031: Type expected
+            // partial* M();
+            Diagnostic(ErrorCode.ERR_TypeExpected, "*").WithLocation(1, 8));
         N(SyntaxKind.MethodDeclaration);
         {
+            N(SyntaxKind.PartialKeyword);
             N(SyntaxKind.PointerType);
             {
-                N(SyntaxKind.IdentifierName);
+                M(SyntaxKind.IdentifierName);
                 {
-                    N(SyntaxKind.IdentifierToken, "partial");
+                    M(SyntaxKind.IdentifierToken);
                 }
                 N(SyntaxKind.AsteriskToken);
             }
@@ -1216,28 +1268,18 @@ public sealed partial class ModifierParserRecoveryTests
     [Fact]
     public void PartialModifierBeforeDotProducesIncompleteMember()
     {
-        UsingDeclaration("""partial.N M();""");
-        N(SyntaxKind.MethodDeclaration);
+        UsingDeclaration(
+            """partial.N M();""",
+            null,
+            // (1,1): error CS1073: Unexpected token '.'
+            // partial.N M();
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "partial").WithArguments(".").WithLocation(1, 1),
+            // (1,8): error CS1519: Invalid token '.' in a member declaration
+            // partial.N M();
+            Diagnostic(ErrorCode.ERR_InvalidMemberDecl, ".").WithArguments(".").WithLocation(1, 8));
+        N(SyntaxKind.IncompleteMember);
         {
-            N(SyntaxKind.QualifiedName);
-            {
-                N(SyntaxKind.IdentifierName);
-                {
-                    N(SyntaxKind.IdentifierToken, "partial");
-                }
-                N(SyntaxKind.DotToken);
-                N(SyntaxKind.IdentifierName);
-                {
-                    N(SyntaxKind.IdentifierToken, "N");
-                }
-            }
-            N(SyntaxKind.IdentifierToken, "M");
-            N(SyntaxKind.ParameterList);
-            {
-                N(SyntaxKind.OpenParenToken);
-                N(SyntaxKind.CloseParenToken);
-            }
-            N(SyntaxKind.SemicolonToken);
+            N(SyntaxKind.PartialKeyword);
         }
         EOF();
     }
@@ -1280,21 +1322,22 @@ public sealed partial class ModifierParserRecoveryTests
     [Fact]
     public void PartialModifierBeforeAsyncTypeProducesIncompleteMember()
     {
-        UsingDeclaration("""partial async;""");
-        N(SyntaxKind.FieldDeclaration);
+        UsingDeclaration(
+            """partial async;""",
+            null,
+            // (1,1): error CS1073: Unexpected token ';'
+            // partial async;
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "partial async").WithArguments(";").WithLocation(1, 1),
+            // (1,14): error CS1519: Invalid token ';' in a member declaration
+            // partial async;
+            Diagnostic(ErrorCode.ERR_InvalidMemberDecl, ";").WithArguments(";").WithLocation(1, 14));
+        N(SyntaxKind.IncompleteMember);
         {
-            N(SyntaxKind.VariableDeclaration);
+            N(SyntaxKind.PartialKeyword);
+            N(SyntaxKind.IdentifierName);
             {
-                N(SyntaxKind.IdentifierName);
-                {
-                    N(SyntaxKind.IdentifierToken, "partial");
-                }
-                N(SyntaxKind.VariableDeclarator);
-                {
-                    N(SyntaxKind.IdentifierToken, "async");
-                }
+                N(SyntaxKind.IdentifierToken, "async");
             }
-            N(SyntaxKind.SemicolonToken);
         }
         EOF();
     }
@@ -1302,14 +1345,24 @@ public sealed partial class ModifierParserRecoveryTests
     [Fact]
     public void PartialModifierBeforeRequiredModifierWithMissingTypeAndName()
     {
-        UsingDeclaration("""partial required => value;""");
+        UsingDeclaration(
+            """partial required => value;""",
+            null,
+            // (1,18): error CS1031: Type expected
+            // partial required => value;
+            Diagnostic(ErrorCode.ERR_TypeExpected, "=>").WithLocation(1, 18),
+            // (1,18): error CS1001: Identifier expected
+            // partial required => value;
+            Diagnostic(ErrorCode.ERR_IdentifierExpected, "=>").WithLocation(1, 18));
         N(SyntaxKind.PropertyDeclaration);
         {
-            N(SyntaxKind.IdentifierName);
+            N(SyntaxKind.PartialKeyword);
+            N(SyntaxKind.RequiredKeyword);
+            M(SyntaxKind.IdentifierName);
             {
-                N(SyntaxKind.IdentifierToken, "partial");
+                M(SyntaxKind.IdentifierToken);
             }
-            N(SyntaxKind.IdentifierToken, "required");
+            M(SyntaxKind.IdentifierToken);
             N(SyntaxKind.ArrowExpressionClause);
             {
                 N(SyntaxKind.EqualsGreaterThanToken);
@@ -1326,14 +1379,24 @@ public sealed partial class ModifierParserRecoveryTests
     [Fact]
     public void PartialModifierBeforeFileModifierWithMissingTypeAndName()
     {
-        UsingDeclaration("""partial file { get; }""");
+        UsingDeclaration(
+            """partial file { get; }""",
+            null,
+            // (1,14): error CS1031: Type expected
+            // partial file { get; }
+            Diagnostic(ErrorCode.ERR_TypeExpected, "{").WithLocation(1, 14),
+            // (1,14): error CS1001: Identifier expected
+            // partial file { get; }
+            Diagnostic(ErrorCode.ERR_IdentifierExpected, "{").WithLocation(1, 14));
         N(SyntaxKind.PropertyDeclaration);
         {
-            N(SyntaxKind.IdentifierName);
+            N(SyntaxKind.PartialKeyword);
+            N(SyntaxKind.FileKeyword);
+            M(SyntaxKind.IdentifierName);
             {
-                N(SyntaxKind.IdentifierToken, "partial");
+                M(SyntaxKind.IdentifierToken);
             }
-            N(SyntaxKind.IdentifierToken, "file");
+            M(SyntaxKind.IdentifierToken);
             N(SyntaxKind.AccessorList);
             {
                 N(SyntaxKind.OpenBraceToken);
@@ -1351,32 +1414,30 @@ public sealed partial class ModifierParserRecoveryTests
     [Fact]
     public void PartialModifierBeforeGenericTypeProducesIncompleteMember()
     {
-        UsingDeclaration("""partial safe<T>() { }""");
-        N(SyntaxKind.MethodDeclaration);
+        UsingDeclaration(
+            """partial safe<T>() { }""",
+            null,
+            // (1,1): error CS1073: Unexpected token '('
+            // partial safe<T>() { }
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "partial safe<T>").WithArguments("(").WithLocation(1, 1),
+            // (1,16): error CS1519: Invalid token '(' in a member declaration
+            // partial safe<T>() { }
+            Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "(").WithArguments("(").WithLocation(1, 16));
+        N(SyntaxKind.IncompleteMember);
         {
-            N(SyntaxKind.IdentifierName);
+            N(SyntaxKind.PartialKeyword);
+            N(SyntaxKind.GenericName);
             {
-                N(SyntaxKind.IdentifierToken, "partial");
-            }
-            N(SyntaxKind.IdentifierToken, "safe");
-            N(SyntaxKind.TypeParameterList);
-            {
-                N(SyntaxKind.LessThanToken);
-                N(SyntaxKind.TypeParameter);
+                N(SyntaxKind.IdentifierToken, "safe");
+                N(SyntaxKind.TypeArgumentList);
                 {
-                    N(SyntaxKind.IdentifierToken, "T");
+                    N(SyntaxKind.LessThanToken);
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "T");
+                    }
+                    N(SyntaxKind.GreaterThanToken);
                 }
-                N(SyntaxKind.GreaterThanToken);
-            }
-            N(SyntaxKind.ParameterList);
-            {
-                N(SyntaxKind.OpenParenToken);
-                N(SyntaxKind.CloseParenToken);
-            }
-            N(SyntaxKind.Block);
-            {
-                N(SyntaxKind.OpenBraceToken);
-                N(SyntaxKind.CloseBraceToken);
             }
         }
         EOF();
@@ -1447,26 +1508,34 @@ public sealed partial class ModifierParserRecoveryTests
         UsingDeclaration(
             """partial<T>() { }""",
             null,
-            // (1,1): error CS1073: Unexpected token '('
+            // (1,1): error CS1520: Method must have a return type
             // partial<T>() { }
-            Diagnostic(ErrorCode.ERR_UnexpectedToken, "partial<T>").WithArguments("(").WithLocation(1, 1),
-            // (1,11): error CS1519: Invalid token '(' in a member declaration
-            // partial<T>() { }
-            Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "(").WithArguments("(").WithLocation(1, 11));
-        N(SyntaxKind.IncompleteMember);
+            Diagnostic(ErrorCode.ERR_MemberNeedsType, "partial").WithLocation(1, 1));
+        N(SyntaxKind.MethodDeclaration);
         {
-            N(SyntaxKind.GenericName);
+            M(SyntaxKind.PredefinedType);
             {
-                N(SyntaxKind.IdentifierToken, "partial");
-                N(SyntaxKind.TypeArgumentList);
+                M(SyntaxKind.VoidKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "partial");
+            N(SyntaxKind.TypeParameterList);
+            {
+                N(SyntaxKind.LessThanToken);
+                N(SyntaxKind.TypeParameter);
                 {
-                    N(SyntaxKind.LessThanToken);
-                    N(SyntaxKind.IdentifierName);
-                    {
-                        N(SyntaxKind.IdentifierToken, "T");
-                    }
-                    N(SyntaxKind.GreaterThanToken);
+                    N(SyntaxKind.IdentifierToken, "T");
                 }
+                N(SyntaxKind.GreaterThanToken);
+            }
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.Block);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.CloseBraceToken);
             }
         }
         EOF();
@@ -1475,27 +1544,83 @@ public sealed partial class ModifierParserRecoveryTests
     [Fact]
     public void PartialGenericMethodNameFollowedByMalformedParameter()
     {
-        UsingDeclaration("""partial<T> M();""");
+        UsingDeclaration(
+            """partial<T> M();""",
+            null,
+            // (1,1): error CS1520: Method must have a return type
+            // partial<T> M();
+            Diagnostic(ErrorCode.ERR_MemberNeedsType, "partial").WithLocation(1, 1),
+            // (1,12): error CS1003: Syntax error, '(' expected
+            // partial<T> M();
+            Diagnostic(ErrorCode.ERR_SyntaxError, "M").WithArguments("(").WithLocation(1, 12),
+            // (1,13): error CS1001: Identifier expected
+            // partial<T> M();
+            Diagnostic(ErrorCode.ERR_IdentifierExpected, "(").WithLocation(1, 13),
+            // (1,13): error CS1003: Syntax error, ',' expected
+            // partial<T> M();
+            Diagnostic(ErrorCode.ERR_SyntaxError, "(").WithArguments(",").WithLocation(1, 13),
+            // (1,14): error CS8124: Tuple must contain at least two elements.
+            // partial<T> M();
+            Diagnostic(ErrorCode.ERR_TupleTooFewElements, ")").WithLocation(1, 14),
+            // (1,15): error CS1001: Identifier expected
+            // partial<T> M();
+            Diagnostic(ErrorCode.ERR_IdentifierExpected, ";").WithLocation(1, 15),
+            // (1,15): error CS1026: ) expected
+            // partial<T> M();
+            Diagnostic(ErrorCode.ERR_CloseParenExpected, ";").WithLocation(1, 15));
         N(SyntaxKind.MethodDeclaration);
         {
-            N(SyntaxKind.GenericName);
+            M(SyntaxKind.PredefinedType);
             {
-                N(SyntaxKind.IdentifierToken, "partial");
-                N(SyntaxKind.TypeArgumentList);
-                {
-                    N(SyntaxKind.LessThanToken);
-                    N(SyntaxKind.IdentifierName);
-                    {
-                        N(SyntaxKind.IdentifierToken, "T");
-                    }
-                    N(SyntaxKind.GreaterThanToken);
-                }
+                M(SyntaxKind.VoidKeyword);
             }
-            N(SyntaxKind.IdentifierToken, "M");
+            N(SyntaxKind.IdentifierToken, "partial");
+            N(SyntaxKind.TypeParameterList);
+            {
+                N(SyntaxKind.LessThanToken);
+                N(SyntaxKind.TypeParameter);
+                {
+                    N(SyntaxKind.IdentifierToken, "T");
+                }
+                N(SyntaxKind.GreaterThanToken);
+            }
             N(SyntaxKind.ParameterList);
             {
-                N(SyntaxKind.OpenParenToken);
-                N(SyntaxKind.CloseParenToken);
+                M(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.Parameter);
+                {
+                    N(SyntaxKind.IdentifierName);
+                    {
+                        N(SyntaxKind.IdentifierToken, "M");
+                    }
+                    M(SyntaxKind.IdentifierToken);
+                }
+                M(SyntaxKind.CommaToken);
+                N(SyntaxKind.Parameter);
+                {
+                    N(SyntaxKind.TupleType);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        M(SyntaxKind.TupleElement);
+                        {
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
+                        }
+                        M(SyntaxKind.CommaToken);
+                        M(SyntaxKind.TupleElement);
+                        {
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
+                        }
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                    M(SyntaxKind.IdentifierToken);
+                }
+                M(SyntaxKind.CloseParenToken);
             }
             N(SyntaxKind.SemicolonToken);
         }
@@ -1508,18 +1633,23 @@ public sealed partial class ModifierParserRecoveryTests
         UsingDeclaration(
             """partial;""",
             null,
-            // (1,1): error CS1073: Unexpected token ';'
+            // (1,1): error CS1520: Method must have a return type
             // partial;
-            Diagnostic(ErrorCode.ERR_UnexpectedToken, "partial").WithArguments(";").WithLocation(1, 1),
-            // (1,8): error CS1519: Invalid token ';' in a member declaration
-            // partial;
-            Diagnostic(ErrorCode.ERR_InvalidMemberDecl, ";").WithArguments(";").WithLocation(1, 8));
-        N(SyntaxKind.IncompleteMember);
+            Diagnostic(ErrorCode.ERR_MemberNeedsType, "partial").WithLocation(1, 1));
+        N(SyntaxKind.FieldDeclaration);
         {
-            N(SyntaxKind.IdentifierName);
+            N(SyntaxKind.VariableDeclaration);
             {
-                N(SyntaxKind.IdentifierToken, "partial");
+                M(SyntaxKind.PredefinedType);
+                {
+                    M(SyntaxKind.VoidKeyword);
+                }
+                N(SyntaxKind.VariableDeclarator);
+                {
+                    N(SyntaxKind.IdentifierToken, "partial");
+                }
             }
+            N(SyntaxKind.SemicolonToken);
         }
         EOF();
     }
@@ -1530,18 +1660,31 @@ public sealed partial class ModifierParserRecoveryTests
         UsingDeclaration(
             """partial = null;""",
             null,
-            // (1,1): error CS1073: Unexpected token '='
+            // (1,1): error CS1520: Method must have a return type
             // partial = null;
-            Diagnostic(ErrorCode.ERR_UnexpectedToken, "partial").WithArguments("=").WithLocation(1, 1),
-            // (1,9): error CS1519: Invalid token '=' in a member declaration
-            // partial = null;
-            Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "=").WithArguments("=").WithLocation(1, 9));
-        N(SyntaxKind.IncompleteMember);
+            Diagnostic(ErrorCode.ERR_MemberNeedsType, "partial").WithLocation(1, 1));
+        N(SyntaxKind.FieldDeclaration);
         {
-            N(SyntaxKind.IdentifierName);
+            N(SyntaxKind.VariableDeclaration);
             {
-                N(SyntaxKind.IdentifierToken, "partial");
+                M(SyntaxKind.PredefinedType);
+                {
+                    M(SyntaxKind.VoidKeyword);
+                }
+                N(SyntaxKind.VariableDeclarator);
+                {
+                    N(SyntaxKind.IdentifierToken, "partial");
+                    N(SyntaxKind.EqualsValueClause);
+                    {
+                        N(SyntaxKind.EqualsToken);
+                        N(SyntaxKind.NullLiteralExpression);
+                        {
+                            N(SyntaxKind.NullKeyword);
+                        }
+                    }
+                }
             }
+            N(SyntaxKind.SemicolonToken);
         }
         EOF();
     }
@@ -1552,18 +1695,25 @@ public sealed partial class ModifierParserRecoveryTests
         UsingDeclaration(
             """partial => null;""",
             null,
-            // (1,1): error CS1073: Unexpected token '=>'
+            // (1,1): error CS1520: Method must have a return type
             // partial => null;
-            Diagnostic(ErrorCode.ERR_UnexpectedToken, "partial").WithArguments("=>").WithLocation(1, 1),
-            // (1,9): error CS1519: Invalid token '=>' in a member declaration
-            // partial => null;
-            Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "=>").WithArguments("=>").WithLocation(1, 9));
-        N(SyntaxKind.IncompleteMember);
+            Diagnostic(ErrorCode.ERR_MemberNeedsType, "partial").WithLocation(1, 1));
+        N(SyntaxKind.PropertyDeclaration);
         {
-            N(SyntaxKind.IdentifierName);
+            M(SyntaxKind.PredefinedType);
             {
-                N(SyntaxKind.IdentifierToken, "partial");
+                M(SyntaxKind.VoidKeyword);
             }
+            N(SyntaxKind.IdentifierToken, "partial");
+            N(SyntaxKind.ArrowExpressionClause);
+            {
+                N(SyntaxKind.EqualsGreaterThanToken);
+                N(SyntaxKind.NullLiteralExpression);
+                {
+                    N(SyntaxKind.NullKeyword);
+                }
+            }
+            N(SyntaxKind.SemicolonToken);
         }
         EOF();
     }
@@ -1574,17 +1724,25 @@ public sealed partial class ModifierParserRecoveryTests
         UsingDeclaration(
             """partial { get; }""",
             null,
-            // (1,1): error CS1073: Unexpected token '{'
+            // (1,1): error CS1520: Method must have a return type
             // partial { get; }
-            Diagnostic(ErrorCode.ERR_UnexpectedToken, "partial").WithArguments("{").WithLocation(1, 1),
-            // (1,9): error CS1519: Invalid token '{' in a member declaration
-            // partial { get; }
-            Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "{").WithArguments("{").WithLocation(1, 9));
-        N(SyntaxKind.IncompleteMember);
+            Diagnostic(ErrorCode.ERR_MemberNeedsType, "partial").WithLocation(1, 1));
+        N(SyntaxKind.PropertyDeclaration);
         {
-            N(SyntaxKind.IdentifierName);
+            M(SyntaxKind.PredefinedType);
             {
-                N(SyntaxKind.IdentifierToken, "partial");
+                M(SyntaxKind.VoidKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "partial");
+            N(SyntaxKind.AccessorList);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.GetAccessorDeclaration);
+                {
+                    N(SyntaxKind.GetKeyword);
+                    N(SyntaxKind.SemicolonToken);
+                }
+                N(SyntaxKind.CloseBraceToken);
             }
         }
         EOF();
@@ -1596,18 +1754,28 @@ public sealed partial class ModifierParserRecoveryTests
         UsingDeclaration(
             """partial, other;""",
             null,
-            // (1,1): error CS1073: Unexpected token ','
+            // (1,1): error CS1520: Method must have a return type
             // partial, other;
-            Diagnostic(ErrorCode.ERR_UnexpectedToken, "partial").WithArguments(",").WithLocation(1, 1),
-            // (1,8): error CS1519: Invalid token ',' in a member declaration
-            // partial, other;
-            Diagnostic(ErrorCode.ERR_InvalidMemberDecl, ",").WithArguments(",").WithLocation(1, 8));
-        N(SyntaxKind.IncompleteMember);
+            Diagnostic(ErrorCode.ERR_MemberNeedsType, "partial").WithLocation(1, 1));
+        N(SyntaxKind.FieldDeclaration);
         {
-            N(SyntaxKind.IdentifierName);
+            N(SyntaxKind.VariableDeclaration);
             {
-                N(SyntaxKind.IdentifierToken, "partial");
+                M(SyntaxKind.PredefinedType);
+                {
+                    M(SyntaxKind.VoidKeyword);
+                }
+                N(SyntaxKind.VariableDeclarator);
+                {
+                    N(SyntaxKind.IdentifierToken, "partial");
+                }
+                N(SyntaxKind.CommaToken);
+                N(SyntaxKind.VariableDeclarator);
+                {
+                    N(SyntaxKind.IdentifierToken, "other");
+                }
             }
+            N(SyntaxKind.SemicolonToken);
         }
         EOF();
     }
@@ -1879,10 +2047,16 @@ public sealed partial class ModifierParserRecoveryTests
     public void PartialAsRefReturnElementType()
     {
         UsingDeclaration("""ref partial M();""");
-        N(SyntaxKind.ConstructorDeclaration);
+        N(SyntaxKind.MethodDeclaration);
         {
-            N(SyntaxKind.RefKeyword);
-            N(SyntaxKind.PartialKeyword);
+            N(SyntaxKind.RefType);
+            {
+                N(SyntaxKind.RefKeyword);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "partial");
+                }
+            }
             N(SyntaxKind.IdentifierToken, "M");
             N(SyntaxKind.ParameterList);
             {

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ModifierParserRecoveryTests.Partial.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ModifierParserRecoveryTests.Partial.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -199,13 +199,10 @@ public sealed partial class ModifierParserRecoveryTests(ITestOutputHelper output
                 N(SyntaxKind.ClassKeyword);
                 N(SyntaxKind.IdentifierToken, "C");
                 N(SyntaxKind.OpenBraceToken);
-                N(SyntaxKind.MethodDeclaration);
+                N(SyntaxKind.ConstructorDeclaration);
                 {
                     N(SyntaxKind.PartialKeyword);
-                    N(SyntaxKind.IdentifierName);
-                    {
-                        N(SyntaxKind.IdentifierToken, "partial");
-                    }
+                    N(SyntaxKind.PartialKeyword);
                     N(SyntaxKind.IdentifierToken, "M");
                     N(SyntaxKind.ParameterList);
                     {
@@ -513,9 +510,33 @@ public sealed partial class ModifierParserRecoveryTests(ITestOutputHelper output
             }
             """;
 
-        CreateCompilation(
+        var compilation = CreateCompilation(
             src,
-            parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion)).VerifyDiagnostics();
+            parseOptions: TestOptions.Regular.WithLanguageVersion(languageVersion));
+
+        if (typeName == "partial")
+        {
+            compilation.VerifyDiagnostics(
+                // (7,21): error CS1004: Duplicate 'partial' modifier
+                //     private partial partial M();
+                Diagnostic(ErrorCode.ERR_DuplicateModifier, "partial").WithArguments("partial").WithLocation(7, 21),
+                // (7,29): error CS1520: Method must have a return type
+                //     private partial partial M();
+                Diagnostic(ErrorCode.ERR_MemberNeedsType, "M").WithLocation(7, 29),
+                // (8,21): error CS1004: Duplicate 'partial' modifier
+                //     private partial partial M() => new();
+                Diagnostic(ErrorCode.ERR_DuplicateModifier, "partial").WithArguments("partial").WithLocation(8, 21),
+                // (8,29): error CS1520: Method must have a return type
+                //     private partial partial M() => new();
+                Diagnostic(ErrorCode.ERR_MemberNeedsType, "M").WithLocation(8, 29),
+                // (8,36): error CS0201: Only assignment, call, increment, decrement, await, and new object expressions can be used as a statement
+                //     private partial partial M() => new();
+                Diagnostic(ErrorCode.ERR_IllegalStatement, "new()").WithLocation(8, 36));
+        }
+        else
+        {
+            compilation.VerifyDiagnostics();
+        }
     }
 
     /// <summary>
@@ -604,9 +625,43 @@ public sealed partial class ModifierParserRecoveryTests(ITestOutputHelper output
     }
 
     [Fact]
-    public void PartialThenFile_NoDeclHead_FallsBackToIdentifier()
+    public void PartialThenFile_NoDeclHead_TreatsPartialAsModifier()
     {
-        UsingTree("partial file;");
+        UsingTree(
+            "partial file;",
+            // (1,9): error CS0116: A namespace cannot directly contain members such as fields, methods or statements
+            // partial file;
+            Diagnostic(ErrorCode.ERR_NamespaceUnexpected, "file").WithLocation(1, 9));
+        N(SyntaxKind.CompilationUnit);
+        {
+            N(SyntaxKind.IncompleteMember);
+            {
+                N(SyntaxKind.PartialKeyword);
+                N(SyntaxKind.IdentifierName);
+                {
+                    N(SyntaxKind.IdentifierToken, "file");
+                }
+            }
+            N(SyntaxKind.GlobalStatement);
+            {
+                N(SyntaxKind.EmptyStatement);
+                {
+                    N(SyntaxKind.SemicolonToken);
+                }
+            }
+            N(SyntaxKind.EndOfFileToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void PartialThenContextualChain_NoDeclHead_FallsBackToIdentifier()
+    {
+        UsingTree(
+            "partial file async required;",
+            // (1,14): error CS1003: Syntax error, ',' expected
+            // partial file async required;
+            Diagnostic(ErrorCode.ERR_SyntaxError, "async").WithArguments(",").WithLocation(1, 14));
         N(SyntaxKind.CompilationUnit);
         {
             N(SyntaxKind.GlobalStatement);
@@ -622,45 +677,6 @@ public sealed partial class ModifierParserRecoveryTests(ITestOutputHelper output
                         N(SyntaxKind.VariableDeclarator);
                         {
                             N(SyntaxKind.IdentifierToken, "file");
-                        }
-                    }
-                    N(SyntaxKind.SemicolonToken);
-                }
-            }
-            N(SyntaxKind.EndOfFileToken);
-        }
-        EOF();
-    }
-
-    [Fact]
-    public void PartialThenContextualChain_NoDeclHead_FallsBackToIdentifier()
-    {
-        UsingTree(
-            "partial file async required;",
-            // (1,1): error CS1031: Type expected
-            // partial file async required;
-            Diagnostic(ErrorCode.ERR_TypeExpected, "partial").WithLocation(1, 1),
-            // (1,1): error CS1525: Invalid expression term 'partial'
-            // partial file async required;
-            Diagnostic(ErrorCode.ERR_InvalidExprTerm, "partial").WithArguments("partial").WithLocation(1, 1),
-            // (1,1): error CS1003: Syntax error, ',' expected
-            // partial file async required;
-            Diagnostic(ErrorCode.ERR_SyntaxError, "partial").WithArguments(",").WithLocation(1, 1));
-        N(SyntaxKind.CompilationUnit);
-        {
-            N(SyntaxKind.GlobalStatement);
-            {
-                N(SyntaxKind.LocalDeclarationStatement);
-                {
-                    M(SyntaxKind.VariableDeclaration);
-                    {
-                        M(SyntaxKind.IdentifierName);
-                        {
-                            M(SyntaxKind.IdentifierToken);
-                        }
-                        M(SyntaxKind.VariableDeclarator);
-                        {
-                            M(SyntaxKind.IdentifierToken);
                         }
                     }
                     N(SyntaxKind.SemicolonToken);
@@ -806,12 +822,9 @@ public sealed partial class ModifierParserRecoveryTests(ITestOutputHelper output
                 N(SyntaxKind.ClassKeyword);
                 N(SyntaxKind.IdentifierToken, "async");
                 N(SyntaxKind.OpenBraceToken);
-                N(SyntaxKind.MethodDeclaration);
+                N(SyntaxKind.ConstructorDeclaration);
                 {
-                    N(SyntaxKind.IdentifierName);
-                    {
-                        N(SyntaxKind.IdentifierToken, "partial");
-                    }
+                    N(SyntaxKind.PartialKeyword);
                     N(SyntaxKind.IdentifierToken, "async");
                     N(SyntaxKind.ParameterList);
                     {
@@ -1171,52 +1184,25 @@ public sealed partial class ModifierParserRecoveryTests(ITestOutputHelper output
             source,
             expectedParsingDiagnostics:
             [
-                // (1,1): error CS1525: Invalid expression term 'partial'
+                // (1,1): error CS1073: Unexpected token 'async'
                 // partial async () => { }
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "partial").WithArguments("partial").WithLocation(1, 1),
-                // (1,1): error CS1073: Unexpected token 'partial'
-                // partial async () => { }
-                Diagnostic(ErrorCode.ERR_UnexpectedToken, "").WithArguments("partial").WithLocation(1, 1),
+                Diagnostic(ErrorCode.ERR_UnexpectedToken, "partial").WithArguments("async").WithLocation(1, 1),
             ],
             expectedBindingDiagnostics:
             [
-                // (5,27): error CS1525: Invalid expression term 'partial'
+                // (5,27): error CS0103: The name 'partial' does not exist in the current context
                 //         System.Action x = partial async () => { };
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "partial").WithArguments("partial").WithLocation(5, 27),
-                // (5,27): error CS1002: ; expected
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "partial").WithArguments("partial").WithLocation(5, 27),
+                // (5,35): error CS1002: ; expected
                 //         System.Action x = partial async () => { };
-                Diagnostic(ErrorCode.ERR_SemicolonExpected, "partial").WithLocation(5, 27),
-                // (5,27): error CS1513: } expected
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "async").WithLocation(5, 35),
+                // (5,35): error CS0201: Only assignment, call, increment, decrement, await, and new object expressions can be used as a statement
                 //         System.Action x = partial async () => { };
-                Diagnostic(ErrorCode.ERR_RbraceExpected, "partial").WithLocation(5, 27),
-                // (5,35): error CS1520: Method must have a return type
-                //         System.Action x = partial async () => { };
-                Diagnostic(ErrorCode.ERR_MemberNeedsType, "async").WithLocation(5, 35),
-                // (5,35): error CS0751: A partial member must be declared within a partial type
-                //         System.Action x = partial async () => { };
-                Diagnostic(ErrorCode.ERR_PartialMemberOnlyInPartialClass, "async").WithLocation(5, 35),
-                // (5,35): error CS9276: Partial member 'C.C()' must have a definition part.
-                //         System.Action x = partial async () => { };
-                Diagnostic(ErrorCode.ERR_PartialMemberMissingDefinition, "async").WithArguments("C.C()").WithLocation(5, 35),
-                // (5,47): error CS1525: Invalid expression term '{'
-                //         System.Action x = partial async () => { };
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "{").WithArguments("{").WithLocation(5, 47),
-                // (5,47): error CS1002: ; expected
-                //         System.Action x = partial async () => { };
-                Diagnostic(ErrorCode.ERR_SemicolonExpected, "{").WithLocation(5, 47),
-                // (5,47): error CS1519: Invalid token '{' in a member declaration
-                //         System.Action x = partial async () => { };
-                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "{").WithArguments("{").WithLocation(5, 47),
-                // (6,5): error CS1022: Type or namespace definition, or end-of-file expected
-                //     }
-                Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(6, 5),
-                // (7,1): error CS1022: Type or namespace definition, or end-of-file expected
-                // }
-                Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(7, 1),
+                Diagnostic(ErrorCode.ERR_IllegalStatement, "async () => { }").WithLocation(5, 35),
             ]);
-        M(SyntaxKind.IdentifierName);
+        N(SyntaxKind.IdentifierName);
         {
-            M(SyntaxKind.IdentifierToken);
+            N(SyntaxKind.IdentifierToken, "partial");
         }
         EOF();
     }
@@ -1278,45 +1264,18 @@ public sealed partial class ModifierParserRecoveryTests(ITestOutputHelper output
                 // (5,27): error CS1002: ; expected
                 //         System.Action x = static partial async () => { };
                 Diagnostic(ErrorCode.ERR_SemicolonExpected, "static").WithLocation(5, 27),
-                // (5,27): error CS0106: The modifier 'static' is not valid for this item
+                // (5,34): error CS0246: The type or namespace name 'partial' could not be found (are you missing a using directive or an assembly reference?)
                 //         System.Action x = static partial async () => { };
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "static").WithArguments("static").WithLocation(5, 27),
-                // (5,34): error CS1031: Type expected
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "partial").WithArguments("partial").WithLocation(5, 34),
+                // (5,42): warning CS8321: The local function 'async' is declared but never used
                 //         System.Action x = static partial async () => { };
-                Diagnostic(ErrorCode.ERR_TypeExpected, "partial").WithLocation(5, 34),
-                // (5,34): error CS1525: Invalid expression term 'partial'
-                //         System.Action x = static partial async () => { };
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "partial").WithArguments("partial").WithLocation(5, 34),
-                // (5,34): error CS1002: ; expected
-                //         System.Action x = static partial async () => { };
-                Diagnostic(ErrorCode.ERR_SemicolonExpected, "partial").WithLocation(5, 34),
-                // (5,34): error CS1513: } expected
-                //         System.Action x = static partial async () => { };
-                Diagnostic(ErrorCode.ERR_RbraceExpected, "partial").WithLocation(5, 34),
-                // (5,42): error CS1520: Method must have a return type
-                //         System.Action x = static partial async () => { };
-                Diagnostic(ErrorCode.ERR_MemberNeedsType, "async").WithLocation(5, 42),
-                // (5,42): error CS0751: A partial member must be declared within a partial type
-                //         System.Action x = static partial async () => { };
-                Diagnostic(ErrorCode.ERR_PartialMemberOnlyInPartialClass, "async").WithLocation(5, 42),
-                // (5,42): error CS9276: Partial member 'C.C()' must have a definition part.
-                //         System.Action x = static partial async () => { };
-                Diagnostic(ErrorCode.ERR_PartialMemberMissingDefinition, "async").WithArguments("C.C()").WithLocation(5, 42),
+                Diagnostic(ErrorCode.WRN_UnreferencedLocalFunction, "async").WithArguments("async").WithLocation(5, 42),
                 // (5,54): error CS1525: Invalid expression term '{'
                 //         System.Action x = static partial async () => { };
                 Diagnostic(ErrorCode.ERR_InvalidExprTerm, "{").WithArguments("{").WithLocation(5, 54),
                 // (5,54): error CS1002: ; expected
                 //         System.Action x = static partial async () => { };
                 Diagnostic(ErrorCode.ERR_SemicolonExpected, "{").WithLocation(5, 54),
-                // (5,54): error CS1519: Invalid token '{' in a member declaration
-                //         System.Action x = static partial async () => { };
-                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "{").WithArguments("{").WithLocation(5, 54),
-                // (6,5): error CS1022: Type or namespace definition, or end-of-file expected
-                //     }
-                Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(6, 5),
-                // (7,1): error CS1022: Type or namespace definition, or end-of-file expected
-                // }
-                Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(7, 1),
             ]);
         M(SyntaxKind.IdentifierName);
         {

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/NameParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/NameParsingTests.cs
@@ -89,11 +89,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.NotNull(name);
             Assert.Equal(SyntaxKind.IdentifierName, name.Kind());
-            Assert.True(name.IsMissing);
-            Assert.Equal(2, name.Errors().Length);
+            Assert.False(name.IsMissing);
+            Assert.Equal(1, name.Errors().Length);
             Assert.Equal((int)ErrorCode.ERR_UnexpectedToken, name.Errors()[0].Code);
-            Assert.Equal((int)ErrorCode.ERR_InvalidExprTerm, name.Errors()[1].Code);
-            Assert.Equal(string.Empty, name.ToString());
+            Assert.Equal("partial", name.ToString());
         }
 
         [Fact]
@@ -104,11 +103,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.NotNull(name);
             Assert.Equal(SyntaxKind.IdentifierName, name.Kind());
-            Assert.True(name.IsMissing);
-            Assert.Equal(2, name.Errors().Length);
+            Assert.False(name.IsMissing);
+            Assert.Equal(1, name.Errors().Length);
             Assert.Equal((int)ErrorCode.ERR_UnexpectedToken, name.Errors()[0].Code);
-            Assert.Equal((int)ErrorCode.ERR_InvalidExprTerm, name.Errors()[1].Code);
-            Assert.Equal(string.Empty, name.ToString());
+            Assert.Equal("partial", name.ToString());
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingErrorRecoveryTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingErrorRecoveryTests.cs
@@ -6952,16 +6952,16 @@ class C
             Assert.True(decl.SemicolonToken.IsMissing);
             Assert.Equal(2, decl.Declaration.Variables.Count);
             Assert.Equal("x", decl.Declaration.Variables[0].Identifier.ToString());
-            Assert.True(decl.Declaration.Variables[1].Identifier.IsMissing);
-            Assert.Equal(3, subitem1.Errors().Length);
-            Assert.Equal((int)ErrorCode.ERR_InvalidExprTerm, subitem1.Errors()[0].Code);
-            Assert.Equal((int)ErrorCode.ERR_SemicolonExpected, subitem1.Errors()[1].Code);
-            Assert.Equal((int)ErrorCode.ERR_RbraceExpected, subitem1.Errors()[2].Code);
+            Assert.Equal("partial", decl.Declaration.Variables[1].Identifier.ToString());
+            Assert.False(decl.Declaration.Variables[1].Identifier.IsMissing);
+            Assert.Equal(2, subitem1.Errors().Length);
+            Assert.Equal((int)ErrorCode.ERR_SemicolonExpected, subitem1.Errors()[0].Code);
+            Assert.Equal((int)ErrorCode.ERR_RbraceExpected, subitem1.Errors()[1].Code);
 
             var subitem2 = (TypeDeclarationSyntax)item1.Members[1];
             Assert.Equal(SyntaxKind.ClassDeclaration, item1.Members[1].Kind());
             Assert.Equal("y", subitem2.Identifier.ToString());
-            Assert.Equal(SyntaxKind.PartialKeyword, subitem2.Modifiers[0].ContextualKind());
+            Assert.Empty(subitem2.Modifiers);
             Assert.True(subitem2.OpenBraceToken.IsMissing);
             Assert.True(subitem2.CloseBraceToken.IsMissing);
             Assert.Equal(3, subitem2.Errors().Length);

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/PartialEventsAndConstructorsParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/PartialEventsAndConstructorsParsingTests.cs
@@ -287,28 +287,22 @@ public sealed class PartialEventsAndConstructorsParsingTests(ITestOutputHelper o
             event partial Action E;
             """,
             TestOptions.Regular.WithLanguageVersion(langVersion),
-            // (1,7): error CS1031: Type expected
+            // (1,22): error CS1003: Syntax error, ',' expected
             // event partial Action E;
-            Diagnostic(ErrorCode.ERR_TypeExpected, "partial").WithLocation(1, 7),
-            // (1,7): error CS1525: Invalid expression term 'partial'
-            // event partial Action E;
-            Diagnostic(ErrorCode.ERR_InvalidExprTerm, "partial").WithArguments("partial").WithLocation(1, 7),
-            // (1,7): error CS1003: Syntax error, ',' expected
-            // event partial Action E;
-            Diagnostic(ErrorCode.ERR_SyntaxError, "partial").WithArguments(",").WithLocation(1, 7));
+            Diagnostic(ErrorCode.ERR_SyntaxError, "E").WithArguments(",").WithLocation(1, 22));
 
         N(SyntaxKind.EventFieldDeclaration);
         {
             N(SyntaxKind.EventKeyword);
-            M(SyntaxKind.VariableDeclaration);
+            N(SyntaxKind.VariableDeclaration);
             {
-                M(SyntaxKind.IdentifierName);
+                N(SyntaxKind.IdentifierName);
                 {
-                    M(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "partial");
                 }
-                M(SyntaxKind.VariableDeclarator);
+                N(SyntaxKind.VariableDeclarator);
                 {
-                    M(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "Action");
                 }
             }
             N(SyntaxKind.SemicolonToken);
@@ -586,15 +580,9 @@ public sealed class PartialEventsAndConstructorsParsingTests(ITestOutputHelper o
             event partial Action E { add { } remove { } }
             """,
             TestOptions.Regular.WithLanguageVersion(langVersion),
-            // (1,7): error CS1031: Type expected
+            // (1,22): error CS1003: Syntax error, ',' expected
             // event partial Action E { add { } remove { } }
-            Diagnostic(ErrorCode.ERR_TypeExpected, "partial").WithLocation(1, 7),
-            // (1,7): error CS1525: Invalid expression term 'partial'
-            // event partial Action E { add { } remove { } }
-            Diagnostic(ErrorCode.ERR_InvalidExprTerm, "partial").WithArguments("partial").WithLocation(1, 7),
-            // (1,7): error CS1003: Syntax error, ',' expected
-            // event partial Action E { add { } remove { } }
-            Diagnostic(ErrorCode.ERR_SyntaxError, "partial").WithArguments(",").WithLocation(1, 7),
+            Diagnostic(ErrorCode.ERR_SyntaxError, "E").WithArguments(",").WithLocation(1, 22),
             // (1,46): error CS1002: ; expected
             // event partial Action E { add { } remove { } }
             Diagnostic(ErrorCode.ERR_SemicolonExpected, "").WithLocation(1, 46));
@@ -602,15 +590,15 @@ public sealed class PartialEventsAndConstructorsParsingTests(ITestOutputHelper o
         N(SyntaxKind.EventFieldDeclaration);
         {
             N(SyntaxKind.EventKeyword);
-            M(SyntaxKind.VariableDeclaration);
+            N(SyntaxKind.VariableDeclaration);
             {
-                M(SyntaxKind.IdentifierName);
+                N(SyntaxKind.IdentifierName);
                 {
-                    M(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "partial");
                 }
-                M(SyntaxKind.VariableDeclarator);
+                N(SyntaxKind.VariableDeclarator);
                 {
-                    M(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "Action");
                 }
             }
             M(SyntaxKind.SemicolonToken);
@@ -724,12 +712,12 @@ public sealed class PartialEventsAndConstructorsParsingTests(ITestOutputHelper o
             }
             """,
             TestOptions.Regular.WithLanguageVersion(langVersion),
-            // (3,11): error CS1026: ) expected
-            //     [Attr(
-            Diagnostic(ErrorCode.ERR_CloseParenExpected, "").WithLocation(3, 11),
-            // (3,11): error CS1003: Syntax error, ']' expected
-            //     [Attr(
-            Diagnostic(ErrorCode.ERR_SyntaxError, "").WithArguments("]").WithLocation(3, 11));
+            // (4,13): error CS1026: ) expected
+            //     partial event Action E;
+            Diagnostic(ErrorCode.ERR_CloseParenExpected, "event").WithLocation(4, 13),
+            // (4,13): error CS1003: Syntax error, ']' expected
+            //     partial event Action E;
+            Diagnostic(ErrorCode.ERR_SyntaxError, "event").WithArguments("]").WithLocation(4, 13));
 
         N(SyntaxKind.CompilationUnit);
         {
@@ -753,12 +741,18 @@ public sealed class PartialEventsAndConstructorsParsingTests(ITestOutputHelper o
                             N(SyntaxKind.AttributeArgumentList);
                             {
                                 N(SyntaxKind.OpenParenToken);
+                                N(SyntaxKind.AttributeArgument);
+                                {
+                                    N(SyntaxKind.IdentifierName);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "partial");
+                                    }
+                                }
                                 M(SyntaxKind.CloseParenToken);
                             }
                         }
                         M(SyntaxKind.CloseBracketToken);
                     }
-                    N(SyntaxKind.PartialKeyword);
                     N(SyntaxKind.EventKeyword);
                     N(SyntaxKind.VariableDeclaration);
                     {
@@ -867,12 +861,9 @@ public sealed class PartialEventsAndConstructorsParsingTests(ITestOutputHelper o
             """,
             TestOptions.Regular13);
 
-        N(SyntaxKind.MethodDeclaration);
+        N(SyntaxKind.ConstructorDeclaration);
         {
-            N(SyntaxKind.IdentifierName);
-            {
-                N(SyntaxKind.IdentifierToken, "partial");
-            }
+            N(SyntaxKind.PartialKeyword);
             N(SyntaxKind.IdentifierToken, "C");
             N(SyntaxKind.ParameterList);
             {
@@ -928,22 +919,21 @@ public sealed class PartialEventsAndConstructorsParsingTests(ITestOutputHelper o
         UsingDeclaration("""
             partial C;
             """,
-            TestOptions.Regular.WithLanguageVersion(langVersion));
+            TestOptions.Regular.WithLanguageVersion(langVersion),
+            // (1,1): error CS1073: Unexpected token ';'
+            // partial C;
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "partial C").WithArguments(";").WithLocation(1, 1),
+            // (1,10): error CS1519: Invalid token ';' in a member declaration
+            // partial C;
+            Diagnostic(ErrorCode.ERR_InvalidMemberDecl, ";").WithArguments(";").WithLocation(1, 10));
 
-        N(SyntaxKind.FieldDeclaration);
+        N(SyntaxKind.IncompleteMember);
         {
-            N(SyntaxKind.VariableDeclaration);
+            N(SyntaxKind.PartialKeyword);
+            N(SyntaxKind.IdentifierName);
             {
-                N(SyntaxKind.IdentifierName);
-                {
-                    N(SyntaxKind.IdentifierToken, "partial");
-                }
-                N(SyntaxKind.VariableDeclarator);
-                {
-                    N(SyntaxKind.IdentifierToken, "C");
-                }
+                N(SyntaxKind.IdentifierToken, "C");
             }
-            N(SyntaxKind.SemicolonToken);
         }
         EOF();
     }
@@ -999,12 +989,9 @@ public sealed class PartialEventsAndConstructorsParsingTests(ITestOutputHelper o
             """,
             TestOptions.Regular13);
 
-        N(SyntaxKind.MethodDeclaration);
+        N(SyntaxKind.ConstructorDeclaration);
         {
-            N(SyntaxKind.IdentifierName);
-            {
-                N(SyntaxKind.IdentifierToken, "partial");
-            }
+            N(SyntaxKind.PartialKeyword);
             N(SyntaxKind.IdentifierToken, "partial");
             N(SyntaxKind.ParameterList);
             {
@@ -1145,19 +1132,48 @@ public sealed class PartialEventsAndConstructorsParsingTests(ITestOutputHelper o
             partial const();
             """,
             TestOptions.Regular.WithLanguageVersion(langVersion),
-            // (1,1): error CS1073: Unexpected token 'const'
+            // (1,15): error CS8124: Tuple must contain at least two elements.
             // partial const();
-            Diagnostic(ErrorCode.ERR_UnexpectedToken, "partial").WithArguments("const").WithLocation(1, 1),
-            // (1,9): error CS1519: Invalid token 'const' in class, record, struct, or interface member declaration
+            Diagnostic(ErrorCode.ERR_TupleTooFewElements, ")").WithLocation(1, 15),
+            // (1,16): error CS1001: Identifier expected
             // partial const();
-            Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "const").WithArguments("const").WithLocation(1, 9));
+            Diagnostic(ErrorCode.ERR_IdentifierExpected, ";").WithLocation(1, 16),
+            // (1,16): error CS0145: A const field requires a value to be provided
+            // partial const();
+            Diagnostic(ErrorCode.ERR_ConstValueRequired, ";").WithLocation(1, 16));
 
-        N(SyntaxKind.IncompleteMember);
+        N(SyntaxKind.FieldDeclaration);
         {
-            N(SyntaxKind.IdentifierName);
+            N(SyntaxKind.PartialKeyword);
+            N(SyntaxKind.ConstKeyword);
+            N(SyntaxKind.VariableDeclaration);
             {
-                N(SyntaxKind.IdentifierToken, "partial");
+                N(SyntaxKind.TupleType);
+                {
+                    N(SyntaxKind.OpenParenToken);
+                    M(SyntaxKind.TupleElement);
+                    {
+                        M(SyntaxKind.IdentifierName);
+                        {
+                            M(SyntaxKind.IdentifierToken);
+                        }
+                    }
+                    M(SyntaxKind.CommaToken);
+                    M(SyntaxKind.TupleElement);
+                    {
+                        M(SyntaxKind.IdentifierName);
+                        {
+                            M(SyntaxKind.IdentifierToken);
+                        }
+                    }
+                    N(SyntaxKind.CloseParenToken);
+                }
+                M(SyntaxKind.VariableDeclarator);
+                {
+                    M(SyntaxKind.IdentifierToken);
+                }
             }
+            N(SyntaxKind.SemicolonToken);
         }
         EOF();
     }
@@ -1173,12 +1189,18 @@ public sealed class PartialEventsAndConstructorsParsingTests(ITestOutputHelper o
             }
             """,
             TestOptions.Regular.WithLanguageVersion(langVersion),
-            // (3,11): error CS1026: ) expected
-            //     [Attr(
-            Diagnostic(ErrorCode.ERR_CloseParenExpected, "").WithLocation(3, 11),
-            // (3,11): error CS1003: Syntax error, ']' expected
-            //     [Attr(
-            Diagnostic(ErrorCode.ERR_SyntaxError, "").WithArguments("]").WithLocation(3, 11));
+            // (4,13): error CS1003: Syntax error, ',' expected
+            //     partial C();
+            Diagnostic(ErrorCode.ERR_SyntaxError, "C").WithArguments(",").WithLocation(4, 13),
+            // (4,16): error CS1003: Syntax error, ',' expected
+            //     partial C();
+            Diagnostic(ErrorCode.ERR_SyntaxError, ";").WithArguments(",").WithLocation(4, 16),
+            // (4,17): error CS1026: ) expected
+            //     partial C();
+            Diagnostic(ErrorCode.ERR_CloseParenExpected, "").WithLocation(4, 17),
+            // (4,17): error CS1003: Syntax error, ']' expected
+            //     partial C();
+            Diagnostic(ErrorCode.ERR_SyntaxError, "").WithArguments("]").WithLocation(4, 17));
 
         N(SyntaxKind.CompilationUnit);
         {
@@ -1188,7 +1210,7 @@ public sealed class PartialEventsAndConstructorsParsingTests(ITestOutputHelper o
                 N(SyntaxKind.ClassKeyword);
                 N(SyntaxKind.IdentifierToken, "C");
                 N(SyntaxKind.OpenBraceToken);
-                N(SyntaxKind.ConstructorDeclaration);
+                N(SyntaxKind.IncompleteMember);
                 {
                     N(SyntaxKind.AttributeList);
                     {
@@ -1202,19 +1224,34 @@ public sealed class PartialEventsAndConstructorsParsingTests(ITestOutputHelper o
                             N(SyntaxKind.AttributeArgumentList);
                             {
                                 N(SyntaxKind.OpenParenToken);
+                                N(SyntaxKind.AttributeArgument);
+                                {
+                                    N(SyntaxKind.IdentifierName);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "partial");
+                                    }
+                                }
+                                M(SyntaxKind.CommaToken);
+                                N(SyntaxKind.AttributeArgument);
+                                {
+                                    N(SyntaxKind.InvocationExpression);
+                                    {
+                                        N(SyntaxKind.IdentifierName);
+                                        {
+                                            N(SyntaxKind.IdentifierToken, "C");
+                                        }
+                                        N(SyntaxKind.ArgumentList);
+                                        {
+                                            N(SyntaxKind.OpenParenToken);
+                                            N(SyntaxKind.CloseParenToken);
+                                        }
+                                    }
+                                }
                                 M(SyntaxKind.CloseParenToken);
                             }
                         }
                         M(SyntaxKind.CloseBracketToken);
                     }
-                    N(SyntaxKind.PartialKeyword);
-                    N(SyntaxKind.IdentifierToken, "C");
-                    N(SyntaxKind.ParameterList);
-                    {
-                        N(SyntaxKind.OpenParenToken);
-                        N(SyntaxKind.CloseParenToken);
-                    }
-                    N(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.CloseBraceToken);
             }
@@ -1235,13 +1272,7 @@ public sealed class PartialEventsAndConstructorsParsingTests(ITestOutputHelper o
                 }
             }
             """,
-            TestOptions.Regular.WithLanguageVersion(langVersion),
-            // (4,6): error CS1513: } expected
-            //     {
-            Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(4, 6),
-            // (7,1): error CS1022: Type or namespace definition, or end-of-file expected
-            // }
-            Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(7, 1));
+            TestOptions.Regular.WithLanguageVersion(langVersion));
 
         N(SyntaxKind.CompilationUnit);
         {
@@ -1265,27 +1296,30 @@ public sealed class PartialEventsAndConstructorsParsingTests(ITestOutputHelper o
                     N(SyntaxKind.Block);
                     {
                         N(SyntaxKind.OpenBraceToken);
-                        M(SyntaxKind.CloseBraceToken);
-                    }
-                }
-                N(SyntaxKind.ConstructorDeclaration);
-                {
-                    N(SyntaxKind.PartialKeyword);
-                    N(SyntaxKind.IdentifierToken, "F");
-                    N(SyntaxKind.ParameterList);
-                    {
-                        N(SyntaxKind.OpenParenToken);
-                        N(SyntaxKind.CloseParenToken);
-                    }
-                    N(SyntaxKind.ArrowExpressionClause);
-                    {
-                        N(SyntaxKind.EqualsGreaterThanToken);
-                        N(SyntaxKind.NullLiteralExpression);
+                        N(SyntaxKind.LocalFunctionStatement);
                         {
-                            N(SyntaxKind.NullKeyword);
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "partial");
+                            }
+                            N(SyntaxKind.IdentifierToken, "F");
+                            N(SyntaxKind.ParameterList);
+                            {
+                                N(SyntaxKind.OpenParenToken);
+                                N(SyntaxKind.CloseParenToken);
+                            }
+                            N(SyntaxKind.ArrowExpressionClause);
+                            {
+                                N(SyntaxKind.EqualsGreaterThanToken);
+                                N(SyntaxKind.NullLiteralExpression);
+                                {
+                                    N(SyntaxKind.NullKeyword);
+                                }
+                            }
+                            N(SyntaxKind.SemicolonToken);
                         }
+                        N(SyntaxKind.CloseBraceToken);
                     }
-                    N(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.CloseBraceToken);
             }
@@ -1368,32 +1402,26 @@ public sealed class PartialEventsAndConstructorsParsingTests(ITestOutputHelper o
         UsingTree("""
             partial F() => null;
             """,
-            TestOptions.Regular.WithLanguageVersion(langVersion),
-            // (1,9): error CS0116: A namespace cannot directly contain members such as fields, methods or statements
-            // partial F() => null;
-            Diagnostic(ErrorCode.ERR_NamespaceUnexpected, "F").WithLocation(1, 9));
+            TestOptions.Regular.WithLanguageVersion(langVersion));
 
         N(SyntaxKind.CompilationUnit);
         {
-            N(SyntaxKind.IncompleteMember);
-            {
-                N(SyntaxKind.PartialKeyword);
-                N(SyntaxKind.IdentifierName);
-                {
-                    N(SyntaxKind.IdentifierToken, "F");
-                }
-            }
             N(SyntaxKind.GlobalStatement);
             {
-                N(SyntaxKind.ExpressionStatement);
+                N(SyntaxKind.LocalFunctionStatement);
                 {
-                    N(SyntaxKind.ParenthesizedLambdaExpression);
+                    N(SyntaxKind.IdentifierName);
                     {
-                        N(SyntaxKind.ParameterList);
-                        {
-                            N(SyntaxKind.OpenParenToken);
-                            N(SyntaxKind.CloseParenToken);
-                        }
+                        N(SyntaxKind.IdentifierToken, "partial");
+                    }
+                    N(SyntaxKind.IdentifierToken, "F");
+                    N(SyntaxKind.ParameterList);
+                    {
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.CloseParenToken);
+                    }
+                    N(SyntaxKind.ArrowExpressionClause);
+                    {
                         N(SyntaxKind.EqualsGreaterThanToken);
                         N(SyntaxKind.NullLiteralExpression);
                         {
@@ -1534,12 +1562,9 @@ public sealed class PartialEventsAndConstructorsParsingTests(ITestOutputHelper o
                 N(SyntaxKind.ClassKeyword);
                 N(SyntaxKind.IdentifierToken, "C");
                 N(SyntaxKind.OpenBraceToken);
-                N(SyntaxKind.MethodDeclaration);
+                N(SyntaxKind.ConstructorDeclaration);
                 {
-                    N(SyntaxKind.IdentifierName);
-                    {
-                        N(SyntaxKind.IdentifierToken, "partial");
-                    }
+                    N(SyntaxKind.PartialKeyword);
                     N(SyntaxKind.IdentifierToken, "M");
                     N(SyntaxKind.ParameterList);
                     {

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ScriptParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ScriptParsingTests.cs
@@ -576,24 +576,40 @@ new T Goo();
             var src = """
 new partial Goo();
 """;
-            var tree = UsingTree(src, options: TestOptions.Regular13);
+            var tree = UsingTree(src, TestOptions.Regular13,
+                // (1,13): error CS0116: A namespace cannot directly contain members such as fields, methods or statements
+                // new partial Goo();
+                Diagnostic(ErrorCode.ERR_NamespaceUnexpected, "Goo").WithLocation(1, 13),
+                // (1,17): error CS1525: Invalid expression term ')'
+                // new partial Goo();
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, ")").WithArguments(")").WithLocation(1, 17));
 
             N(SyntaxKind.CompilationUnit);
             {
-                N(SyntaxKind.MethodDeclaration);
+                N(SyntaxKind.IncompleteMember);
                 {
                     N(SyntaxKind.NewKeyword);
+                    N(SyntaxKind.PartialKeyword);
                     N(SyntaxKind.IdentifierName);
                     {
-                        N(SyntaxKind.IdentifierToken);
+                        N(SyntaxKind.IdentifierToken, "Goo");
                     }
-                    N(SyntaxKind.IdentifierToken);
-                    N(SyntaxKind.ParameterList);
+                }
+                N(SyntaxKind.GlobalStatement);
+                {
+                    N(SyntaxKind.ExpressionStatement);
                     {
-                        N(SyntaxKind.OpenParenToken);
-                        N(SyntaxKind.CloseParenToken);
+                        N(SyntaxKind.ParenthesizedExpression);
+                        {
+                            N(SyntaxKind.OpenParenToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
+                            N(SyntaxKind.CloseParenToken);
+                        }
+                        N(SyntaxKind.SemicolonToken);
                     }
-                    N(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
@@ -631,18 +647,22 @@ new partial Goo();
         {
             var tree = UsingTree(@"
 new partial[] Goo();
-");
+",
+                // (2,12): error CS1031: Type expected
+                // new partial[] Goo();
+                Diagnostic(ErrorCode.ERR_TypeExpected, "[").WithLocation(2, 12));
 
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.MethodDeclaration);
                 {
                     N(SyntaxKind.NewKeyword);
+                    N(SyntaxKind.PartialKeyword);
                     N(SyntaxKind.ArrayType);
                     {
-                        N(SyntaxKind.IdentifierName);
+                        M(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            M(SyntaxKind.IdentifierToken);
                         }
                         N(SyntaxKind.ArrayRankSpecifier);
                         {
@@ -654,7 +674,7 @@ new partial[] Goo();
                             N(SyntaxKind.CloseBracketToken);
                         }
                     }
-                    N(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.IdentifierToken, "Goo");
                     N(SyntaxKind.ParameterList);
                     {
                         N(SyntaxKind.OpenParenToken);
@@ -672,77 +692,49 @@ new partial[] Goo();
             var src = """
 new partial.partial Goo();
 """;
-            var tree = UsingTree(src, options: TestOptions.Regular13);
+            var tree = UsingTree(src, TestOptions.Regular13,
+                // (1,5): error CS0116: A namespace cannot directly contain members such as fields, methods or statements
+                // new partial.partial Goo();
+                Diagnostic(ErrorCode.ERR_NamespaceUnexpected, "partial").WithLocation(1, 5),
+                // (1,12): error CS1022: Type or namespace definition, or end-of-file expected
+                // new partial.partial Goo();
+                Diagnostic(ErrorCode.ERR_EOFExpected, ".").WithLocation(1, 12));
 
             N(SyntaxKind.CompilationUnit);
             {
-                N(SyntaxKind.MethodDeclaration);
+                N(SyntaxKind.GlobalStatement);
                 {
-                    N(SyntaxKind.NewKeyword);
-                    N(SyntaxKind.QualifiedName);
+                    N(SyntaxKind.LocalFunctionStatement);
                     {
                         N(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.IdentifierToken, "partial");
                         }
-                        N(SyntaxKind.DotToken);
-                        N(SyntaxKind.IdentifierName);
+                        N(SyntaxKind.IdentifierToken, "Goo");
+                        N(SyntaxKind.ParameterList);
                         {
-                            N(SyntaxKind.IdentifierToken);
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.CloseParenToken);
                         }
+                        N(SyntaxKind.SemicolonToken);
                     }
-                    N(SyntaxKind.IdentifierToken);
-                    N(SyntaxKind.ParameterList);
-                    {
-                        N(SyntaxKind.OpenParenToken);
-                        N(SyntaxKind.CloseParenToken);
-                    }
-                    N(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
 
             tree = UsingTree(src,
-                // (1,13): error CS1525: Invalid expression term 'partial'
+                // (1,12): error CS7017: Member definition, statement, or end-of-file expected
                 // new partial.partial Goo();
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "partial").WithArguments("partial").WithLocation(1, 13),
-                // (1,13): error CS1002: ; expected
+                Diagnostic(ErrorCode.ERR_GlobalDefinitionOrStatementExpected, ".").WithLocation(1, 12),
+                // (1,12): error CS1519: Invalid token '.' in a member declaration
                 // new partial.partial Goo();
-                Diagnostic(ErrorCode.ERR_SemicolonExpected, "partial").WithLocation(1, 13),
+                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, ".").WithArguments(".").WithLocation(1, 12),
                 // (1,21): error CS1520: Method must have a return type
                 // new partial.partial Goo();
                 Diagnostic(ErrorCode.ERR_MemberNeedsType, "Goo").WithLocation(1, 21));
 
             N(SyntaxKind.CompilationUnit);
             {
-                N(SyntaxKind.GlobalStatement);
-                {
-                    N(SyntaxKind.ExpressionStatement);
-                    {
-                        N(SyntaxKind.ObjectCreationExpression);
-                        {
-                            N(SyntaxKind.NewKeyword);
-                            N(SyntaxKind.QualifiedName);
-                            {
-                                N(SyntaxKind.IdentifierName);
-                                {
-                                    N(SyntaxKind.IdentifierToken, "partial");
-                                }
-                                N(SyntaxKind.DotToken);
-                                M(SyntaxKind.IdentifierName);
-                                {
-                                    M(SyntaxKind.IdentifierToken);
-                                }
-                            }
-                            M(SyntaxKind.ArgumentList);
-                            {
-                                M(SyntaxKind.OpenParenToken);
-                                M(SyntaxKind.CloseParenToken);
-                            }
-                        }
-                        M(SyntaxKind.SemicolonToken);
-                    }
-                }
                 N(SyntaxKind.MethodDeclaration);
                 {
                     N(SyntaxKind.PartialKeyword);
@@ -803,25 +795,41 @@ new partial.partial Goo();
             var src = """
 new partial partial Goo();
 """;
-            var tree = UsingTree(src, options: TestOptions.Regular13);
+            var tree = UsingTree(src, TestOptions.Regular13,
+                // (1,21): error CS0116: A namespace cannot directly contain members such as fields, methods or statements
+                // new partial partial Goo();
+                Diagnostic(ErrorCode.ERR_NamespaceUnexpected, "Goo").WithLocation(1, 21),
+                // (1,25): error CS1525: Invalid expression term ')'
+                // new partial partial Goo();
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, ")").WithArguments(")").WithLocation(1, 25));
 
             N(SyntaxKind.CompilationUnit);
             {
-                N(SyntaxKind.MethodDeclaration);
+                N(SyntaxKind.IncompleteMember);
                 {
                     N(SyntaxKind.NewKeyword);
                     N(SyntaxKind.PartialKeyword);
+                    N(SyntaxKind.PartialKeyword);
                     N(SyntaxKind.IdentifierName);
                     {
-                        N(SyntaxKind.IdentifierToken);
+                        N(SyntaxKind.IdentifierToken, "Goo");
                     }
-                    N(SyntaxKind.IdentifierToken);
-                    N(SyntaxKind.ParameterList);
+                }
+                N(SyntaxKind.GlobalStatement);
+                {
+                    N(SyntaxKind.ExpressionStatement);
                     {
-                        N(SyntaxKind.OpenParenToken);
-                        N(SyntaxKind.CloseParenToken);
+                        N(SyntaxKind.ParenthesizedExpression);
+                        {
+                            N(SyntaxKind.OpenParenToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
+                            N(SyntaxKind.CloseParenToken);
+                        }
+                        N(SyntaxKind.SemicolonToken);
                     }
-                    N(SyntaxKind.SemicolonToken);
                 }
                 N(SyntaxKind.EndOfFileToken);
             }
@@ -861,115 +869,61 @@ new partial partial Goo();
             var src = """
 new partial partial.partial partial();
 """;
-            var tree = UsingTree(src, options: TestOptions.Regular13);
+            var tree = UsingTree(src, TestOptions.Regular13,
+                // (1,13): error CS0116: A namespace cannot directly contain members such as fields, methods or statements
+                // new partial partial.partial partial();
+                Diagnostic(ErrorCode.ERR_NamespaceUnexpected, "partial").WithLocation(1, 13),
+                // (1,20): error CS1022: Type or namespace definition, or end-of-file expected
+                // new partial partial.partial partial();
+                Diagnostic(ErrorCode.ERR_EOFExpected, ".").WithLocation(1, 20));
 
             N(SyntaxKind.CompilationUnit);
             {
-                N(SyntaxKind.MethodDeclaration);
+                N(SyntaxKind.GlobalStatement);
                 {
-                    N(SyntaxKind.NewKeyword);
-                    N(SyntaxKind.PartialKeyword);
-                    N(SyntaxKind.QualifiedName);
-                    {
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                        N(SyntaxKind.DotToken);
-                        N(SyntaxKind.IdentifierName);
-                        {
-                            N(SyntaxKind.IdentifierToken);
-                        }
-                    }
-                    N(SyntaxKind.IdentifierToken);
-                    N(SyntaxKind.ParameterList);
-                    {
-                        N(SyntaxKind.OpenParenToken);
-                        N(SyntaxKind.CloseParenToken);
-                    }
-                    N(SyntaxKind.SemicolonToken);
-                }
-                N(SyntaxKind.EndOfFileToken);
-            }
-
-            tree = UsingTree(src,
-                // (1,21): error CS1525: Invalid expression term 'partial'
-                // new partial partial.partial partial();
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "partial").WithArguments("partial").WithLocation(1, 21),
-                // (1,21): error CS1003: Syntax error, '(' expected
-                // new partial partial.partial partial();
-                Diagnostic(ErrorCode.ERR_SyntaxError, "partial").WithArguments("(").WithLocation(1, 21),
-                // (1,36): error CS1001: Identifier expected
-                // new partial partial.partial partial();
-                Diagnostic(ErrorCode.ERR_IdentifierExpected, "(").WithLocation(1, 36),
-                // (1,36): error CS1003: Syntax error, ',' expected
-                // new partial partial.partial partial();
-                Diagnostic(ErrorCode.ERR_SyntaxError, "(").WithArguments(",").WithLocation(1, 36),
-                // (1,37): error CS8124: Tuple must contain at least two elements.
-                // new partial partial.partial partial();
-                Diagnostic(ErrorCode.ERR_TupleTooFewElements, ")").WithLocation(1, 37),
-                // (1,38): error CS1001: Identifier expected
-                // new partial partial.partial partial();
-                Diagnostic(ErrorCode.ERR_IdentifierExpected, ";").WithLocation(1, 38),
-                // (1,38): error CS1026: ) expected
-                // new partial partial.partial partial();
-                Diagnostic(ErrorCode.ERR_CloseParenExpected, ";").WithLocation(1, 38));
-
-            N(SyntaxKind.CompilationUnit);
-            {
-                N(SyntaxKind.MethodDeclaration);
-                {
-                    N(SyntaxKind.NewKeyword);
-                    N(SyntaxKind.IdentifierName);
-                    {
-                        N(SyntaxKind.IdentifierToken, "partial");
-                    }
-                    N(SyntaxKind.ExplicitInterfaceSpecifier);
+                    N(SyntaxKind.LocalFunctionStatement);
                     {
                         N(SyntaxKind.IdentifierName);
                         {
                             N(SyntaxKind.IdentifierToken, "partial");
                         }
-                        N(SyntaxKind.DotToken);
+                        N(SyntaxKind.IdentifierToken, "partial");
+                        N(SyntaxKind.ParameterList);
+                        {
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.CloseParenToken);
+                        }
+                        N(SyntaxKind.SemicolonToken);
                     }
-                    M(SyntaxKind.IdentifierToken);
+                }
+                N(SyntaxKind.EndOfFileToken);
+            }
+
+            tree = UsingTree(src,
+                // (1,20): error CS7017: Member definition, statement, or end-of-file expected
+                // new partial partial.partial partial();
+                Diagnostic(ErrorCode.ERR_GlobalDefinitionOrStatementExpected, ".").WithLocation(1, 20),
+                // (1,20): error CS1519: Invalid token '.' in a member declaration
+                // new partial partial.partial partial();
+                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, ".").WithArguments(".").WithLocation(1, 20),
+                // (1,29): error CS1520: Method must have a return type
+                // new partial partial.partial partial();
+                Diagnostic(ErrorCode.ERR_MemberNeedsType, "partial").WithLocation(1, 29));
+
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.MethodDeclaration);
+                {
+                    N(SyntaxKind.PartialKeyword);
+                    M(SyntaxKind.PredefinedType);
+                    {
+                        M(SyntaxKind.VoidKeyword);
+                    }
+                    N(SyntaxKind.IdentifierToken, "partial");
                     N(SyntaxKind.ParameterList);
                     {
-                        M(SyntaxKind.OpenParenToken);
-                        N(SyntaxKind.Parameter);
-                        {
-                            N(SyntaxKind.IdentifierName);
-                            {
-                                N(SyntaxKind.IdentifierToken, "partial");
-                            }
-                            M(SyntaxKind.IdentifierToken);
-                        }
-                        M(SyntaxKind.CommaToken);
-                        N(SyntaxKind.Parameter);
-                        {
-                            N(SyntaxKind.TupleType);
-                            {
-                                N(SyntaxKind.OpenParenToken);
-                                M(SyntaxKind.TupleElement);
-                                {
-                                    M(SyntaxKind.IdentifierName);
-                                    {
-                                        M(SyntaxKind.IdentifierToken);
-                                    }
-                                }
-                                M(SyntaxKind.CommaToken);
-                                M(SyntaxKind.TupleElement);
-                                {
-                                    M(SyntaxKind.IdentifierName);
-                                    {
-                                        M(SyntaxKind.IdentifierToken);
-                                    }
-                                }
-                                N(SyntaxKind.CloseParenToken);
-                            }
-                            M(SyntaxKind.IdentifierToken);
-                        }
-                        M(SyntaxKind.CloseParenToken);
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.CloseParenToken);
                     }
                     N(SyntaxKind.SemicolonToken);
                 }
@@ -1113,7 +1067,10 @@ new T[] this[int a] { get; }
 
             var tree = UsingTree(@"
 new partial partial this[int i] { get; }
-");
+",
+                // (2,21): error CS1031: Type expected
+                // new partial partial this[int i] { get; }
+                Diagnostic(ErrorCode.ERR_TypeExpected, "this").WithLocation(2, 21));
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -1121,9 +1078,10 @@ new partial partial this[int i] { get; }
                 {
                     N(SyntaxKind.NewKeyword);
                     N(SyntaxKind.PartialKeyword);
-                    N(SyntaxKind.IdentifierName);
+                    N(SyntaxKind.PartialKeyword);
+                    M(SyntaxKind.IdentifierName);
                     {
-                        N(SyntaxKind.IdentifierToken);
+                        M(SyntaxKind.IdentifierToken);
                     }
                     N(SyntaxKind.ThisKeyword);
                     N(SyntaxKind.BracketedParameterList);
@@ -2207,7 +2165,88 @@ partial partial Goo() { }
 partial partial[] Goo() { } 
 partial partial<int> Goo() { }
 """;
-            var tree = UsingTree(src, options: TestOptions.Regular13);
+            var tree = UsingTree(src, TestOptions.Regular13,
+                // (6,13): error CS1001: Identifier expected
+                // partial Goo { get; }
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "{").WithLocation(6, 13),
+                // (7,21): error CS1001: Identifier expected
+                // partial partial Goo { get; }
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "{").WithLocation(7, 21),
+                // (8,16): error CS1031: Type expected
+                // partial partial[] Goo { get; }
+                Diagnostic(ErrorCode.ERR_TypeExpected, "[").WithLocation(8, 16),
+                // (9,17): error CS1001: Identifier expected
+                // partial partial<int> Goo { get; }
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "int").WithLocation(9, 17),
+                // (9,17): error CS1003: Syntax error, ',' expected
+                // partial partial<int> Goo { get; }
+                Diagnostic(ErrorCode.ERR_SyntaxError, "int").WithArguments(",").WithLocation(9, 17),
+                // (9,22): error CS1003: Syntax error, '(' expected
+                // partial partial<int> Goo { get; }
+                Diagnostic(ErrorCode.ERR_SyntaxError, "Goo").WithArguments("(").WithLocation(9, 22),
+                // (9,26): error CS1001: Identifier expected
+                // partial partial<int> Goo { get; }
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "{").WithLocation(9, 26),
+                // (9,26): error CS1003: Syntax error, ',' expected
+                // partial partial<int> Goo { get; }
+                Diagnostic(ErrorCode.ERR_SyntaxError, "{").WithArguments(",").WithLocation(9, 26),
+                // (9,28): error CS1003: Syntax error, ',' expected
+                // partial partial<int> Goo { get; }
+                Diagnostic(ErrorCode.ERR_SyntaxError, "get").WithArguments(",").WithLocation(9, 28),
+                // (9,31): error CS1001: Identifier expected
+                // partial partial<int> Goo { get; }
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, ";").WithLocation(9, 31),
+                // (9,31): error CS1026: ) expected
+                // partial partial<int> Goo { get; }
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, ";").WithLocation(9, 31),
+                // (9,33): error CS1022: Type or namespace definition, or end-of-file expected
+                // partial partial<int> Goo { get; }
+                Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(9, 33),
+                // (12,17): error CS0116: A namespace cannot directly contain members such as fields, methods or statements
+                // partial partial Goo() { }
+                Diagnostic(ErrorCode.ERR_NamespaceUnexpected, "Goo").WithLocation(12, 17),
+                // (12,21): error CS1525: Invalid expression term ')'
+                // partial partial Goo() { }
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, ")").WithArguments(")").WithLocation(12, 21),
+                // (12,23): error CS1002: ; expected
+                // partial partial Goo() { }
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "{").WithLocation(12, 23),
+                // (13,16): error CS1031: Type expected
+                // partial partial[] Goo() { }
+                Diagnostic(ErrorCode.ERR_TypeExpected, "[").WithLocation(13, 16),
+                // (14,17): error CS1001: Identifier expected
+                // partial partial<int> Goo() { }
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "int").WithLocation(14, 17),
+                // (14,17): error CS1003: Syntax error, ',' expected
+                // partial partial<int> Goo() { }
+                Diagnostic(ErrorCode.ERR_SyntaxError, "int").WithArguments(",").WithLocation(14, 17),
+                // (14,22): error CS1003: Syntax error, '(' expected
+                // partial partial<int> Goo() { }
+                Diagnostic(ErrorCode.ERR_SyntaxError, "Goo").WithArguments("(").WithLocation(14, 22),
+                // (14,25): error CS1001: Identifier expected
+                // partial partial<int> Goo() { }
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "(").WithLocation(14, 25),
+                // (14,25): error CS1003: Syntax error, ',' expected
+                // partial partial<int> Goo() { }
+                Diagnostic(ErrorCode.ERR_SyntaxError, "(").WithArguments(",").WithLocation(14, 25),
+                // (14,26): error CS8124: Tuple must contain at least two elements.
+                // partial partial<int> Goo() { }
+                Diagnostic(ErrorCode.ERR_TupleTooFewElements, ")").WithLocation(14, 26),
+                // (14,28): error CS1001: Identifier expected
+                // partial partial<int> Goo() { }
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "{").WithLocation(14, 28),
+                // (14,28): error CS1003: Syntax error, ',' expected
+                // partial partial<int> Goo() { }
+                Diagnostic(ErrorCode.ERR_SyntaxError, "{").WithArguments(",").WithLocation(14, 28),
+                // (14,30): error CS1026: ) expected
+                // partial partial<int> Goo() { }
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, "}").WithLocation(14, 30),
+                // (14,30): error CS1002: ; expected
+                // partial partial<int> Goo() { }
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "}").WithLocation(14, 30),
+                // (14,30): error CS1022: Type or namespace definition, or end-of-file expected
+                // partial partial<int> Goo() { }
+                Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(14, 30));
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -2276,11 +2315,12 @@ partial partial<int> Goo() { }
                 }
                 N(SyntaxKind.PropertyDeclaration);
                 {
+                    N(SyntaxKind.PartialKeyword);
                     N(SyntaxKind.IdentifierName);
                     {
-                        N(SyntaxKind.IdentifierToken, "partial");
+                        N(SyntaxKind.IdentifierToken, "Goo");
                     }
-                    N(SyntaxKind.IdentifierToken, "Goo");
+                    M(SyntaxKind.IdentifierToken);
                     N(SyntaxKind.AccessorList);
                     {
                         N(SyntaxKind.OpenBraceToken);
@@ -2295,11 +2335,12 @@ partial partial<int> Goo() { }
                 N(SyntaxKind.PropertyDeclaration);
                 {
                     N(SyntaxKind.PartialKeyword);
+                    N(SyntaxKind.PartialKeyword);
                     N(SyntaxKind.IdentifierName);
                     {
-                        N(SyntaxKind.IdentifierToken, "partial");
+                        N(SyntaxKind.IdentifierToken, "Goo");
                     }
-                    N(SyntaxKind.IdentifierToken, "Goo");
+                    M(SyntaxKind.IdentifierToken);
                     N(SyntaxKind.AccessorList);
                     {
                         N(SyntaxKind.OpenBraceToken);
@@ -2313,12 +2354,13 @@ partial partial<int> Goo() { }
                 }
                 N(SyntaxKind.PropertyDeclaration);
                 {
+                    N(SyntaxKind.PartialKeyword);
                     N(SyntaxKind.PartialKeyword);
                     N(SyntaxKind.ArrayType);
                     {
-                        N(SyntaxKind.IdentifierName);
+                        M(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken, "partial");
+                            M(SyntaxKind.IdentifierToken);
                         }
                         N(SyntaxKind.ArrayRankSpecifier);
                         {
@@ -2342,32 +2384,47 @@ partial partial<int> Goo() { }
                         N(SyntaxKind.CloseBraceToken);
                     }
                 }
-                N(SyntaxKind.PropertyDeclaration);
+                N(SyntaxKind.GlobalStatement);
                 {
-                    N(SyntaxKind.PartialKeyword);
-                    N(SyntaxKind.GenericName);
+                    N(SyntaxKind.LocalFunctionStatement);
                     {
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "partial");
+                        }
                         N(SyntaxKind.IdentifierToken, "partial");
-                        N(SyntaxKind.TypeArgumentList);
+                        N(SyntaxKind.TypeParameterList);
                         {
                             N(SyntaxKind.LessThanToken);
-                            N(SyntaxKind.PredefinedType);
+                            M(SyntaxKind.TypeParameter);
                             {
-                                N(SyntaxKind.IntKeyword);
+                                M(SyntaxKind.IdentifierToken);
                             }
                             N(SyntaxKind.GreaterThanToken);
                         }
-                    }
-                    N(SyntaxKind.IdentifierToken, "Goo");
-                    N(SyntaxKind.AccessorList);
-                    {
-                        N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.GetAccessorDeclaration);
+                        N(SyntaxKind.ParameterList);
                         {
-                            N(SyntaxKind.GetKeyword);
-                            N(SyntaxKind.SemicolonToken);
+                            M(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.Parameter);
+                            {
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "Goo");
+                                }
+                                M(SyntaxKind.IdentifierToken);
+                            }
+                            M(SyntaxKind.CommaToken);
+                            N(SyntaxKind.Parameter);
+                            {
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "get");
+                                }
+                                M(SyntaxKind.IdentifierToken);
+                            }
+                            M(SyntaxKind.CloseParenToken);
                         }
-                        N(SyntaxKind.CloseBraceToken);
+                        N(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.GlobalStatement);
@@ -2391,19 +2448,33 @@ partial partial<int> Goo() { }
                         }
                     }
                 }
-                N(SyntaxKind.MethodDeclaration);
+                N(SyntaxKind.IncompleteMember);
                 {
+                    N(SyntaxKind.PartialKeyword);
                     N(SyntaxKind.PartialKeyword);
                     N(SyntaxKind.IdentifierName);
                     {
-                        N(SyntaxKind.IdentifierToken, "partial");
+                        N(SyntaxKind.IdentifierToken, "Goo");
                     }
-                    N(SyntaxKind.IdentifierToken, "Goo");
-                    N(SyntaxKind.ParameterList);
+                }
+                N(SyntaxKind.GlobalStatement);
+                {
+                    N(SyntaxKind.ExpressionStatement);
                     {
-                        N(SyntaxKind.OpenParenToken);
-                        N(SyntaxKind.CloseParenToken);
+                        N(SyntaxKind.ParenthesizedExpression);
+                        {
+                            N(SyntaxKind.OpenParenToken);
+                            M(SyntaxKind.IdentifierName);
+                            {
+                                M(SyntaxKind.IdentifierToken);
+                            }
+                            N(SyntaxKind.CloseParenToken);
+                        }
+                        M(SyntaxKind.SemicolonToken);
                     }
+                }
+                N(SyntaxKind.GlobalStatement);
+                {
                     N(SyntaxKind.Block);
                     {
                         N(SyntaxKind.OpenBraceToken);
@@ -2413,11 +2484,12 @@ partial partial<int> Goo() { }
                 N(SyntaxKind.MethodDeclaration);
                 {
                     N(SyntaxKind.PartialKeyword);
+                    N(SyntaxKind.PartialKeyword);
                     N(SyntaxKind.ArrayType);
                     {
-                        N(SyntaxKind.IdentifierName);
+                        M(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken, "partial");
+                            M(SyntaxKind.IdentifierToken);
                         }
                         N(SyntaxKind.ArrayRankSpecifier);
                         {
@@ -2441,32 +2513,63 @@ partial partial<int> Goo() { }
                         N(SyntaxKind.CloseBraceToken);
                     }
                 }
-                N(SyntaxKind.MethodDeclaration);
+                N(SyntaxKind.GlobalStatement);
                 {
-                    N(SyntaxKind.PartialKeyword);
-                    N(SyntaxKind.GenericName);
+                    N(SyntaxKind.LocalFunctionStatement);
                     {
+                        N(SyntaxKind.IdentifierName);
+                        {
+                            N(SyntaxKind.IdentifierToken, "partial");
+                        }
                         N(SyntaxKind.IdentifierToken, "partial");
-                        N(SyntaxKind.TypeArgumentList);
+                        N(SyntaxKind.TypeParameterList);
                         {
                             N(SyntaxKind.LessThanToken);
-                            N(SyntaxKind.PredefinedType);
+                            M(SyntaxKind.TypeParameter);
                             {
-                                N(SyntaxKind.IntKeyword);
+                                M(SyntaxKind.IdentifierToken);
                             }
                             N(SyntaxKind.GreaterThanToken);
                         }
-                    }
-                    N(SyntaxKind.IdentifierToken, "Goo");
-                    N(SyntaxKind.ParameterList);
-                    {
-                        N(SyntaxKind.OpenParenToken);
-                        N(SyntaxKind.CloseParenToken);
-                    }
-                    N(SyntaxKind.Block);
-                    {
-                        N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.CloseBraceToken);
+                        N(SyntaxKind.ParameterList);
+                        {
+                            M(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.Parameter);
+                            {
+                                N(SyntaxKind.IdentifierName);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "Goo");
+                                }
+                                M(SyntaxKind.IdentifierToken);
+                            }
+                            M(SyntaxKind.CommaToken);
+                            N(SyntaxKind.Parameter);
+                            {
+                                N(SyntaxKind.TupleType);
+                                {
+                                    N(SyntaxKind.OpenParenToken);
+                                    M(SyntaxKind.TupleElement);
+                                    {
+                                        M(SyntaxKind.IdentifierName);
+                                        {
+                                            M(SyntaxKind.IdentifierToken);
+                                        }
+                                    }
+                                    M(SyntaxKind.CommaToken);
+                                    M(SyntaxKind.TupleElement);
+                                    {
+                                        M(SyntaxKind.IdentifierName);
+                                        {
+                                            M(SyntaxKind.IdentifierToken);
+                                        }
+                                    }
+                                    N(SyntaxKind.CloseParenToken);
+                                }
+                                M(SyntaxKind.IdentifierToken);
+                            }
+                            M(SyntaxKind.CloseParenToken);
+                        }
+                        M(SyntaxKind.SemicolonToken);
                     }
                 }
                 N(SyntaxKind.EndOfFileToken);
@@ -2474,12 +2577,75 @@ partial partial<int> Goo() { }
             EOF();
 
             tree = UsingTree(src,
+                // (3,9): error CS1520: Method must have a return type
+                // partial partial;
+                Diagnostic(ErrorCode.ERR_MemberNeedsType, "partial").WithLocation(3, 9),
+                // (4,9): error CS1520: Method must have a return type
+                // partial partial = partial;
+                Diagnostic(ErrorCode.ERR_MemberNeedsType, "partial").WithLocation(4, 9),
+                // (6,13): error CS1001: Identifier expected
+                // partial Goo { get; }
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "{").WithLocation(6, 13),
+                // (7,21): error CS1001: Identifier expected
+                // partial partial Goo { get; }
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "{").WithLocation(7, 21),
+                // (8,16): error CS1031: Type expected
+                // partial partial[] Goo { get; }
+                Diagnostic(ErrorCode.ERR_TypeExpected, "[").WithLocation(8, 16),
+                // (9,9): error CS1520: Method must have a return type
+                // partial partial<int> Goo { get; }
+                Diagnostic(ErrorCode.ERR_MemberNeedsType, "partial").WithLocation(9, 9),
+                // (9,17): error CS1001: Identifier expected
+                // partial partial<int> Goo { get; }
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "int").WithLocation(9, 17),
+                // (9,17): error CS1003: Syntax error, ',' expected
+                // partial partial<int> Goo { get; }
+                Diagnostic(ErrorCode.ERR_SyntaxError, "int").WithArguments(",").WithLocation(9, 17),
+                // (9,22): error CS1003: Syntax error, '(' expected
+                // partial partial<int> Goo { get; }
+                Diagnostic(ErrorCode.ERR_SyntaxError, "Goo").WithArguments("(").WithLocation(9, 22),
+                // (9,26): error CS1001: Identifier expected
+                // partial partial<int> Goo { get; }
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "{").WithLocation(9, 26),
+                // (9,26): error CS1026: ) expected
+                // partial partial<int> Goo { get; }
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, "{").WithLocation(9, 26),
                 // (11,9): error CS1520: Method must have a return type
                 // partial Goo() { } 
                 Diagnostic(ErrorCode.ERR_MemberNeedsType, "Goo").WithLocation(11, 9),
                 // (12,17): error CS1520: Method must have a return type
                 // partial partial Goo() { } 
-                Diagnostic(ErrorCode.ERR_MemberNeedsType, "Goo").WithLocation(12, 17));
+                Diagnostic(ErrorCode.ERR_MemberNeedsType, "Goo").WithLocation(12, 17),
+                // (13,16): error CS1031: Type expected
+                // partial partial[] Goo() { }
+                Diagnostic(ErrorCode.ERR_TypeExpected, "[").WithLocation(13, 16),
+                // (14,9): error CS1520: Method must have a return type
+                // partial partial<int> Goo() { }
+                Diagnostic(ErrorCode.ERR_MemberNeedsType, "partial").WithLocation(14, 9),
+                // (14,17): error CS1001: Identifier expected
+                // partial partial<int> Goo() { }
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "int").WithLocation(14, 17),
+                // (14,17): error CS1003: Syntax error, ',' expected
+                // partial partial<int> Goo() { }
+                Diagnostic(ErrorCode.ERR_SyntaxError, "int").WithArguments(",").WithLocation(14, 17),
+                // (14,22): error CS1003: Syntax error, '(' expected
+                // partial partial<int> Goo() { }
+                Diagnostic(ErrorCode.ERR_SyntaxError, "Goo").WithArguments("(").WithLocation(14, 22),
+                // (14,25): error CS1001: Identifier expected
+                // partial partial<int> Goo() { }
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "(").WithLocation(14, 25),
+                // (14,25): error CS1003: Syntax error, ',' expected
+                // partial partial<int> Goo() { }
+                Diagnostic(ErrorCode.ERR_SyntaxError, "(").WithArguments(",").WithLocation(14, 25),
+                // (14,26): error CS8124: Tuple must contain at least two elements.
+                // partial partial<int> Goo() { }
+                Diagnostic(ErrorCode.ERR_TupleTooFewElements, ")").WithLocation(14, 26),
+                // (14,28): error CS1001: Identifier expected
+                // partial partial<int> Goo() { }
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "{").WithLocation(14, 28),
+                // (14,28): error CS1026: ) expected
+                // partial partial<int> Goo() { }
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, "{").WithLocation(14, 28));
 
             N(SyntaxKind.CompilationUnit);
             {
@@ -2504,11 +2670,12 @@ partial partial<int> Goo() { }
                 }
                 N(SyntaxKind.FieldDeclaration);
                 {
+                    N(SyntaxKind.PartialKeyword);
                     N(SyntaxKind.VariableDeclaration);
                     {
-                        N(SyntaxKind.IdentifierName);
+                        M(SyntaxKind.PredefinedType);
                         {
-                            N(SyntaxKind.IdentifierToken, "partial");
+                            M(SyntaxKind.VoidKeyword);
                         }
                         N(SyntaxKind.VariableDeclarator);
                         {
@@ -2519,11 +2686,12 @@ partial partial<int> Goo() { }
                 }
                 N(SyntaxKind.FieldDeclaration);
                 {
+                    N(SyntaxKind.PartialKeyword);
                     N(SyntaxKind.VariableDeclaration);
                     {
-                        N(SyntaxKind.IdentifierName);
+                        M(SyntaxKind.PredefinedType);
                         {
-                            N(SyntaxKind.IdentifierToken, "partial");
+                            M(SyntaxKind.VoidKeyword);
                         }
                         N(SyntaxKind.VariableDeclarator);
                         {
@@ -2542,11 +2710,12 @@ partial partial<int> Goo() { }
                 }
                 N(SyntaxKind.PropertyDeclaration);
                 {
+                    N(SyntaxKind.PartialKeyword);
                     N(SyntaxKind.IdentifierName);
                     {
-                        N(SyntaxKind.IdentifierToken, "partial");
+                        N(SyntaxKind.IdentifierToken, "Goo");
                     }
-                    N(SyntaxKind.IdentifierToken, "Goo");
+                    M(SyntaxKind.IdentifierToken);
                     N(SyntaxKind.AccessorList);
                     {
                         N(SyntaxKind.OpenBraceToken);
@@ -2561,11 +2730,12 @@ partial partial<int> Goo() { }
                 N(SyntaxKind.PropertyDeclaration);
                 {
                     N(SyntaxKind.PartialKeyword);
+                    N(SyntaxKind.PartialKeyword);
                     N(SyntaxKind.IdentifierName);
                     {
-                        N(SyntaxKind.IdentifierToken, "partial");
+                        N(SyntaxKind.IdentifierToken, "Goo");
                     }
-                    N(SyntaxKind.IdentifierToken, "Goo");
+                    M(SyntaxKind.IdentifierToken);
                     N(SyntaxKind.AccessorList);
                     {
                         N(SyntaxKind.OpenBraceToken);
@@ -2579,12 +2749,13 @@ partial partial<int> Goo() { }
                 }
                 N(SyntaxKind.PropertyDeclaration);
                 {
+                    N(SyntaxKind.PartialKeyword);
                     N(SyntaxKind.PartialKeyword);
                     N(SyntaxKind.ArrayType);
                     {
-                        N(SyntaxKind.IdentifierName);
+                        M(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken, "partial");
+                            M(SyntaxKind.IdentifierToken);
                         }
                         N(SyntaxKind.ArrayRankSpecifier);
                         {
@@ -2608,29 +2779,45 @@ partial partial<int> Goo() { }
                         N(SyntaxKind.CloseBraceToken);
                     }
                 }
-                N(SyntaxKind.PropertyDeclaration);
+                N(SyntaxKind.MethodDeclaration);
                 {
                     N(SyntaxKind.PartialKeyword);
-                    N(SyntaxKind.GenericName);
+                    M(SyntaxKind.PredefinedType);
                     {
-                        N(SyntaxKind.IdentifierToken, "partial");
-                        N(SyntaxKind.TypeArgumentList);
-                        {
-                            N(SyntaxKind.LessThanToken);
-                            N(SyntaxKind.PredefinedType);
-                            {
-                                N(SyntaxKind.IntKeyword);
-                            }
-                            N(SyntaxKind.GreaterThanToken);
-                        }
+                        M(SyntaxKind.VoidKeyword);
                     }
-                    N(SyntaxKind.IdentifierToken, "Goo");
-                    N(SyntaxKind.AccessorList);
+                    N(SyntaxKind.IdentifierToken, "partial");
+                    N(SyntaxKind.TypeParameterList);
+                    {
+                        N(SyntaxKind.LessThanToken);
+                        M(SyntaxKind.TypeParameter);
+                        {
+                            M(SyntaxKind.IdentifierToken);
+                        }
+                        N(SyntaxKind.GreaterThanToken);
+                    }
+                    N(SyntaxKind.ParameterList);
+                    {
+                        M(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.Parameter);
+                        {
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "Goo");
+                            }
+                            M(SyntaxKind.IdentifierToken);
+                        }
+                        M(SyntaxKind.CloseParenToken);
+                    }
+                    N(SyntaxKind.Block);
                     {
                         N(SyntaxKind.OpenBraceToken);
-                        N(SyntaxKind.GetAccessorDeclaration);
+                        N(SyntaxKind.ExpressionStatement);
                         {
-                            N(SyntaxKind.GetKeyword);
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "get");
+                            }
                             N(SyntaxKind.SemicolonToken);
                         }
                         N(SyntaxKind.CloseBraceToken);
@@ -2678,11 +2865,12 @@ partial partial<int> Goo() { }
                 N(SyntaxKind.MethodDeclaration);
                 {
                     N(SyntaxKind.PartialKeyword);
+                    N(SyntaxKind.PartialKeyword);
                     N(SyntaxKind.ArrayType);
                     {
-                        N(SyntaxKind.IdentifierName);
+                        M(SyntaxKind.IdentifierName);
                         {
-                            N(SyntaxKind.IdentifierToken, "partial");
+                            M(SyntaxKind.IdentifierToken);
                         }
                         N(SyntaxKind.ArrayRankSpecifier);
                         {
@@ -2709,24 +2897,57 @@ partial partial<int> Goo() { }
                 N(SyntaxKind.MethodDeclaration);
                 {
                     N(SyntaxKind.PartialKeyword);
-                    N(SyntaxKind.GenericName);
+                    M(SyntaxKind.PredefinedType);
                     {
-                        N(SyntaxKind.IdentifierToken, "partial");
-                        N(SyntaxKind.TypeArgumentList);
-                        {
-                            N(SyntaxKind.LessThanToken);
-                            N(SyntaxKind.PredefinedType);
-                            {
-                                N(SyntaxKind.IntKeyword);
-                            }
-                            N(SyntaxKind.GreaterThanToken);
-                        }
+                        M(SyntaxKind.VoidKeyword);
                     }
-                    N(SyntaxKind.IdentifierToken, "Goo");
+                    N(SyntaxKind.IdentifierToken, "partial");
+                    N(SyntaxKind.TypeParameterList);
+                    {
+                        N(SyntaxKind.LessThanToken);
+                        M(SyntaxKind.TypeParameter);
+                        {
+                            M(SyntaxKind.IdentifierToken);
+                        }
+                        N(SyntaxKind.GreaterThanToken);
+                    }
                     N(SyntaxKind.ParameterList);
                     {
-                        N(SyntaxKind.OpenParenToken);
-                        N(SyntaxKind.CloseParenToken);
+                        M(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.Parameter);
+                        {
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "Goo");
+                            }
+                            M(SyntaxKind.IdentifierToken);
+                        }
+                        M(SyntaxKind.CommaToken);
+                        N(SyntaxKind.Parameter);
+                        {
+                            N(SyntaxKind.TupleType);
+                            {
+                                N(SyntaxKind.OpenParenToken);
+                                M(SyntaxKind.TupleElement);
+                                {
+                                    M(SyntaxKind.IdentifierName);
+                                    {
+                                        M(SyntaxKind.IdentifierToken);
+                                    }
+                                }
+                                M(SyntaxKind.CommaToken);
+                                M(SyntaxKind.TupleElement);
+                                {
+                                    M(SyntaxKind.IdentifierName);
+                                    {
+                                        M(SyntaxKind.IdentifierToken);
+                                    }
+                                }
+                                N(SyntaxKind.CloseParenToken);
+                            }
+                            M(SyntaxKind.IdentifierToken);
+                        }
+                        M(SyntaxKind.CloseParenToken);
                     }
                     N(SyntaxKind.Block);
                     {

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/TopLevelStatementsParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/TopLevelStatementsParsingTests.cs
@@ -3546,18 +3546,12 @@ struct S { }
 partial ext X
 """;
             UsingTree(text,
-                // (1,13): error CS1031: Type expected
-                // struct S { }
-                Diagnostic(ErrorCode.ERR_TypeExpected, "").WithLocation(1, 13),
-                // (1,13): error CS1525: Invalid expression term 'partial'
-                // struct S { }
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "").WithArguments("partial").WithLocation(1, 13),
-                // (1,13): error CS1003: Syntax error, ',' expected
-                // struct S { }
-                Diagnostic(ErrorCode.ERR_SyntaxError, "").WithArguments(",").WithLocation(1, 13),
                 // (2,1): error CS8803: Top-level statements must precede namespace and type declarations.
                 // partial ext X
-                Diagnostic(ErrorCode.ERR_TopLevelStatementAfterNamespaceOrType, "partial").WithLocation(2, 1),
+                Diagnostic(ErrorCode.ERR_TopLevelStatementAfterNamespaceOrType, "partial ext X").WithLocation(2, 1),
+                // (2,13): error CS1003: Syntax error, ',' expected
+                // partial ext X
+                Diagnostic(ErrorCode.ERR_SyntaxError, "X").WithArguments(",").WithLocation(2, 13),
                 // (2,14): error CS1002: ; expected
                 // partial ext X
                 Diagnostic(ErrorCode.ERR_SemicolonExpected, "").WithLocation(2, 14));
@@ -3571,19 +3565,19 @@ partial ext X
                     N(SyntaxKind.OpenBraceToken);
                     N(SyntaxKind.CloseBraceToken);
                 }
-                M(SyntaxKind.GlobalStatement);
+                N(SyntaxKind.GlobalStatement);
                 {
-                    M(SyntaxKind.LocalDeclarationStatement);
+                    N(SyntaxKind.LocalDeclarationStatement);
                     {
-                        M(SyntaxKind.VariableDeclaration);
+                        N(SyntaxKind.VariableDeclaration);
                         {
-                            M(SyntaxKind.IdentifierName);
+                            N(SyntaxKind.IdentifierName);
                             {
-                                M(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "partial");
                             }
-                            M(SyntaxKind.VariableDeclarator);
+                            N(SyntaxKind.VariableDeclarator);
                             {
-                                M(SyntaxKind.IdentifierToken);
+                                N(SyntaxKind.IdentifierToken, "ext");
                             }
                         }
                         M(SyntaxKind.SemicolonToken);

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/UnionParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/UnionParsingTests.cs
@@ -385,63 +385,112 @@ ref union U1(E1);
 ref partial union U1(E1);
 """;
         UsingTree(src, TestOptions.Regular14,
-            // (1,24): error CS1001: Identifier expected
+            // (1,19): error CS1003: Syntax error, '=' expected
             // ref partial union U1(E1);
-            Diagnostic(ErrorCode.ERR_IdentifierExpected, ")").WithLocation(1, 24));
+            Diagnostic(ErrorCode.ERR_SyntaxError, "U1").WithArguments("=").WithLocation(1, 19));
 
         N(SyntaxKind.CompilationUnit);
         {
-            N(SyntaxKind.MethodDeclaration);
+            N(SyntaxKind.GlobalStatement);
             {
-                N(SyntaxKind.RefKeyword);
-                N(SyntaxKind.PartialKeyword);
-                N(SyntaxKind.IdentifierName);
+                N(SyntaxKind.LocalDeclarationStatement);
                 {
-                    N(SyntaxKind.IdentifierToken, "union");
-                }
-                N(SyntaxKind.IdentifierToken, "U1");
-                N(SyntaxKind.ParameterList);
-                {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.Parameter);
+                    N(SyntaxKind.VariableDeclaration);
                     {
-                        N(SyntaxKind.IdentifierName);
+                        N(SyntaxKind.RefType);
                         {
-                            N(SyntaxKind.IdentifierToken, "E1");
+                            N(SyntaxKind.RefKeyword);
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "partial");
+                            }
                         }
-                        M(SyntaxKind.IdentifierToken);
+                        N(SyntaxKind.VariableDeclarator);
+                        {
+                            N(SyntaxKind.IdentifierToken, "union");
+                            N(SyntaxKind.EqualsValueClause);
+                            {
+                                M(SyntaxKind.EqualsToken);
+                                N(SyntaxKind.InvocationExpression);
+                                {
+                                    N(SyntaxKind.IdentifierName);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "U1");
+                                    }
+                                    N(SyntaxKind.ArgumentList);
+                                    {
+                                        N(SyntaxKind.OpenParenToken);
+                                        N(SyntaxKind.Argument);
+                                        {
+                                            N(SyntaxKind.IdentifierName);
+                                            {
+                                                N(SyntaxKind.IdentifierToken, "E1");
+                                            }
+                                        }
+                                        N(SyntaxKind.CloseParenToken);
+                                    }
+                                }
+                            }
+                        }
                     }
-                    N(SyntaxKind.CloseParenToken);
+                    N(SyntaxKind.SemicolonToken);
                 }
-                N(SyntaxKind.SemicolonToken);
             }
             N(SyntaxKind.EndOfFileToken);
         }
         EOF();
 
-        UsingTree(src, useCSharp15 ? TestOptions.Regular15 : TestOptions.RegularPreview);
+        UsingTree(src, useCSharp15 ? TestOptions.Regular15 : TestOptions.RegularPreview,
+            // (1,19): error CS1003: Syntax error, '=' expected
+            // ref partial union U1(E1);
+            Diagnostic(ErrorCode.ERR_SyntaxError, "U1").WithArguments("=").WithLocation(1, 19));
 
         N(SyntaxKind.CompilationUnit);
         {
-            N(SyntaxKind.UnionDeclaration);
+            N(SyntaxKind.GlobalStatement);
             {
-                N(SyntaxKind.RefKeyword);
-                N(SyntaxKind.PartialKeyword);
-                N(SyntaxKind.UnionKeyword);
-                N(SyntaxKind.IdentifierToken, "U1");
-                N(SyntaxKind.ParameterList);
+                N(SyntaxKind.LocalDeclarationStatement);
                 {
-                    N(SyntaxKind.OpenParenToken);
-                    N(SyntaxKind.Parameter);
+                    N(SyntaxKind.VariableDeclaration);
                     {
-                        N(SyntaxKind.IdentifierName);
+                        N(SyntaxKind.RefType);
                         {
-                            N(SyntaxKind.IdentifierToken, "E1");
+                            N(SyntaxKind.RefKeyword);
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "partial");
+                            }
+                        }
+                        N(SyntaxKind.VariableDeclarator);
+                        {
+                            N(SyntaxKind.IdentifierToken, "union");
+                            N(SyntaxKind.EqualsValueClause);
+                            {
+                                M(SyntaxKind.EqualsToken);
+                                N(SyntaxKind.InvocationExpression);
+                                {
+                                    N(SyntaxKind.IdentifierName);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "U1");
+                                    }
+                                    N(SyntaxKind.ArgumentList);
+                                    {
+                                        N(SyntaxKind.OpenParenToken);
+                                        N(SyntaxKind.Argument);
+                                        {
+                                            N(SyntaxKind.IdentifierName);
+                                            {
+                                                N(SyntaxKind.IdentifierToken, "E1");
+                                            }
+                                        }
+                                        N(SyntaxKind.CloseParenToken);
+                                    }
+                                }
+                            }
                         }
                     }
-                    N(SyntaxKind.CloseParenToken);
+                    N(SyntaxKind.SemicolonToken);
                 }
-                N(SyntaxKind.SemicolonToken);
             }
             N(SyntaxKind.EndOfFileToken);
         }
@@ -450,9 +499,21 @@ ref partial union U1(E1);
         CreateCompilation(
             [src, "struct E1;", UnionAttributeSource, IUnionSource],
             parseOptions: useCSharp15 ? TestOptions.Regular15 : TestOptions.RegularPreview).VerifyDiagnostics(
-                // (1,19): error CS0106: The modifier 'ref' is not valid for this item
+                // (1,5): error CS0246: The type or namespace name 'partial' could not be found (are you missing a using directive or an assembly reference?)
                 // ref partial union U1(E1);
-                Diagnostic(ErrorCode.ERR_BadMemberFlag, "U1").WithArguments("ref").WithLocation(1, 19));
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "partial").WithArguments("partial").WithLocation(1, 5),
+                // (1,13): error CS8172: Cannot initialize a by-reference variable with a value
+                // ref partial union U1(E1);
+                Diagnostic(ErrorCode.ERR_InitializeByReferenceVariableWithValue, "union U1(E1)").WithLocation(1, 13),
+                // (1,19): error CS1003: Syntax error, '=' expected
+                // ref partial union U1(E1);
+                Diagnostic(ErrorCode.ERR_SyntaxError, "U1").WithArguments("=").WithLocation(1, 19),
+                // (1,19): error CS0103: The name 'U1' does not exist in the current context
+                // ref partial union U1(E1);
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "U1").WithArguments("U1").WithLocation(1, 19),
+                // (1,22): error CS0119: 'E1' is a type, which is not valid in the given context
+                // ref partial union U1(E1);
+                Diagnostic(ErrorCode.ERR_BadSKunknown, "E1").WithArguments("E1", "type").WithLocation(1, 22));
     }
 
     [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxTests.cs
@@ -112,7 +112,7 @@ void goo()
             AssertCompleteSubmission("interface goo {}");
             AssertCompleteSubmission("interface goo : {}");
 
-            AssertCompleteSubmission("partial");
+            AssertIncompleteSubmission("partial");
             AssertIncompleteSubmission("partial class");
 
             AssertIncompleteSubmission("int x = 1");


### PR DESCRIPTION
## Summary

Built on [#83216](https://github.com/dotnet/roslyn/pull/83216).

- Treat unescaped `partial` as a modifier in declaration heads in every language version.
- Remove legacy parsing that treated `partial` as a return type in ambiguous declarations.
- Require `@partial` when `partial` is intended as a type name.

## Rationale

C# warns about lowercase type names, and declaration forms such as records, unions, and extensions use contextual keywords in the same area. Keeping the legacy type-name interpretation for `partial` adds substantial lookahead and recovery complexity for little benefit. Escaping the identifier provides a clear spelling for code that intentionally names a type `partial`.

