### PR TITLE
Centralize Language Server workspace folder tracking

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/MiscellaneousFiles/CsprojInConeCheckerTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/MiscellaneousFiles/CsprojInConeCheckerTests.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.LanguageServer.FileBasedPrograms;
+using Microsoft.CodeAnalysis.LanguageServer.Handler;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.LanguageServer.Protocol;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.UnitTests.FileBasedPrograms;
+
+public sealed class CsprojInConeCheckerTests : IDisposable
+{
+    private readonly TempRoot _tempRoot = new();
+
+    public void Dispose()
+        => _tempRoot.Dispose();
+
+    [Fact]
+    public void UsesCurrentWorkspaceFolders()
+    {
+        var initialWorkspace = _tempRoot.CreateDirectory();
+        var projectWorkspace = _tempRoot.CreateDirectory();
+        projectWorkspace.CreateFile("Project.csproj");
+        var sourceFile = projectWorkspace.CreateDirectory("src").CreateFile("Program.cs");
+        var initialFolder = CreateWorkspaceFolder(initialWorkspace.Path);
+        var projectFolder = CreateWorkspaceFolder(projectWorkspace.Path);
+        var tracker = new WorkspaceFolderTracker();
+        tracker.Update([initialFolder], removedFolders: null);
+        var checker = new CsprojInConeChecker(tracker);
+
+        Assert.False(checker.IsContainedInCsprojCone(sourceFile.Path));
+
+        tracker.Update([projectFolder], [initialFolder]);
+
+        Assert.True(checker.IsContainedInCsprojCone(sourceFile.Path));
+    }
+
+    private static WorkspaceFolder CreateWorkspaceFolder(string path)
+        => new()
+        {
+            DocumentUri = ProtocolConversions.CreateAbsoluteDocumentUri(path),
+            Name = Path.GetFileName(path),
+        };
+}

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/MiscellaneousFiles/FileBasedProgramsEntryPointDiscoveryTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/MiscellaneousFiles/FileBasedProgramsEntryPointDiscoveryTests.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using Microsoft.CodeAnalysis.FileBasedPrograms;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.LanguageServer.FileBasedPrograms;
+using Microsoft.CodeAnalysis.LanguageServer.Handler;
 using Microsoft.CodeAnalysis.LanguageServer.HostWorkspace;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
@@ -276,9 +277,44 @@ public sealed class FileBasedProgramsEntryPointDiscoveryTests : AbstractLanguage
         DeferDeleteCacheDirectory(testLspServer, tempDir.Path);
 
         var discovery = testLspServer.GetRequiredLspService<FileBasedProgramsEntryPointDiscovery>();
-        await discovery.FindAndLoadEntryPointsAsync();
+        await discovery.FindAndLoadEntryPointsAsync(CancellationToken.None);
         await testLspServer.TestWorkspace.GetService<AsynchronousOperationListenerProvider>().GetWaiter(FeatureAttribute.Workspace).ExpeditedWaitAsync();
         var (workspace, document) = await GetRequiredLspWorkspaceAndDocumentAsync(CreateAbsoluteDocumentUri(appFile.Path), testLspServer);
+        Assert.Equal(WorkspaceKind.Host, workspace.Kind);
+        Assert.NotNull(document);
+    }
+
+    [Fact]
+    public async Task TestDiscovery_WorkspaceFoldersChangedRefreshes()
+    {
+        var removedWorkspace = _tempRoot.CreateDirectory();
+        var addedWorkspace = _tempRoot.CreateDirectory();
+
+        await using var testLspServer = await CreateTestLspServerAsync(string.Empty, mutatingLspWorkspace: false, new InitializationOptions
+        {
+            ServerKind = WellKnownLspServerKinds.CSharpVisualBasicLspServer,
+            OptionUpdater = options => options.SetGlobalOption(LanguageServerProjectSystemOptionsStorage.EnableFileBasedPrograms, true),
+            WorkspaceFolders =
+            [
+                new() { DocumentUri = CreateAbsoluteDocumentUri(removedWorkspace.Path), Name = "removed" }
+            ]
+        });
+        DeferDeleteCacheDirectory(testLspServer, removedWorkspace.Path);
+        DeferDeleteCacheDirectory(testLspServer, addedWorkspace.Path);
+        await testLspServer.TestWorkspace.GetService<AsynchronousOperationListenerProvider>().GetWaiter(FeatureAttribute.Workspace).ExpeditedWaitAsync();
+
+        var appText = "#!/usr/bin/env dotnet";
+        var removedApp = removedWorkspace.CreateFile("Removed.cs").WriteAllText(appText);
+        var addedApp = addedWorkspace.CreateFile("Added.cs").WriteAllText(appText);
+        var workspaceFolderTracker = testLspServer.GetRequiredLspService<IWorkspaceFolderTracker>();
+        workspaceFolderTracker.Update(
+            [new() { DocumentUri = CreateAbsoluteDocumentUri(addedWorkspace.Path), Name = "added" }],
+            [new() { DocumentUri = CreateAbsoluteDocumentUri(removedWorkspace.Path), Name = "removed" }]);
+
+        await testLspServer.TestWorkspace.GetService<AsynchronousOperationListenerProvider>().GetWaiter(FeatureAttribute.Workspace).ExpeditedWaitAsync();
+
+        AssertDocumentNotPersisted(testLspServer, CreateAbsoluteDocumentUri(removedApp.Path));
+        var (workspace, document) = await GetRequiredLspWorkspaceAndDocumentAsync(CreateAbsoluteDocumentUri(addedApp.Path), testLspServer);
         Assert.Equal(WorkspaceKind.Host, workspace.Kind);
         Assert.NotNull(document);
     }
