### PR TITLE
Fix dotnet restore command syntax

### DIFF
--- a/src/LanguageServer/Protocol.TestUtilities/LanguageServer/MaterializedLspWorkspace.cs
+++ b/src/LanguageServer/Protocol.TestUtilities/LanguageServer/MaterializedLspWorkspace.cs
@@ -60,7 +60,7 @@ internal sealed class MaterializedLspWorkspace
         if (content.ShouldRestore)
         {
             foreach (var projectPath in content.Files.Keys.Where(static path => PathUtilities.GetExtension(path) == ".csproj"))
-                ProcessUtilities.Run("dotnet", $"restore --project \"{GetFullPath(rootPath, projectPath)}\"");
+                ProcessUtilities.Run("dotnet", $"restore \"{GetFullPath(rootPath, projectPath)}\"");
         }
 
         return new MaterializedLspWorkspace(content, rootPath, annotatedLocations);


### PR DESCRIPTION
There is no `--project` option https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-restore
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85111)