### PR TITLE
Use case-insensitive Language Server path semantics

### DIFF
--- a/src/LanguageServer/BannedSymbols.txt
+++ b/src/LanguageServer/BannedSymbols.txt
@@ -21,3 +21,4 @@ M:System.Uri.#ctor(System.Uri,System.String,System.Boolean); Use Extensions.GetU
 M:System.Uri.TryCreate(System.String,System.UriKind,System.Uri@); Use Extensions.GetURI() if you have a document, or ProtocolConversions.CreateAbsoluteUri if you are sure the path is a real file path and not a generated file path
 M:System.Uri.TryCreate(System.Uri,System.String,System.Uri@); Use Extensions.GetURI() if you have a document, or ProtocolConversions.CreateAbsoluteUri if you are sure the path is a real file path and not a generated file path
 M:System.Uri.TryCreate(System.Uri,System.Uri,System.Uri@); Use Extensions.GetURI() if you have a document, or ProtocolConversions.CreateAbsoluteUri if you are sure the path is a real file path and not a generated file path
+F:Roslyn.Utilities.PathUtilities.Comparer; Use StringComparer.OrdinalIgnoreCase for path comparisons in the Language Server

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/HostWorkspace/SharedMetadataReferenceCacheTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/HostWorkspace/SharedMetadataReferenceCacheTests.cs
@@ -192,21 +192,44 @@ public sealed class SharedMetadataReferenceCacheTests : TestBase
         Assert.NotSame(assemblyReference.GetMetadataId(), moduleReference.GetMetadataId());
     }
 
-    [ConditionalFact(typeof(LinuxOnly))]
-    public void PathsDifferingOnlyByCase_DoNotShareReferenceOnCaseSensitiveFileSystem()
+    [Fact]
+    public void PathsDifferingOnlyByCase_ShareReference()
     {
         var cache = new SharedMetadataReferenceCache();
         var directory = Temp.CreateDirectory();
         var lowerCasePath = Path.Combine(directory.Path, "reference.dll");
         var upperCasePath = Path.Combine(directory.Path, "REFERENCE.dll");
+        var timestamp = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         File.Copy(typeof(object).Assembly.Location, lowerCasePath);
-        File.Copy(typeof(object).Assembly.Location, upperCasePath);
+        File.SetLastWriteTimeUtc(lowerCasePath, timestamp);
+
+        // On a case-insensitive file system these paths refer to the same file. On a case-sensitive
+        // file system, create the second path so both cache lookups observe the same file timestamp.
+        if (!File.Exists(upperCasePath))
+        {
+            File.Copy(lowerCasePath, upperCasePath);
+            File.SetLastWriteTimeUtc(upperCasePath, timestamp);
+        }
 
         var lowerCaseReference = GetReference(cache, lowerCasePath);
         var upperCaseReference = GetReference(cache, upperCasePath);
 
-        Assert.NotSame(lowerCaseReference, upperCaseReference);
-        Assert.Equal(2, cache.GetTestAccessor().EntryCount);
+        Assert.Same(lowerCaseReference, upperCaseReference);
+        Assert.Equal(1, cache.GetTestAccessor().EntryCount);
+    }
+
+    [ConditionalFact(typeof(WindowsOnly))]
+    public void PathsDifferingOnlyByDirectorySeparator_ShareReference()
+    {
+        var cache = new SharedMetadataReferenceCache();
+        var path = typeof(object).Assembly.Location;
+        var alternatePath = path.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+        var reference = GetReference(cache, path);
+        var alternateReference = GetReference(cache, alternatePath);
+
+        Assert.Same(reference, alternateReference);
+        Assert.Equal(1, cache.GetTestAccessor().EntryCount);
     }
 
     [Fact]

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectSystem.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/LanguageServerProjectSystem.cs
@@ -98,7 +98,7 @@ internal sealed class LanguageServerProjectSystem : LanguageServerProjectLoader,
         try
         {
             var (_, projects) = await SolutionFileReader.ReadSolutionFileAsync(solutionPath, DiagnosticReportingMode.Throw, cancellationToken);
-            solutionProjectPaths = projects.Select(static p => p.ProjectPath).ToImmutableHashSet(PathUtilities.Comparer);
+            solutionProjectPaths = projects.Select(static p => p.ProjectPath).ToImmutableHashSet(StringComparer.OrdinalIgnoreCase);
         }
         catch (Exception e) when (e is not OperationCanceledException)
         {

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/SharedMetadataReferenceCache.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/HostWorkspace/SharedMetadataReferenceCache.cs
@@ -168,18 +168,19 @@ internal sealed class SharedMetadataReferenceCache(int cleanupThreshold = 500)
 
     private readonly struct CacheKey(string fullPath, MetadataImageKind kind) : IEquatable<CacheKey>
     {
-        private readonly string _fullPath = fullPath;
+        // Both separators are accepted for Windows paths, so use one stable representation for the cache key.
+        private readonly string _fullPath = fullPath.Replace('\\', '/');
         private readonly MetadataImageKind _kind = kind;
 
         public bool Equals(CacheKey other)
             => _kind == other._kind
-                && PathUtilities.Comparer.Equals(_fullPath, other._fullPath);
+                && StringComparer.OrdinalIgnoreCase.Equals(_fullPath, other._fullPath);
 
         public override bool Equals(object? obj)
             => obj is CacheKey other && Equals(other);
 
         public override int GetHashCode()
-            => Hash.Combine((int)_kind, PathUtilities.Comparer.GetHashCode(_fullPath));
+            => Hash.Combine((int)_kind, StringComparer.OrdinalIgnoreCase.GetHashCode(_fullPath));
     }
 
     internal readonly struct TestAccessor(SharedMetadataReferenceCache cache)

--- a/src/LanguageServer/Protocol/Protocol/DocumentUri.cs
+++ b/src/LanguageServer/Protocol/Protocol/DocumentUri.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 
 namespace Roslyn.LanguageServer.Protocol;
@@ -117,5 +118,41 @@ internal sealed record class DocumentUri(string UriString)
         return this.ParsedUri.IsAbsoluteUri
             ? StringComparer.OrdinalIgnoreCase.GetHashCode(this.ParsedUri.AbsoluteUri)
             : this.ParsedUri.GetHashCode();
+    }
+}
+
+internal sealed class DocumentUriComparer : IEqualityComparer<DocumentUri>
+{
+    public static readonly DocumentUriComparer Instance = new();
+
+    private DocumentUriComparer()
+    {
+    }
+
+    public bool Equals(DocumentUri? left, DocumentUri? right)
+    {
+        if (ReferenceEquals(left, right))
+            return true;
+
+        if (left is null || right is null)
+            return false;
+
+        if (left.Equals(right))
+            return true;
+
+        return left.ParsedUri?.IsFile == true &&
+            right.ParsedUri?.IsFile == true &&
+            StringComparer.OrdinalIgnoreCase.Equals(left.ParsedUri.Host, right.ParsedUri.Host) &&
+            StringComparer.OrdinalIgnoreCase.Equals(left.ParsedUri.LocalPath, right.ParsedUri.LocalPath);
+    }
+
+    public int GetHashCode(DocumentUri uri)
+    {
+        if (uri.ParsedUri?.IsFile != true)
+            return uri.GetHashCode();
+
+        return HashCode.Combine(
+            StringComparer.OrdinalIgnoreCase.GetHashCode(uri.ParsedUri.Host),
+            StringComparer.OrdinalIgnoreCase.GetHashCode(uri.ParsedUri.LocalPath));
     }
 }

