### PR TITLE
Update Tasks.DataFlow bindingRedirect in MSBuildTasksTests

### DIFF
--- a/src/Compilers/Core/MSBuildTaskTests/app.config
+++ b/src/Compilers/Core/MSBuildTaskTests/app.config
@@ -14,7 +14,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.Threading.Tasks.Dataflow" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.1" newVersion="10.0.0.1" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.10" newVersion="10.0.0.10" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>


### PR DESCRIPTION
Resolves errors we are seeing in [the rolling CI](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1575521&view=ms.vss-test-web.build-test-results-tab&runId=43425470&resultId=249478&paneView=debug)

> System.IO.FileLoadException : Could not load file or assembly 'System.Threading.Tasks.Dataflow, Version=10.0.0.4, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85110)