### PR TITLE
Embed F# external access resources under the name their accessor asks for

### DIFF
--- a/src/VisualStudio/ExternalAccess/Core/Microsoft.VisualStudio.LanguageServices.ExternalAccess.csproj
+++ b/src/VisualStudio/ExternalAccess/Core/Microsoft.VisualStudio.LanguageServices.ExternalAccess.csproj
@@ -61,9 +61,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- The generated accessor looks the resources up under a namespace RootNamespace
+         cannot produce, so the manifest name has to be spelled out to match it. -->
     <EmbeddedResource Update="FSharp\ExternalAccessFSharpResources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>ExternalAccessFSharpResources.Designer.cs</LastGenOutput>
+      <LogicalName>Microsoft.CodeAnalysis.ExternalAccess.FSharp.ExternalAccessFSharpResources.resources</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
 


### PR DESCRIPTION
## Problem

Consolidating the ExternalAccess libraries (#81593) moved `ExternalAccessFSharpResources.resx` into `Microsoft.VisualStudio.LanguageServices.ExternalAccess.csproj`, whose `RootNamespace` is `Microsoft.VisualStudio.LanguageServices.ExternalAccess`. MSBuild derives the manifest resource name from that root namespace plus the containing folder, so the resource is now embedded as:

```
Microsoft.VisualStudio.LanguageServices.ExternalAccess.FSharp.ExternalAccessFSharpResources.resources
```

The generated `ExternalAccessFSharpResources.Designer.cs` kept its pre-consolidation namespace and still asks the `ResourceManager` for:

```
Microsoft.CodeAnalysis.ExternalAccess.FSharp.ExternalAccessFSharpResources
```

Reading any property on `ExternalAccessFSharpResources` (`CannotDetermineSymbol`, `NavigatingTo`, `SimplifyName`, the F# classification-type names, etc.) throws `MissingManifestResourceException` at runtime — verified against a live VS session hosting FSharp.Editor.

## Fix

Set `LogicalName` explicitly on the `EmbeddedResource` item so the embedded manifest name matches what the generated accessor looks up, regardless of the project's `RootNamespace`. Verified the rebuilt DLL's manifest lists the resource under the expected name for both the neutral resources and the `.resources.dll` satellites (XlfTasks' `AdjustLogicalName` appends the culture automatically).

## Test plan

- [x] Rebuilt `Microsoft.VisualStudio.LanguageServices.ExternalAccess.csproj` and confirmed via `ildasm`/manifest inspection that the neutral and satellite (`ru`) resources are now embedded as `Microsoft.CodeAnalysis.ExternalAccess.FSharp.ExternalAccessFSharpResources[.ru].resources`.
- [x] Full `Roslyn.slnx` Debug build with `-deployExtensions` succeeded and deployed into the `RoslynDev` experimental hive; the deployed assembly carries the corrected manifest name.
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85095)