@@ -309,7 +345,7 @@ public sealed class FileBasedProgramsEntryPointDiscoveryTests : AbstractLanguage
         DeferDeleteCacheDirectory(testLspServer, tempDir.Path);
 
         var discovery = testLspServer.GetRequiredLspService<FileBasedProgramsEntryPointDiscovery>();
-        await discovery.FindAndLoadEntryPointsAsync();
+        await discovery.FindAndLoadEntryPointsAsync(CancellationToken.None);
         await testLspServer.TestWorkspace.GetService<AsynchronousOperationListenerProvider>().GetWaiter(FeatureAttribute.Workspace).ExpeditedWaitAsync();
         AssertDocumentNotPersisted(testLspServer, CreateAbsoluteDocumentUri(appFile.Path));
     }
@@ -331,7 +367,7 @@ public sealed class FileBasedProgramsEntryPointDiscoveryTests : AbstractLanguage
         await using var testLspServer = await CreateDiscoveryTestServerAsync(tempDir.Path);
 
         var discovery = testLspServer.GetRequiredLspService<FileBasedProgramsEntryPointDiscovery>();
-        await discovery.FindAndLoadEntryPointsAsync();
+        await discovery.FindAndLoadEntryPointsAsync(CancellationToken.None);
         await testLspServer.TestWorkspace.GetService<AsynchronousOperationListenerProvider>().GetWaiter(FeatureAttribute.Workspace).ExpeditedWaitAsync();
         AssertDocumentNotPersisted(testLspServer, CreateAbsoluteDocumentUri(appFile.Path));
     }

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/MiscellaneousFiles/FileBasedProgramsWorkspaceTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/MiscellaneousFiles/FileBasedProgramsWorkspaceTests.cs
@@ -203,7 +203,7 @@ public sealed class FileBasedProgramsWorkspaceTests(ITestOutputHelper testOutput
         var globalOptions = testLspServer.TestWorkspace.ExportProvider.GetExportedValue<IGlobalOptionService>();
         globalOptions.SetGlobalOption(FileBasedAppsOptionsStorage.EnableAutomaticDiscovery, true);
         var discovery = testLspServer.GetRequiredLspService<FileBasedProgramsEntryPointDiscovery>();
-        await discovery.FindAndLoadEntryPointsAsync();
+        await discovery.FindAndLoadEntryPointsAsync(CancellationToken.None);
         await testLspServer.TestWorkspace.GetService<AsynchronousOperationListenerProvider>().GetWaiter(FeatureAttribute.Workspace).ExpeditedWaitAsync();
 
         // Verify all FBAs loaded successfully in the host workspace.
@@ -1282,7 +1282,7 @@ public sealed class FileBasedProgramsWorkspaceTests(ITestOutputHelper testOutput
         var globalOptions = testLspServer.TestWorkspace.ExportProvider.GetExportedValue<IGlobalOptionService>();
         globalOptions.SetGlobalOption(FileBasedAppsOptionsStorage.EnableAutomaticDiscovery, true);
         var discovery = testLspServer.GetRequiredLspService<FileBasedProgramsEntryPointDiscovery>();
-        await discovery.FindAndLoadEntryPointsAsync();
+        await discovery.FindAndLoadEntryPointsAsync(CancellationToken.None);
         await testLspServer.TestWorkspace.GetService<AsynchronousOperationListenerProvider>().GetWaiter(FeatureAttribute.Workspace).ExpeditedWaitAsync();
 
         // Even though the primary file was never opened in the editor,

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/FileBasedPrograms/CsprojInConeChecker.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/FileBasedPrograms/CsprojInConeChecker.cs
@@ -1,8 +1,7 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Immutable;
 using System.Composition;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageServer.Handler;
@@ -20,35 +19,28 @@ internal sealed class CsprojInConeCheckerFactory() : ILspServiceFactory
 {
     public ILspService CreateILspService(LspServices lspServices, WellKnownLspServerKinds serverKind)
     {
-        return new CsprojInConeChecker();
+        return new CsprojInConeChecker(lspServices.GetRequiredService<IWorkspaceFolderTracker>());
     }
 }
 
-internal sealed class CsprojInConeChecker : ILspService, IOnInitialized
+internal sealed class CsprojInConeChecker(IWorkspaceFolderTracker workspaceFolderTracker) : ILspService
 {
-    private ImmutableArray<string> _workspaceFolders;
-
-    public Task OnInitializedAsync(ClientCapabilities clientCapabilities, RequestContext context, CancellationToken cancellationToken)
-    {
-        var initializeManager = context.GetRequiredService<IInitializeManager>();
-        _workspaceFolders = initializeManager.GetRequiredWorkspaceFolderPaths();
-        return Task.CompletedTask;
-    }
-
     public bool IsContainedInCsprojCone(string csFilePath)
     {
         // Note: manual perf testing of this check on Windows, in a reasonably complex case,
         // showed an overhead on the order of 100s of microseconds for this check.
         // If this overhead becomes problematic, we may want to put a cache in front of it.
 
-        Contract.ThrowIfTrue(_workspaceFolders.IsDefault, $"{nameof(OnInitializedAsync)} must be called before {nameof(IsContainedInCsprojCone)}.");
-        if (_workspaceFolders.IsEmpty)
+        // Bound the search to workspace folders so opening an arbitrary file outside the workspace does not
+        // discover and load an unrelated project from one of its ancestor directories.
+        var workspaceFolders = workspaceFolderTracker.GetRequiredWorkspaceFolderPaths();
+        if (workspaceFolders.IsEmpty)
             return false;
 
         if (!PathUtilities.IsAbsolute(csFilePath))
             return false;
 
-        foreach (var workspaceFolder in _workspaceFolders)
+        foreach (var workspaceFolder in workspaceFolders)
         {
             var directoryName = PathUtilities.GetDirectoryName(csFilePath);
             while (PathUtilities.IsSameDirectoryOrChildOf(child: directoryName, parent: workspaceFolder))

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/FileBasedPrograms/FileBasedProgramsEntryPointDiscovery.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/FileBasedPrograms/FileBasedProgramsEntryPointDiscovery.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -20,6 +20,7 @@ using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Shared.Utilities;
+using Microsoft.CodeAnalysis.Threading;
 using Microsoft.Extensions.Logging;
 using Roslyn.LanguageServer.Protocol;
 using Roslyn.Utilities;
@@ -38,7 +39,8 @@ internal sealed class FileBasedProgramsEntryPointDiscoveryFactory(IGlobalOptionS
             globalOptionService,
             listenerProvider.GetListener(FeatureAttribute.Workspace),
             lspServices.GetRequiredService<IHostWorkspaceProvider>().Workspace.Services.GetRequiredService<IFileBasedProgramService>(),
-            lspServices.GetRequiredService<ILoggerFactory>(),
+            lspServices.GetRequiredService<ILoggerFactory>().CreateLogger<FileBasedProgramsEntryPointDiscovery>(),
+            lspServices.GetRequiredService<IWorkspaceFolderTracker>(),
             lspServices);
     }
 }
@@ -47,8 +49,9 @@ internal sealed partial class FileBasedProgramsEntryPointDiscovery(
     IGlobalOptionService globalOptionService,
     IAsynchronousOperationListener listener,
     IFileBasedProgramService fileBasedProgramService,
-    ILoggerFactory loggerFactory,
-    LspServices lspServices) : ILspService, IOnInitialized
+    ILogger logger,
+    IWorkspaceFolderTracker workspaceFolderTracker,
+    LspServices lspServices) : ILspService, IOnInitialized, IDisposable
 {
     private static readonly StringComparer s_pathComparer = StringComparer.OrdinalIgnoreCase;
 
@@ -61,48 +64,56 @@ internal sealed partial class FileBasedProgramsEntryPointDiscovery(
         "node_modules"
     ], StringComparison.OrdinalIgnoreCase);
 
-    private readonly ILogger _logger = loggerFactory.CreateLogger<FileBasedProgramsEntryPointDiscovery>();
-    private ImmutableArray<string> _workspaceFolders;
+    private readonly AsyncBatchingWorkQueue _discoveryQueue = new(
+        TimeSpan.Zero,
+        cancellationToken => FindAndLoadEntryPointsAsync(globalOptionService, fileBasedProgramService, workspaceFolderTracker, lspServices, logger, cancellationToken),
+        listener);
 
     public Task OnInitializedAsync(ClientCapabilities clientCapabilities, RequestContext context, CancellationToken cancellationToken)
     {
-        var initializeManager = context.GetRequiredService<IInitializeManager>();
-        _workspaceFolders = initializeManager.GetRequiredWorkspaceFolderPaths();
-        Task.Run(async () =>
-        {
-            try
-            {
-                using var token = listener.BeginAsyncOperation(nameof(FindAndLoadEntryPointsAsync));
-                await FindAndLoadEntryPointsAsync();
-            }
-            catch (Exception ex) when (FatalError.ReportAndCatch(ex))
-            {
-                throw ExceptionUtilities.Unreachable();
-            }
-        }, cancellationToken);
+        workspaceFolderTracker.WorkspaceFoldersChanged += OnWorkspaceFoldersChanged;
+        _discoveryQueue.AddWork();
 
         return Task.CompletedTask;
     }
 
-    internal async Task FindAndLoadEntryPointsAsync()
-    {
-        Contract.ThrowIfTrue(_workspaceFolders.IsDefault, $"{nameof(OnInitializedAsync)} must be called before {nameof(FindAndLoadEntryPointsAsync)}.");
+    private void OnWorkspaceFoldersChanged(ImmutableHashSet<string> _)
+        => _discoveryQueue.AddWork();
 
-        if (_workspaceFolders.IsEmpty)
+    public void Dispose()
+    {
+        workspaceFolderTracker.WorkspaceFoldersChanged -= OnWorkspaceFoldersChanged;
+        _discoveryQueue.Dispose();
+    }
+
+    internal ValueTask FindAndLoadEntryPointsAsync(CancellationToken cancellationToken)
+        => FindAndLoadEntryPointsAsync(globalOptionService, fileBasedProgramService, workspaceFolderTracker, lspServices, logger, cancellationToken);
+
+    private static async ValueTask FindAndLoadEntryPointsAsync(
+        IGlobalOptionService globalOptionService,
+        IFileBasedProgramService fileBasedProgramService,
+        IWorkspaceFolderTracker workspaceFolderTracker,
+        LspServices lspServices,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var workspaceFolders = workspaceFolderTracker.GetRequiredWorkspaceFolderPaths();
+
+        if (workspaceFolders.IsEmpty)
         {
-            _logger.LogTrace("No workspace folders to search for file-based apps.");
+            logger.LogTrace("No workspace folders to search for file-based apps.");
             return;
         }
 
         if (!globalOptionService.GetOption(LanguageServerProjectSystemOptionsStorage.EnableFileBasedPrograms))
         {
-            _logger.LogTrace(@"""dotnet.projects.enableFileBasedPrograms"" is false. Not discovering entry points.");
+            logger.LogTrace(@"""dotnet.projects.enableFileBasedPrograms"" is false. Not discovering entry points.");
             return;
         }
 
         if (!globalOptionService.GetOption(FileBasedAppsOptionsStorage.EnableAutomaticDiscovery))
         {
-            _logger.LogTrace(@"""dotnet.fileBasedApps.enableAutomaticDiscovery"" is false. Not discovering entry points.");
+            logger.LogTrace(@"""dotnet.fileBasedApps.enableAutomaticDiscovery"" is false. Not discovering entry points.");
             return;
         }
 
@@ -111,10 +122,13 @@ internal sealed partial class FileBasedProgramsEntryPointDiscovery(
 
         // Note: the overwhelmingly common case is when there is just one workspace folder.
         // For simplicity we orient our search around one workspace folder at a time.
-        foreach (var workspaceFolder in _workspaceFolders)
+        foreach (var workspaceFolder in workspaceFolders)
         {
-            foreach (var fileBasedAppPath in FindEntryPoints(workspaceFolder))
+            cancellationToken.ThrowIfCancellationRequested();
+
+            foreach (var fileBasedAppPath in FindEntryPoints(workspaceFolder, fileBasedProgramService, logger))
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 await fileBasedProgramsProjectSystem.TryBeginLoadingFileBasedAppAsync(fileBasedAppPath);
             }
         }
@@ -146,6 +160,9 @@ internal sealed partial class FileBasedProgramsEntryPointDiscovery(
     }
 
     internal ImmutableArray<string> FindEntryPoints(string workspaceFolder)
+        => FindEntryPoints(workspaceFolder, fileBasedProgramService, logger);
+
+    private static ImmutableArray<string> FindEntryPoints(string workspaceFolder, IFileBasedProgramService fileBasedProgramService, ILogger logger)
     {
         var stopwatch = SharedStopwatch.StartNew();
         var cacheDirectory = fileBasedProgramService.GetDiscoveryCacheDirectory(workspaceFolder);
@@ -170,7 +187,7 @@ internal sealed partial class FileBasedProgramsEntryPointDiscovery(
         }
         catch (Exception ex)
         {
-            _logger.LogDebug("Could not read cache file: {ex.Message}", ex.Message);
+            logger.LogDebug("Could not read cache file: {ex.Message}", ex.Message);
         }
 
         cache ??= new Cache(workspaceFolder, DateTimeOffset.MinValue, FileBasedAppFullPaths: [], DirectoriesContainingCsproj: []);
@@ -193,10 +210,10 @@ internal sealed partial class FileBasedProgramsEntryPointDiscovery(
 
         var newFileBasedAppsBuilder = ArrayBuilder<string>.GetInstance(cache.FileBasedAppFullPaths.Length);
         var directoriesContainingCsprojBuilder = ArrayBuilder<string>.GetInstance(cache.DirectoriesContainingCsproj.Length);
-        var visitor = new WorkspaceFolderVisitor(cache, newFileBasedAppsBuilder, directoriesContainingCsprojBuilder, _logger);
+        var visitor = new WorkspaceFolderVisitor(cache, newFileBasedAppsBuilder, directoriesContainingCsprojBuilder, logger);
         visitor.Visit();
         var elapsedMilliseconds = Math.Round(stopwatch.Elapsed.TotalMilliseconds);
-        _logger.LogInformation("Finished discovery in '{workspaceFolder}' in {elapsedMilliseconds} milliseconds", workspaceFolder, elapsedMilliseconds);
+        logger.LogInformation("Finished discovery in '{workspaceFolder}' in {elapsedMilliseconds} milliseconds", workspaceFolder, elapsedMilliseconds);
 
         // Ensure items go into the cache file in a stable order.
         // This is useful for manual inspection and allows use of 'BinarySearch' to match directories against the cache.

--- a/src/LanguageServer/Protocol/Handler/IInitializeManager.cs
+++ b/src/LanguageServer/Protocol/Handler/IInitializeManager.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Immutable;
 using Roslyn.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler;
@@ -14,9 +13,6 @@ internal interface IInitializeManager : ILspService
     ClientCapabilities? TryGetClientCapabilities();
 
     InitializeParams? TryGetInitializeParams();
-
-    /// <summary>Expected to be non-default after the Initialize event.</summary>
-    ImmutableArray<string> GetRequiredWorkspaceFolderPaths();
 
     void SetInitializeParams(InitializeParams initializeParams);
 }

--- a/src/LanguageServer/Protocol/Handler/IWorkspaceFolderTracker.cs
+++ b/src/LanguageServer/Protocol/Handler/IWorkspaceFolderTracker.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using Roslyn.LanguageServer.Protocol;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.Handler;
+
+internal interface IWorkspaceFolderTracker : ILspService
+{
+    event Action<ImmutableHashSet<string>>? WorkspaceFoldersChanged;
+
+    ImmutableHashSet<string> GetRequiredWorkspaceFolderPaths();
+
+    void Update(WorkspaceFolder[]? addedFolders, WorkspaceFolder[]? removedFolders);
+}

--- a/src/LanguageServer/Protocol/Handler/InitializeManager.cs
+++ b/src/LanguageServer/Protocol/Handler/InitializeManager.cs
@@ -3,20 +3,13 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Immutable;
-using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.LanguageServer.Handler;
 
 internal sealed class InitializeManager : IInitializeManager
 {
-    public InitializeManager()
-    {
-    }
-
     private InitializeParams? _initializeParams;
-    private ImmutableArray<string> _workspaceFolderPathsOpt;
 
     public ClientCapabilities GetClientCapabilities()
     {
@@ -32,33 +25,11 @@ internal sealed class InitializeManager : IInitializeManager
     {
         Contract.ThrowIfFalse(_initializeParams == null);
         _initializeParams = initializeParams;
-        _workspaceFolderPathsOpt = initializeParams.WorkspaceFolders is [_, ..] workspaceFolders ? GetFolderPaths(workspaceFolders) : [];
-
-        static ImmutableArray<string> GetFolderPaths(WorkspaceFolder[] workspaceFolders)
-        {
-            var builder = ArrayBuilder<string>.GetInstance(workspaceFolders.Length);
-            foreach (var workspaceFolder in workspaceFolders)
-            {
-                if (workspaceFolder.DocumentUri.ParsedDocumentUri is null)
-                    continue;
-
-                var workspaceFolderPath = workspaceFolder.DocumentUri.GetDocumentFilePathFromUri();
-                builder.Add(workspaceFolderPath);
-            }
-
-            return builder.ToImmutableAndFree();
-        }
     }
 
     public InitializeParams? TryGetInitializeParams()
     {
         return _initializeParams;
-    }
-
-    public ImmutableArray<string> GetRequiredWorkspaceFolderPaths()
-    {
-        Contract.ThrowIfTrue(_workspaceFolderPathsOpt.IsDefault, $"{nameof(_workspaceFolderPathsOpt)} was not initialized. Was this accessed before the OnInitialized event ran?");
-        return _workspaceFolderPathsOpt;
     }
 
     public ClientCapabilities? TryGetClientCapabilities()

--- a/src/LanguageServer/Protocol/Handler/ServerLifetime/DidChangeWorkspaceFoldersNotificationHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/ServerLifetime/DidChangeWorkspaceFoldersNotificationHandler.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CommonLanguageServerProtocol.Framework;
+using Roslyn.LanguageServer.Protocol;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.Handler.ServerLifetime;
+
+[ExportCSharpVisualBasicLspServiceFactory(typeof(DidChangeWorkspaceFoldersNotificationHandler)), Shared]
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class DidChangeWorkspaceFoldersNotificationHandlerFactory() : ILspServiceFactory
+{
+    public ILspService CreateILspService(LspServices lspServices, WellKnownLspServerKinds serverKind)
+        => new DidChangeWorkspaceFoldersNotificationHandler(
+            lspServices.GetRequiredService<IWorkspaceFolderTracker>());
+}
+
+[Method(Methods.WorkspaceDidChangeWorkspaceFoldersName)]
+internal sealed class DidChangeWorkspaceFoldersNotificationHandler(IWorkspaceFolderTracker workspaceFolderTracker)
+    : ILspServiceNotificationHandler<DidChangeWorkspaceFoldersParams>
+{
+    public bool MutatesSolutionState => true;
+    public bool RequiresLSPSolution => false;
+
+    Task INotificationHandler<DidChangeWorkspaceFoldersParams, RequestContext>.HandleNotificationAsync(
+        DidChangeWorkspaceFoldersParams request, RequestContext requestContext, CancellationToken cancellationToken)
+    {
+        workspaceFolderTracker.Update(
+            addedFolders: request.Event?.Added,
+            removedFolders: request.Event?.Removed);
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/LanguageServer/Protocol/Handler/ServerLifetime/InitializeHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/ServerLifetime/InitializeHandler.cs
@@ -22,6 +22,7 @@ internal sealed class InitializeHandler() : ILspServiceRequestHandler<Initialize
         var clientCapabilitiesManager = context.GetRequiredLspService<IInitializeManager>();
         var clientCapabilities = request.Capabilities;
         clientCapabilitiesManager.SetInitializeParams(request);
+        context.GetRequiredLspService<IWorkspaceFolderTracker>().Update(request.WorkspaceFolders, removedFolders: null);
 
         var lspServices = context.GetRequiredService<ILspServices>();
         var capabilitiesProvider = context.GetRequiredLspService<ICapabilitiesProvider>();

--- a/src/LanguageServer/Protocol/Handler/WorkspaceFolderTracker.cs
+++ b/src/LanguageServer/Protocol/Handler/WorkspaceFolderTracker.cs
@@ -1,0 +1,79 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using Roslyn.LanguageServer.Protocol;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.LanguageServer.Handler;
+
+internal sealed class WorkspaceFolderTracker : IWorkspaceFolderTracker
+{
+    // Mutations are serialized by the request queue, but non-mutating requests may read the current folders concurrently.
+    private readonly object _gate = new();
+    private ImmutableHashSet<string> _workspaceFolderPaths = ImmutableHashSet.Create(PathUtilities.Comparer);
+
+    public event Action<ImmutableHashSet<string>>? WorkspaceFoldersChanged;
+
+    public void Update(WorkspaceFolder[]? addedFolders, WorkspaceFolder[]? removedFolders)
+    {
+        ImmutableHashSet<string> updatedWorkspaceFolderPaths;
+        lock (_gate)
+        {
+            updatedWorkspaceFolderPaths = _workspaceFolderPaths;
+            if (removedFolders is not null)
+            {
+                foreach (var workspaceFolder in removedFolders)
+                {
+                    if (GetNormalizedFilePath(workspaceFolder) is not { } normalizedPath)
+                        continue;
+
+                    updatedWorkspaceFolderPaths = updatedWorkspaceFolderPaths.Remove(normalizedPath);
+                }
+            }
+
+            if (addedFolders is not null)
+            {
+                foreach (var workspaceFolder in addedFolders)
+                {
+                    if (GetNormalizedFilePath(workspaceFolder) is not { } normalizedPath)
+                        continue;
+
+                    updatedWorkspaceFolderPaths = updatedWorkspaceFolderPaths.Add(normalizedPath);
+                }
+            }
+
+            if (updatedWorkspaceFolderPaths.SetEquals(_workspaceFolderPaths))
+                return;
+
+            _workspaceFolderPaths = updatedWorkspaceFolderPaths;
+        }
+
+        WorkspaceFoldersChanged?.Invoke(updatedWorkspaceFolderPaths);
+    }
+
+    public ImmutableHashSet<string> GetRequiredWorkspaceFolderPaths()
+    {
+        lock (_gate)
+        {
+            return _workspaceFolderPaths;
+        }
+    }
+
+    private static string? GetNormalizedFilePath(WorkspaceFolder workspaceFolder)
+        => workspaceFolder.DocumentUri.ParsedDocumentUri?.IsFile == true
+            ? NormalizePath(workspaceFolder.DocumentUri.GetDocumentFilePathFromUri())
+            : null;
+
+    private static string NormalizePath(string path)
+    {
+        var fullPath = Path.GetFullPath(path);
+        var rootLength = Path.GetPathRoot(fullPath)?.Length ?? 0;
+        return fullPath.Length > rootLength && PathUtilities.IsDirectorySeparator(fullPath[^1])
+            ? fullPath[..^1]
+            : fullPath;
+    }
+}

--- a/src/LanguageServer/Protocol/RoslynLanguageServer.cs
+++ b/src/LanguageServer/Protocol/RoslynLanguageServer.cs
@@ -132,6 +132,7 @@ internal sealed class RoslynLanguageServer : SystemTextJsonLanguageServer<Reques
         AddLazyService<AbstractRequestContextFactory<RequestContext>>(lspServices => new RequestContextFactory(lspServices));
         AddLazyService<AbstractTelemetryService>(lspServices => new TelemetryService(lspServices));
         AddLazyService<AbstractHandlerProvider>(_ => HandlerProvider);
+        AddService<IWorkspaceFolderTracker>(new WorkspaceFolderTracker());
         AddService<IInitializeManager>(new InitializeManager());
         AddService<IMethodHandler>(new InitializeHandler());
         AddService<IMethodHandler>(new InitializedHandler());

--- a/src/LanguageServer/ProtocolUnitTests/HandlerTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/HandlerTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.IO;
 using System.Composition;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -40,6 +41,24 @@ public sealed class HandlerTests : AbstractLanguageServerProtocolTests
         typeof(TestFSharpOnlyDocumentHandler),
         typeof(TestFSharpOnlyNotificationHandler),
         typeof(TestConfigurableDocumentHandler));
+
+    [Fact]
+    public void WorkspaceFolderTrackerPreservesSetForEquivalentUpdate()
+    {
+        var tracker = new WorkspaceFolderTracker();
+        var workspaceFolder = new WorkspaceFolder { DocumentUri = new("file:///Workspace"), Name = "Workspace" };
+        var equivalentWorkspaceFolder = new WorkspaceFolder { DocumentUri = new("file:///Workspace/"), Name = "Workspace" };
+        var eventCount = 0;
+        tracker.WorkspaceFoldersChanged += _ => eventCount++;
+
+        tracker.Update([workspaceFolder], removedFolders: null);
+        var workspaceFolders = tracker.GetRequiredWorkspaceFolderPaths();
+        tracker.Update([equivalentWorkspaceFolder], [workspaceFolder]);
+
+        Assert.Equal(1, eventCount);
+        Assert.Same(workspaceFolders, tracker.GetRequiredWorkspaceFolderPaths());
+        Assert.Equal(Path.GetFullPath(workspaceFolder.DocumentUri.GetDocumentFilePathFromUri()), Assert.Single(workspaceFolders));
+    }
 
     [Theory, CombinatorialData]
     public async Task CanExecuteRequestHandler(bool mutatingLspWorkspace)

--- a/src/LanguageServer/ProtocolUnitTests/TestConfigurableDocumentHandler.cs
+++ b/src/LanguageServer/ProtocolUnitTests/TestConfigurableDocumentHandler.cs
@@ -29,21 +29,24 @@ internal sealed class TestConfigurableDocumentHandler() : ILspServiceDocumentReq
 
     private bool? _mutatesSolutionState;
     private bool? _requiresLSPSolution;
-    private Task<TestConfigurableResponse>? _response;
+    private Func<RequestContext, CancellationToken, Task<TestConfigurableResponse>>? _responseFactory;
 
     public bool MutatesSolutionState => _mutatesSolutionState ?? throw new InvalidOperationException($"{nameof(ConfigureHandler)} has not been called");
     public bool RequiresLSPSolution => _requiresLSPSolution ?? throw new InvalidOperationException($"{nameof(ConfigureHandler)} has not been called");
 
     public void ConfigureHandler(bool mutatesSolutionState, bool requiresLspSolution, Task<TestConfigurableResponse> response)
+        => ConfigureHandler(mutatesSolutionState, requiresLspSolution, (_, _) => response);
+
+    public void ConfigureHandler(bool mutatesSolutionState, bool requiresLspSolution, Func<RequestContext, CancellationToken, Task<TestConfigurableResponse>> responseFactory)
     {
-        if (_mutatesSolutionState is not null || _requiresLSPSolution is not null || _response is not null)
+        if (_mutatesSolutionState is not null || _requiresLSPSolution is not null || _responseFactory is not null)
         {
             throw new InvalidOperationException($"{nameof(ConfigureHandler)} has already been called");
         }
 
         _mutatesSolutionState = mutatesSolutionState;
         _requiresLSPSolution = requiresLspSolution;
-        _response = response;
+        _responseFactory = responseFactory;
     }
 
     public TextDocumentIdentifier GetTextDocumentIdentifier(TestRequestWithDocument request)
@@ -53,8 +56,8 @@ internal sealed class TestConfigurableDocumentHandler() : ILspServiceDocumentReq
 
     public Task<TestConfigurableResponse> HandleRequestAsync(TestRequestWithDocument request, RequestContext context, CancellationToken cancellationToken)
     {
-        Contract.ThrowIfNull(_response, $"{nameof(ConfigureHandler)} has not been called");
-        return _response;
+        Contract.ThrowIfNull(_responseFactory, $"{nameof(ConfigureHandler)} has not been called");
+        return _responseFactory(context, cancellationToken);
     }
 
     public static void ConfigureHandler(TestLspServer server, bool mutatesSolutionState, bool requiresLspSolution, Task<TestConfigurableResponse> response)
@@ -62,5 +65,16 @@ internal sealed class TestConfigurableDocumentHandler() : ILspServiceDocumentReq
         var handler = (TestConfigurableDocumentHandler)server.GetQueueAccessor()!.Value.GetHandlerProvider().GetMethodHandler(TestConfigurableDocumentHandler.MethodName,
             TypeRef.From(typeof(TestRequestWithDocument)), TypeRef.From(typeof(TestConfigurableResponse)), LanguageServerConstants.DefaultLanguageName);
         handler.ConfigureHandler(mutatesSolutionState, requiresLspSolution, response);
+    }
+
+    public static void ConfigureHandler(
+        TestLspServer server,
+        bool mutatesSolutionState,
+        bool requiresLspSolution,
+        Func<RequestContext, CancellationToken, Task<TestConfigurableResponse>> responseFactory)
+    {
+        var handler = (TestConfigurableDocumentHandler)server.GetQueueAccessor()!.Value.GetHandlerProvider().GetMethodHandler(TestConfigurableDocumentHandler.MethodName,
+            TypeRef.From(typeof(TestRequestWithDocument)), TypeRef.From(typeof(TestConfigurableResponse)), LanguageServerConstants.DefaultLanguageName);
+        handler.ConfigureHandler(mutatesSolutionState, requiresLspSolution, responseFactory);
     }
 }


### PR DESCRIPTION
## Summary

Introduce a synchronized Language Server service as the authoritative source of current local workspace folders.

- Add initial folders directly from the LSP initialize handler.
- Remove and add folders for `workspace/didChangeWorkspaceFolders` notifications.
- Normalize paths and compare them with platform path semantics, and ignore non-file workspace-folder URIs.
- Migrate existing file-based-program consumers away from `IInitializeManager` folder state.

## Validation

- `WorkspaceFolderTrackerTests` (2 passed)
- Analyzer-enabled Language Server unit-test project build succeeded with 0 errors
- Final stacked analyzer-enabled Language Server build succeeded with 0 errors
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85105)

