### PR TITLE
Prevent type rename from renaming ordinary Finalize methods

### DIFF
--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.NamedTypeSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.NamedTypeSymbols.vb
@@ -2145,6 +2145,23 @@ class {|Definition:$$A|} {    ~{|Definition:A|}()    {        Console.WriteLine(
             Await TestAPIAndFeature(input, kind, host)
         End Function
 
+        <WorkItem("https://github.com/dotnet/roslyn/issues/84976")>
+        <WpfTheory, CombinatorialData>
+        Public Async Function TestNamedType_DoNotFindOrdinaryMethodNamedFinalize(kind As TestKind, host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+interface {|Definition:$$IEnvironment|}
+{
+    bool Finalize();
+}
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input, kind, host)
+        End Function
+
         <WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546229")>
         <WpfTheory, CombinatorialData>
         Public Async Function TestNamedType_CrossLanguageModule(kind As TestKind, host As TestHost) As Task

--- a/src/EditorFeatures/Test2/Rename/RenameEngineTests.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameEngineTests.vb
@@ -896,6 +896,27 @@ class {|unresolve3:$$D|} // Rename to C
         End Sub
 
         <Theory, CombinatorialData>
+        <WorkItem("https://github.com/dotnet/roslyn/issues/84976")>
+        Public Sub RenameCSharpInterfaceDoesNotRenameOrdinaryMethodNamedFinalize(host As RenameTestHost)
+            Using result = RenameEngineResult.Create(_outputHelper,
+                <Workspace>
+                    <Project Language="C#" CommonReferences="true">
+                        <Document>
+                            interface [|$$IEnvironment|]
+                            {
+                                bool Finalize();
+                            }
+                        </Document>
+                    </Project>
+                </Workspace>, host:=host, renameTo:="IRenamed")
+
+                Dim documentText = result.ConflictResolution.NewSolution.Projects.Single().Documents.Single().GetTextAsync().Result.ToString()
+                Assert.Contains("interface IRenamed", documentText)
+                Assert.Contains("bool Finalize();", documentText)
+            End Using
+        End Sub
+
+        <Theory, CombinatorialData>
         Public Sub RenameCSharpTypeFromSynthesizedConstructorUse(host As RenameTestHost)
             Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>

--- a/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/NamedTypeSymbolReferenceFinder.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/FindReferences/Finders/NamedTypeSymbolReferenceFinder.cs
@@ -40,7 +40,11 @@ internal sealed class NamedTypeSymbolReferenceFinder : AbstractReferenceFinder<I
         Add(result, symbol.Constructors);
 
         // cascade to destructor
-        Add(result, symbol.GetMembers(WellKnownMemberNames.DestructorName));
+        foreach (var member in symbol.GetMembers(WellKnownMemberNames.DestructorName))
+        {
+            if (member is IMethodSymbol { MethodKind: MethodKind.Destructor })
+                result.Add(member);
+        }
 
         return result.ToImmutable();
     }


### PR DESCRIPTION
Fixes #84976

Named type reference discovery treated every member named `Finalize` as a destructor. This caused renaming an interface or type to also rename an unrelated ordinary `Finalize` method.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85126)