### PR TITLE
Unsafe evolution: display `unsafe` modifier on interface members too

### DIFF
--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Members.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Members.cs
@@ -933,32 +933,34 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (Format.MemberOptions.IncludesOption(SymbolDisplayMemberOptions.IncludeModifiers) &&
                 (containingType == null ||
-                 (containingType.TypeKind != TypeKind.Interface && !IsEnumMember(symbol) && !IsLocalFunction(symbol))))
+                 (!IsEnumMember(symbol) && !IsLocalFunction(symbol))))
             {
-                var isConst = symbol is IFieldSymbol { IsConst: true };
-                var isRequired = symbol is IFieldSymbol { IsRequired: true } or IPropertySymbol { IsRequired: true };
-                if (symbol.IsStatic && !isConst)
+                if (containingType?.TypeKind != TypeKind.Interface)
                 {
-                    AddKeyword(SyntaxKind.StaticKeyword);
-                    AddSpace();
-                }
+                    var isConst = symbol is IFieldSymbol { IsConst: true };
+                    if (symbol.IsStatic && !isConst)
+                    {
+                        AddKeyword(SyntaxKind.StaticKeyword);
+                        AddSpace();
+                    }
 
-                if (symbol.IsOverride)
-                {
-                    AddKeyword(SyntaxKind.OverrideKeyword);
-                    AddSpace();
-                }
+                    if (symbol.IsOverride)
+                    {
+                        AddKeyword(SyntaxKind.OverrideKeyword);
+                        AddSpace();
+                    }
 
-                if (symbol.IsAbstract)
-                {
-                    AddKeyword(SyntaxKind.AbstractKeyword);
-                    AddSpace();
-                }
+                    if (symbol.IsAbstract)
+                    {
+                        AddKeyword(SyntaxKind.AbstractKeyword);
+                        AddSpace();
+                    }
 
-                if (symbol.IsSealed)
-                {
-                    AddKeyword(SyntaxKind.SealedKeyword);
-                    AddSpace();
+                    if (symbol.IsSealed)
+                    {
+                        AddKeyword(SyntaxKind.SealedKeyword);
+                        AddSpace();
+                    }
                 }
 
                 // unsafe is added only for new code (code that opts into unsafe evolution and uses the keyword to annotate caller-unsafe members)
@@ -969,22 +971,26 @@ namespace Microsoft.CodeAnalysis.CSharp
                     AddSpace();
                 }
 
-                if (symbol.IsExtern)
+                if (containingType?.TypeKind != TypeKind.Interface)
                 {
-                    AddKeyword(SyntaxKind.ExternKeyword);
-                    AddSpace();
-                }
+                    if (symbol.IsExtern)
+                    {
+                        AddKeyword(SyntaxKind.ExternKeyword);
+                        AddSpace();
+                    }
 
-                if (symbol.IsVirtual)
-                {
-                    AddKeyword(SyntaxKind.VirtualKeyword);
-                    AddSpace();
-                }
+                    if (symbol.IsVirtual)
+                    {
+                        AddKeyword(SyntaxKind.VirtualKeyword);
+                        AddSpace();
+                    }
 
-                if (isRequired)
-                {
-                    AddKeyword(SyntaxKind.RequiredKeyword);
-                    AddSpace();
+                    var isRequired = symbol is IFieldSymbol { IsRequired: true } or IPropertySymbol { IsRequired: true };
+                    if (isRequired)
+                    {
+                        AddKeyword(SyntaxKind.RequiredKeyword);
+                        AddSpace();
+                    }
                 }
             }
         }

--- a/src/Compilers/CSharp/Test/CSharp15/UnsafeEvolutionTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/UnsafeEvolutionTests.cs
@@ -6162,7 +6162,24 @@ public sealed class UnsafeEvolutionTests : CompilingTestBase
                 // (3,1): error CS9362: 'I.M2()' must be used in an unsafe context because it is marked as 'unsafe'
                 // i.M2();
                 Diagnostic(ErrorCode.ERR_UnsafeMemberOperation, "i.M2()").WithArguments("I.M2()").WithLocation(3, 1),
-            ]);
+            ],
+            legacyLibValidator: static comp =>
+            {
+                AssertEx.Equal("I", comp.GetTypeByMetadataName("I")!.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat.AddMemberOptions(SymbolDisplayMemberOptions.IncludeModifiers)));
+                AssertEx.Equal("void I.M1()", comp.GetMember("I.M1").ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat.AddMemberOptions(SymbolDisplayMemberOptions.IncludeModifiers)));
+                AssertEx.Equal("void I.M2()", comp.GetMember("I.M2").ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat.AddMemberOptions(SymbolDisplayMemberOptions.IncludeModifiers)));
+            },
+            updatedLibValidator: static comp =>
+            {
+                AssertEx.Equal("I", comp.GetTypeByMetadataName("I")!.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat.AddMemberOptions(SymbolDisplayMemberOptions.IncludeModifiers)));
+                AssertEx.Equal("void I.M1()", comp.GetMember("I.M1").ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat.AddMemberOptions(SymbolDisplayMemberOptions.IncludeModifiers)));
+
+                AssertEx.Equal("void I.M2()", comp.GetMember("I.M2").ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat));
+                AssertEx.Equal("unsafe void I.M2()", comp.GetMember("I.M2").ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat.AddMemberOptions(SymbolDisplayMemberOptions.IncludeModifiers)));
+
+                // interface members never have accessibility displayed
+                AssertEx.Equal("unsafe void I.M2()", comp.GetMember("I.M2").ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat.AddMemberOptions(SymbolDisplayMemberOptions.IncludeModifiers | SymbolDisplayMemberOptions.IncludeAccessibility)));
+            });
     }
 
     [Fact]


### PR DESCRIPTION
Test plan: https://github.com/dotnet/roslyn/issues/81207
Follow up on https://github.com/dotnet/roslyn/pull/84706.
Needed for https://github.com/dotnet/roslyn/pull/85010#discussion_r3854201694.

Review with whitespace off.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85118)