### PR TITLE
Clamp LSP position character to the line end

### DIFF
--- a/src/LanguageServer/Protocol/Extensions/Extensions.cs
+++ b/src/LanguageServer/Protocol/Extensions/Extensions.cs
@@ -222,7 +222,11 @@ internal static partial class Extensions
     public static async Task<int> GetPositionFromLinePositionAsync(this TextDocument document, LinePosition linePosition, CancellationToken cancellationToken)
     {
         var text = await document.GetValueTextAsync(cancellationToken).ConfigureAwait(false);
-        return text.Lines.GetPosition(linePosition);
+
+        // The client is allowed to send a character past the end of the line, so clamp before converting to an
+        // absolute position.  Otherwise we compute an offset outside the document (or overflow entirely) and
+        // downstream APIs like SyntaxNode.FindToken throw ArgumentOutOfRangeException.
+        return text.Lines.GetPosition(ProtocolConversions.ClampPositionToLineEnd(linePosition, text));
     }
 
     public static bool HasVisualStudioLspCapability(this ClientCapabilities? clientCapabilities)

--- a/src/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
+++ b/src/LanguageServer/Protocol/Extensions/ProtocolConversions.cs
@@ -319,6 +319,26 @@ internal static partial class ProtocolConversions
     public static LinePosition PositionToLinePosition(LSP.Position position)
         => new(position.Line, position.Character);
 
+    /// <summary>
+    /// Clamps the character of <paramref name="position"/> to the end of its line.  The LSP spec explicitly
+    /// allows clients to send a character past the end of the line:
+    /// <em>"If the character value is greater than the line length it defaults back to the line length."</em>
+    /// <para/>
+    /// Positions whose line is outside <paramref name="text"/> are returned unchanged so that callers still
+    /// surface the out of range line - the spec does not allow the line to go past the end of the document.
+    /// </summary>
+    public static LinePosition ClampPositionToLineEnd(LinePosition position, SourceText text)
+    {
+        if (position.Line < 0 || position.Line >= text.Lines.Count)
+            return position;
+
+        var line = text.Lines[position.Line];
+        var lineLength = line.End - line.Start;
+        return position.Character > lineLength
+            ? new LinePosition(position.Line, lineLength)
+            : position;
+    }
+
     public static LinePositionSpan RangeToLinePositionSpan(LSP.Range range)
         => new(PositionToLinePosition(range.Start), PositionToLinePosition(range.End));
 
@@ -367,18 +387,6 @@ internal static partial class ProtocolConversions
 
         static string PositionToString(LSP.Position position)
             => $"{{ Line={position.Line}, Character={position.Character} }}";
-
-        static LinePosition ClampPositionToLineEnd(LinePosition position, SourceText text)
-        {
-            if (position.Line < 0 || position.Line >= text.Lines.Count)
-                return position;
-
-            var line = text.Lines[position.Line];
-            var lineLength = line.End - line.Start;
-            return position.Character > lineLength
-                ? new LinePosition(position.Line, lineLength)
-                : position;
-        }
     }
 
     public static LSP.TextEdit TextChangeToTextEdit(TextChange textChange, SourceText oldText)

--- a/src/LanguageServer/ProtocolUnitTests/Highlights/DocumentHighlightTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Highlights/DocumentHighlightTests.cs
@@ -168,10 +168,81 @@ public sealed class DocumentHighlightTests(ITestOutputHelper testOutputHelper)
         Assert.NotNull(results);
     }
 