--- a/src/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
+++ b/src/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
@@ -62,7 +62,8 @@ internal sealed class LspWorkspaceManager : IDocumentChangeTracker, ILspService
     /// the URI.
     /// <para/> Access to this is guaranteed to be serial by the <see cref="RequestExecutionQueue{RequestContextType}"/>
     /// </summary>
-    private ImmutableDictionary<DocumentUri, TrackedDocumentInfo> _trackedDocuments = ImmutableDictionary<DocumentUri, TrackedDocumentInfo>.Empty;
+    private ImmutableDictionary<DocumentUri, TrackedDocumentInfo> _trackedDocuments =
+        ImmutableDictionary<DocumentUri, TrackedDocumentInfo>.Empty.WithComparers(DocumentUriComparer.Instance);
 
     private readonly ILspLogger _logger;
     private readonly ILspMiscellaneousFilesWorkspaceProvider? _lspMiscellaneousFilesWorkspaceProvider;

--- a/src/LanguageServer/ProtocolUnitTests/UriTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/UriTests.cs
@@ -220,7 +220,7 @@ public sealed class UriTests : AbstractLanguageServerProtocolTests
         await using var testLspServer = await CreateTestLspServerAsync(string.Empty, mutatingLspWorkspace, new InitializationOptions { ServerKind = WellKnownLspServerKinds.CSharpVisualBasicLspServer });
 
         var upperCaseUri = new DocumentUri(@"file:///C:/Users/dabarbet/source/repos/XUnitApp1/UnitTest1.cs");
-        var lowerCaseUri = new DocumentUri(@"file:///c:/Users/dabarbet/source/repos/XUnitApp1/UnitTest1.cs");
+        var lowerCaseUri = new DocumentUri(@"file:///c:/users/dabarbet/source/repos/xunitapp1/unittest1.cs");
 
         // Execute the request as JSON directly to avoid the test client serializing System.Uri.
         var requestJson = $$$"""


### PR DESCRIPTION
## Summary

Use consistent ordinal-ignore-case identity for local paths throughout the Language Server, independent of the host platform.

- Add a file-aware `DocumentUriComparer` while preserving normal equality for non-file URIs.
- Use it for tracked LSP documents.
- Make the shared metadata-reference cache use ordinal-ignore-case paths.
- Ban `PathUtilities.Comparer` under the Language Server to prevent platform-dependent path identity.

## Validation

- Protocol `UriTests`
- `SharedMetadataReferenceCacheTests`
- Analyzer-enabled Language Server build at this PR head
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85104)