### PR TITLE
Fix local error type assert in nullable analysis

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -3246,7 +3246,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // When the local is used before or during initialization, there can potentially be a mismatch between node.LocalSymbol.Type and node.Type. We
                 // need to prefer node.Type as we shouldn't be changing the type of the BoundLocal node during rewrite.
                 // https://github.com/dotnet/roslyn/issues/34158
-                Debug.Assert(node.Type.IsErrorType() || type.Type.IsErrorType());
+                Debug.Assert(node.Type.ContainsErrorType() || type.Type.ContainsErrorType());
                 type = TypeWithAnnotations.Create(node.Type, type.NullableAnnotation);
             }
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/AnonymousTypesSemanticsTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/AnonymousTypesSemanticsTests.cs
@@ -1775,6 +1775,26 @@ public class Program
 }").VerifyDiagnostics();
         }
 
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/84675")]
+        public void InvalidCompoundAssignmentInAnonymousTypeInitializer()
+        {
+            var source = """
+                class C
+                {
+                    static void M()
+                    {
+                        var v = new { F = 0 += 0 };
+                        _ = v.F;
+                    }
+                }
+                """;
+
+            CreateCompilation(source).VerifyEmitDiagnostics(
+                // (5,27): error CS0131: The left-hand side of an assignment must be a variable, property or indexer
+                //         var v = new { F = 0 += 0 };
+                Diagnostic(ErrorCode.ERR_AssgLvalueExpected, "0").WithLocation(5, 27));
+        }
+
         [CompilerTrait(CompilerFeature.IOperation)]
         [Fact, WorkItem(22588, "https://github.com/dotnet/roslyn/issues/22588")]
         public void AnonymousTypeSymbols_ErrorCases()


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/84675.

The outer type was a valid anonymous type containing an error type which the assert didn't handle.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85103)