### PR TITLE
Visit left operand conversion in a fast path of nullable analysis

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -5569,7 +5569,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // The left operand was visited without its stripped conversion.
                     if (binary.Left is BoundConversion leftConversionNode && leftConversionNode != leftOperand)
                     {
-                        Debug.Assert(leftConversionNode.Type is not null);
                         VisitConversion(
                             leftConversionNode,
                             leftOperand,

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/NullableWalker.cs
@@ -5565,6 +5565,23 @@ namespace Microsoft.CodeAnalysis.CSharp
                 else if (binary.Left.ConstantValueOpt is { IsBoolean: true } leftConstant)
                 {
                     Unsplit();
+
+                    // The left operand was visited without its stripped conversion.
+                    if (binary.Left is BoundConversion leftConversionNode && leftConversionNode != leftOperand)
+                    {
+                        Debug.Assert(leftConversionNode.Type is not null);
+                        VisitConversion(
+                            leftConversionNode,
+                            leftOperand,
+                            leftConversion,
+                            TypeWithAnnotations.Create(leftConversionNode.Type),
+                            leftResult,
+                            checkConversion: true,
+                            fromExplicitCast: false,
+                            useLegacyWarnings: false,
+                            AssignmentKind.Argument);
+                    }
+
                     Visit(binary.Right);
                     UseRvalueOnly(binary.Right);
                     if (IsConditionalState && isEquals(binary) != leftConstant.BooleanValue)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -51746,6 +51746,22 @@ class C
                 );
         }
 
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/84642")]
+        public void EqualsBoolConstant_DefaultLiteral()
+        {
+            var source = """
+                class C
+                {
+                    static bool M()
+                    {
+                        return default != true;
+                    }
+                }
+                """;
+
+            CreateNullableCompilation(source).VerifyEmitDiagnostics();
+        }
+
         [Fact]
         public void EqualsBoolConstant_UserDefinedOperator_BoolRight()
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/84642.

In `VisitBinaryOperatorChildren`, the conversion from the LHS is removed but then in the code path going through `learnFromConditionalAccessOrBoolConstant`, the removed conversion wasn't visited, failing the assert.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85115)