-    private static async Task<LSP.DocumentHighlight[]> RunGetDocumentHighlightAsync(TestLspServer testLspServer, LSP.Location caret)
+    [Theory, CombinatorialData, WorkItem("https://github.com/dotnet/vscode-csharp/issues/9716")]
+    public async Task TestGetDocumentHighlightAsync_CharacterPastEndOfLine(bool lspMutatingWorkspace)
     {
-        var results = await testLspServer.ExecuteRequestAsync<LSP.TextDocumentPositionParams, LSP.DocumentHighlight[]>(LSP.Methods.TextDocumentDocumentHighlightName,
-            CreateTextDocumentPositionParams(caret), CancellationToken.None);
+        var markup =
+            """
+            class A
+            {
+                void M()
+                {
+                }
+            }{|caret:|}
+            """;
+        await using var testLspServer = await CreateTestLspServerAsync(markup, lspMutatingWorkspace);
+
+        var caret = testLspServer.GetLocations("caret").Single();
+
+        // The LSP spec allows a client to send a character past the end of the line:
+        // "If the character value is greater than the line length it defaults back to the line length."
+        // The caret is on the last line here, so an unclamped offset lands past the end of the document
+        // and SyntaxNode.FindToken throws ArgumentOutOfRangeException.
+        var pastEndOfLine = new LSP.Position { Line = caret.Range.Start.Line, Character = caret.Range.Start.Character + 100 };
+
+        var results = await RunGetDocumentHighlightAsync(testLspServer, caret.DocumentUri, pastEndOfLine);
+        Assert.Empty(results);
+    }
+
+    [Theory, CombinatorialData, WorkItem("https://github.com/dotnet/vscode-csharp/issues/9716")]
+    public async Task TestGetDocumentHighlightAsync_KeywordCharacterPastEndOfLine(bool lspMutatingWorkspace)
+    {
+        var markup =
+            """
+            class A
+            {
+                void M()
+                {
+                    if (true)
+                        return;
+                    else{|caret:|}
+                        return;
+                }
+            }
+            """;
+        await using var testLspServer = await CreateTestLspServerAsync(markup, lspMutatingWorkspace);
+
+        var caret = testLspServer.GetLocations("caret").Single();
+
+        // Far enough past the end of the line that the unclamped offset lands past the end of the
+        // document, which is what reaches the throw in SyntaxNode.FindToken via AbstractKeywordHighlighter.
+        var pastEndOfLine = new LSP.Position { Line = caret.Range.Start.Line, Character = caret.Range.Start.Character + 1000 };
+
+        var expected = await RunGetDocumentHighlightAsync(testLspServer, caret);
+
+        // Verify the keyword highlighter is actually what produces results for this position.
+        Assert.NotEmpty(expected);
+        Assert.All(expected, r => Assert.Equal(LSP.DocumentHighlightKind.Text, r.Kind));
+
+        // Clamping the character to the line end must produce the same result as the in-range position.
+        var results = await RunGetDocumentHighlightAsync(testLspServer, caret.DocumentUri, pastEndOfLine);
+        AssertJsonEquals(expected, results);
+    }
+
+    private static Task<LSP.DocumentHighlight[]> RunGetDocumentHighlightAsync(TestLspServer testLspServer, LSP.Location caret)
+        => RunGetDocumentHighlightAsync(testLspServer, caret.DocumentUri, caret.Range.Start);
+
+    private static async Task<LSP.DocumentHighlight[]> RunGetDocumentHighlightAsync(
+        TestLspServer testLspServer, LSP.DocumentUri documentUri, LSP.Position position)
+    {
+        var request = new LSP.TextDocumentPositionParams
+        {
+            TextDocument = CreateTextDocumentIdentifier(documentUri),
+            Position = position,
+        };
+
+        var results = await testLspServer.ExecuteRequestAsync<LSP.TextDocumentPositionParams, LSP.DocumentHighlight[]>(
+            LSP.Methods.TextDocumentDocumentHighlightName, request, CancellationToken.None);
         Array.Sort(results, (h1, h2) =>
         {
             var compareKind = h1.Kind.CompareTo(h2.Kind);

--- a/src/LanguageServer/ProtocolUnitTests/ProtocolConversionsTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/ProtocolConversionsTests.cs
@@ -353,6 +353,62 @@ public sealed class ProtocolConversionsTests : AbstractLanguageServerProtocolTes
         Assert.Throws<ArgumentException>(() => ProtocolConversions.RangeToTextSpan(range, sourceText));
     }
 
+    [Fact, WorkItem("https://github.com/dotnet/vscode-csharp/issues/9716")]
+    public void ClampPositionToLineEnd_CharacterPastLineEnd()
+    {
+        var sourceText = SourceText.From(GetTestMarkup());
+
+        // "    var x = 5;" is line 2, which starts at 13 and ends at 27 (a length of 14).
+        Assert.Equal(
+            new LinePosition(2, 14),
+            ProtocolConversions.ClampPositionToLineEnd(new LinePosition(2, int.MaxValue), sourceText));
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/vscode-csharp/issues/9716")]
+    public void ClampPositionToLineEnd_CharacterWithinLine()
+    {
+        var sourceText = SourceText.From(GetTestMarkup());
+
+        // Positions that are already in range are returned untouched.
+        Assert.Equal(
+            new LinePosition(2, 8),
+            ProtocolConversions.ClampPositionToLineEnd(new LinePosition(2, 8), sourceText));
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/vscode-csharp/issues/9716")]
+    public void ClampPositionToLineEnd_LineOutOfRange()
+    {
+        var sourceText = SourceText.From(GetTestMarkup());
+
+        // The spec only allows the character to go past the end of the line, not the line to go past the
+        // end of the document. Leave those alone so callers still report the out of range line.
+        var outOfRange = new LinePosition(sourceText.Lines.Count, 5);
+        Assert.Equal(outOfRange, ProtocolConversions.ClampPositionToLineEnd(outOfRange, sourceText));
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/vscode-csharp/issues/9716")]
+    public async Task GetPositionFromLinePositionAsync_ClampsCharacterPastLineEnd()
+    {
+        await using var testLspServer = await CreateTestLspServerAsync(GetTestMarkup(), mutatingLspWorkspace: false);
+        var document = testLspServer.GetCurrentSolution().Projects.Single().Documents.Single();
+
+        // Line 2 ("    var x = 5;") starts at 13 and ends at 27. A character past the end of the line must
+        // clamp to the end of the line rather than producing an offset outside the document.
+        var position = await document.GetPositionFromLinePositionAsync(new LinePosition(2, int.MaxValue), CancellationToken.None);
+        Assert.Equal(27, position);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/vscode-csharp/issues/9716")]
+    public async Task GetPositionFromLinePositionAsync_ThrowsForLineOutOfRange()
+    {
+        await using var testLspServer = await CreateTestLspServerAsync(GetTestMarkup(), mutatingLspWorkspace: false);
+        var document = testLspServer.GetCurrentSolution().Projects.Single().Documents.Single();
+
+        var lineCount = (await document.GetTextAsync(CancellationToken.None)).Lines.Count;
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+            () => document.GetPositionFromLinePositionAsync(new LinePosition(lineCount, 0), CancellationToken.None));
+    }
+
     private static string GetTestMarkup()
     {
         // Markup is 31 characters long. Line break (\n) is 2 characters 


### PR DESCRIPTION
Fixes https://github.com/dotnet/vscode-csharp/issues/9716

## Problem

`textDocument/documentHighlight` fails with:

```
System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values. (Parameter 'position')
   at Microsoft.CodeAnalysis.SyntaxNode.FindTokenCore(Int32 position, Boolean findInsideTrivia)
   at Microsoft.CodeAnalysis.Highlighting.AbstractKeywordHighlighter.AddHighlights(...)
   at Microsoft.CodeAnalysis.Highlighting.HighlightingService.AddHighlights(...)
   at ...DocumentHighlightsHandler.GetKeywordHighlightsAsync(...)
   at ...DocumentHighlightsHandler.HandleRequestAsync(...)
```

## Root cause

Per the LSP spec, a client may send a `Position.character` past the end of the line:

> If the character value is greater than the line length it defaults back to the line length.

`TextLineCollection.GetPosition` validates **only** `LinePosition.Line` — it returns
`Lines[line].Start + character` with no check on the character. So an out-of-range character
silently produced an offset outside the document (or overflowed to a negative int for
`int.MaxValue`), which then threw from `SyntaxNode.FindTokenCore`.

Two details confirm this is the *character* and not something else:

* The failing parameter is `position` from `FindTokenCore`, not `Line` from
  `TextLineCollection.GetPosition`. An out-of-range *line* throws earlier, inside `GetPosition`,
  with parameter name `Line`. So the line was valid and only the character was out of range.
* `FindTokenCore` returns the EOF token when `position == EndPosition`, so the offset had to land
  *strictly* past the end of the document — a simple off-by-one at EOF is not enough.

`ProtocolConversions.RangeToTextSpan` already clamped this for **ranges** (added in "Allow LSP
character position to go beyond line length"), but the **single-position** path never got the same
treatment. That path — `TextDocument.GetPositionFromLinePositionAsync` — is shared by roughly a
dozen handlers (hover, completion, signatureHelp, rename, goToDefinition, findAllReferences,
callHierarchy, typeHierarchy, and others), so they all had the same latent crash.
`documentHighlight` just hits it most often because VS Code fires it continuously as the caret moves.

## Fix

Promote the local `ClampPositionToLineEnd` inside `RangeToTextSpan` to a shared helper on
`ProtocolConversions`, and use it from `GetPositionFromLinePositionAsync`. Both the range and
single-position conversions now go through one implementation.

Out-of-range *lines* are intentionally left unclamped so callers still surface them — the spec only
allows the character to go past the end of the line, not the line to go past the end of the document.

## Tests

Tests were written first and confirmed to reproduce the reported stack trace frame-for-frame before
the fix was applied (5 failed / 1 passed):

* `DocumentHighlightTests.TestGetDocumentHighlightAsync_CharacterPastEndOfLine` — end-to-end LSP
  repro at a character past the end of the last line.
* `DocumentHighlightTests.TestGetDocumentHighlightAsync_KeywordCharacterPastEndOfLine` — same, but
  the clamped position lands on a keyword construct, exercising `AbstractKeywordHighlighter` and
  asserting the result matches the in-range position.
* `ProtocolConversionsTests` — unit coverage for `ClampPositionToLineEnd` (past line end, within
  line, line out of range) and for `GetPositionFromLinePositionAsync` (clamps character, still
  throws for an out-of-range line). The clamping test also covers the `int.MaxValue` overflow case.

Full `Microsoft.CodeAnalysis.LanguageServer.Protocol.UnitTests` suite passed on both `net10.0` and
`net472` (1573 passed, 0 failed) prior to the final rebase onto `main`.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85125)