### PR TITLE
Allow Razor to supply editorconfig options during code action cleanup

### DIFF
--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Microsoft.CodeAnalysis.Razor.CohostingShared.projitems
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Microsoft.CodeAnalysis.Razor.CohostingShared.projitems
@@ -41,6 +41,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)RazorAnalyzerAssemblyRedirector.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RazorConfigurationChangedServiceFactory.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RazorMiscellaneousProjectInfoService.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)RazorSourceGeneratedDocumentAnalyzerConfigOptionsProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RazorSourceGeneratedDocumentExcerptService.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RazorSourceGeneratedDocumentExcerptServiceWrapper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RazorSourceGeneratedDocumentSpanMappingService.cs" />

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/RazorSourceGeneratedDocumentAnalyzerConfigOptionsProvider.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/RazorSourceGeneratedDocumentAnalyzerConfigOptionsProvider.cs
@@ -1,0 +1,87 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Razor;
+
+namespace Microsoft.VisualStudio.Razor;
+
+#pragma warning disable RS0030 // Do not use banned APIs
+[ExportWorkspaceService(typeof(ISourceGeneratedDocumentAnalyzerConfigOptionsProvider), ServiceLayer.Host), Shared]
+[method: ImportingConstructor]
+[method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
+internal sealed class RazorSourceGeneratedDocumentAnalyzerConfigOptionsProvider() : ISourceGeneratedDocumentAnalyzerConfigOptionsProvider
+#pragma warning restore RS0030 // Do not use banned APIs
+{
+    public ValueTask<AnalyzerConfigOptions?> GetOptionsAsync(SourceGeneratedDocument sourceGeneratedDocument, CancellationToken cancellationToken)
+    {
+        if (!sourceGeneratedDocument.IsRazorSourceGeneratedDocument())
+        {
+            return default;
+        }
+
+        var razorDocument = TryGetRazorDocumentForGeneratedDocument(sourceGeneratedDocument);
+        if (razorDocument?.FilePath is not { } filePath)
+        {
+            return default;
+        }
+
+        var options = razorDocument.Project.State.GetAnalyzerOptionsForPath(filePath, cancellationToken).ConfigOptionsWithFallback;
+
+        return new(options);
+    }
+
+    /// <summary>
+    /// Performs the inverse of <see cref="ProjectExtensions.TryGetSourceGeneratedDocumentsForRazorDocumentAsync"/>,
+    /// using the same full-path and project-relative hint-name matching.
+    /// </summary>
+    private static TextDocument? TryGetRazorDocumentForGeneratedDocument(SourceGeneratedDocument generatedDocument)
+    {
+        // Razor SDK projects use project-relative hint names, while miscellaneous and non-Razor SDK
+        // projects use full paths.
+        var project = generatedDocument.Project;
+        TextDocument? fullPathMatchedDocument = null;
+        TextDocument? candidateDocument = null;
+        var hasMultipleFullPathMatches = false;
+        var hasMultipleCandidates = false;
+
+        foreach (var razorDocument in project.AdditionalDocuments)
+        {
+            if (razorDocument.FilePath is not { } filePath ||
+                !filePath.IsRazorFilePath())
+            {
+                continue;
+            }
+
+            var (fullPathHintName, fullPathDeclHintName, projectRelativeHintName, projectRelativeDeclHintName) = ProjectExtensions.GetGeneratedDocumentHintNames(razorDocument);
+            if (generatedDocument.HintName == fullPathHintName ||
+                generatedDocument.HintName == fullPathDeclHintName)
+            {
+                hasMultipleFullPathMatches = fullPathMatchedDocument is not null;
+                fullPathMatchedDocument ??= razorDocument;
+            }
+            else if (generatedDocument.HintName == projectRelativeHintName ||
+                     generatedDocument.HintName == projectRelativeDeclHintName)
+            {
+                hasMultipleCandidates = candidateDocument is not null;
+                candidateDocument ??= razorDocument;
+            }
+        }
+
+        // Prefer a full-path match because project-relative hint names can collide. For either form,
+        // refuse to choose arbitrarily when multiple Razor documents match.
+        if (fullPathMatchedDocument is not null)
+        {
+            return hasMultipleFullPathMatches ? null : fullPathMatchedDocument;
+        }
+
+        return hasMultipleCandidates ? null : candidateDocument;
+    }
+}

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/ProjectExtensions.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/ProjectExtensions.cs
@@ -53,14 +53,7 @@ internal static class ProjectExtensions
         // and for non-Razor SDK projects we fallback to using the full path for hint names. We can't easily detect which situation we're
         // in here, so the loop below handles both cases.
 
-        // For misc files, and projects that don't have a globalconfig file (eg, non Razor SDK projects), the hint name will be based
-        // on the full path of the file.
-        var fullPathHintName = RazorSourceGenerator.GetIdentifierFromPath(razorDocument.FilePath);
-        var fullPathDeclHintName = RazorSourceGenerator.GetDeclIdentifierFromHintName(fullPathHintName);
-
-        // For normal Razor SDK projects, the hint name will be based on the project-relative path of the file.
-        var projectRelativeHintName = GetProjectRelativeHintName(razorDocument);
-        var projectRelativeDeclHintName = projectRelativeHintName is null ? null : RazorSourceGenerator.GetDeclIdentifierFromHintName(projectRelativeHintName);
+        var (fullPathHintName, fullPathDeclHintName, projectRelativeHintName, projectRelativeDeclHintName) = GetGeneratedDocumentHintNames(razorDocument);
 
         SourceGeneratedDocument? fullPathMatchedDoc = null;
         SourceGeneratedDocument? fullPathMatchedDeclDoc = null;
@@ -133,6 +126,21 @@ internal static class ProjectExtensions
         }
 
         return new(candidateDoc, candidateDeclDoc);
+    }
+
+    internal static (string fullPath, string fullPathDecl, string? projectRelative, string? projectRelativeDecl) GetGeneratedDocumentHintNames(
+        TextDocument razorDocument)
+    {
+        // For misc files, and projects that don't have a globalconfig file (eg, non Razor SDK projects), the hint name will be based
+        // on the full path of the file.
+        var fullPathHintName = RazorSourceGenerator.GetIdentifierFromPath(razorDocument.FilePath.AssumeNotNull());
+        var fullPathDeclHintName = RazorSourceGenerator.GetDeclIdentifierFromHintName(fullPathHintName);
+
+        // For normal Razor SDK projects, the hint name will be based on the project-relative path of the file.
+        var projectRelativeHintName = GetProjectRelativeHintName(razorDocument);
+        var projectRelativeDeclHintName = projectRelativeHintName is null ? null : RazorSourceGenerator.GetDeclIdentifierFromHintName(projectRelativeHintName);
+
+        return (fullPathHintName, fullPathDeclHintName, projectRelativeHintName, projectRelativeDeclHintName);
 
         static string? GetProjectRelativeHintName(TextDocument razorDocument)
         {

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/CodeActions/CohostCodeActionsEndpointTestBase.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/CodeActions/CohostCodeActionsEndpointTestBase.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Razor;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.AspNetCore.Razor.Test.Common.Mef;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.LanguageServer;
 using Microsoft.CodeAnalysis.Razor.CodeActions.Models;
@@ -27,6 +28,9 @@ namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost.CodeActions;
 
 public abstract class CohostCodeActionsEndpointTestBase(ITestOutputHelper testOutputHelper) : CohostEndpointTestBase(testOutputHelper)
 {
+    private protected override TestComposition ConfigureLocalComposition(TestComposition composition)
+        => composition.AddParts(typeof(RazorSourceGeneratedDocumentAnalyzerConfigOptionsProvider));
+
     private protected async Task VerifyCodeActionAsync(
         TestCode input,
         string? expected,

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/CodeActions/GenerateConstructorTests.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/CodeActions/GenerateConstructorTests.cs
@@ -54,6 +54,52 @@ public class GenerateConstructorTests(ITestOutputHelper testOutputHelper) : Coho
     }
 
     [Fact]
+    public async Task GenerateConstructor_FromCodeBlock_ExistingCodeBlock_UsesEditorConfig()
+    {
+        var input = """
+            @code
+            {
+                private File1 Create(int value)
+                {
+                    return new [||]File1(value);
+                }
+            }
+            """;
+
+        var expected = """
+            @code
+            {
+                private File1 Create(int value)
+                {
+                    return new File1(value);
+                }
+
+                private int value;
+
+                public File1(int value) {
+                    this.value = value;
+                }
+            }
+            """;
+
+        await VerifyCodeActionAsync(
+            input,
+            expected,
+            PredefinedCodeFixProviderNames.GenerateConstructor,
+            codeActionIndex: 0,
+            makeDiagnosticsRequest: true,
+            additionalFiles:
+            [
+                (".editorconfig", """
+                    root = true
+
+                    [*.razor]
+                    csharp_new_line_before_open_brace = none
+                    """)
+            ]);
+    }
+
+    [Fact]
     public async Task GenerateConstructor_ForClassInCodeBlock_WithoutParameter()
     {
         var input = """

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/CodeActions/GenerateConversionTests.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/CodeActions/GenerateConversionTests.cs
@@ -47,6 +47,51 @@ public class GenerateConversionTests(ITestOutputHelper testOutputHelper) : Cohos
     }
 
     [Fact]
+    public async Task GenerateExplicitConversion_FromCodeBlock_ExistingCodeBlock_UsesEditorConfig()
+    {
+        var input = """
+            @code
+            {
+                private int M()
+                {
+                    return [||](int)this;
+                }
+            }
+            """;
+
+        var expected = """
+            @using System
+            @code
+            {
+                private int M()
+                {
+                    return (int)this;
+                }
+
+                public static explicit operator int (File1 v)
+                {
+                    throw new NotImplementedException();
+                }
+            }
+            """;
+
+        await VerifyCodeActionAsync(
+            input,
+            expected,
+            PredefinedCodeFixProviderNames.GenerateConversion,
+            makeDiagnosticsRequest: true,
+            additionalFiles:
+            [
+                (".editorconfig", """
+                    root = true
+
+                    [*.razor]
+                    csharp_space_between_method_declaration_name_and_open_parenthesis = true
+                    """)
+            ]);
+    }
+
+    [Fact]
     public async Task GenerateExplicitConversion_FromExplicitExpression_WithoutCodeBlock()
     {
         var input = """

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/CodeActions/GenerateDeconstructMethodTests.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/CodeActions/GenerateDeconstructMethodTests.cs
@@ -47,6 +47,51 @@ public class GenerateDeconstructMethodTests(ITestOutputHelper testOutputHelper) 
     }
 
     [Fact]
+    public async Task GenerateDeconstructMethod_FromCodeBlock_ExistingCodeBlock_UsesEditorConfig()
+    {
+        var input = """
+            @code
+            {
+                private void M()
+                {
+                    (int x, int y) = [||]this;
+                }
+            }
+            """;
+
+        var expected = """
+            @using System
+            @code
+            {
+                private void M()
+                {
+                    (int x, int y) = this;
+                }
+
+                private void Deconstruct (out int x, out int y)
+                {
+                    throw new NotImplementedException();
+                }
+            }
+            """;
+
+        await VerifyCodeActionAsync(
+            input,
+            expected,
+            PredefinedCodeFixProviderNames.GenerateDeconstructMethod,
+            makeDiagnosticsRequest: true,
+            additionalFiles:
+            [
+                (".editorconfig", """
+                    root = true
+
+                    [*.razor]
+                    csharp_space_between_method_declaration_name_and_open_parenthesis = true
+                    """)
+            ]);
+    }
+
+    [Fact]
     public async Task GenerateDeconstructMethod_WithoutCodeBlock()
     {
         var input = """

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/CodeActions/GenerateFieldTests.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/CodeActions/GenerateFieldTests.cs
@@ -48,6 +48,48 @@ public class GenerateFieldTests(ITestOutputHelper testOutputHelper) : CohostCode
     }
 
     [Fact]
+    public async Task GenerateField_FromCodeBlock_ExistingCodeBlock_UsesEditorConfig()
+    {
+        var input = """
+            @code
+            {
+                private (int, string) M()
+                {
+                    return [||]newField;
+                }
+            }
+            """;
+
+        var expected = """
+            @code
+            {
+                private (int, string) M()
+                {
+                    return newField;
+                }
+
+                private (int,string) newField;
+            }
+            """;
+
+        await VerifyCodeActionAsync(
+            input,
+            expected,
+            PredefinedCodeFixProviderNames.GenerateVariable,
+            codeActionIndex: FieldActionIndex,
+            makeDiagnosticsRequest: true,
+            additionalFiles:
+            [
+                (".editorconfig", """
+                    root = true
+
+                    [*.razor]
+                    csharp_space_after_comma = false
+                    """)
+            ]);
+    }
+
+    [Fact]
     public async Task GenerateReadonlyField_FromCodeBlock_ExistingCodeBlock()
     {
         var input = """

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/CodeActions/GenerateMethodTests.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/CodeActions/GenerateMethodTests.cs
@@ -572,6 +572,46 @@ public class GenerateMethodTests(ITestOutputHelper testOutputHelper) : CohostCod
     }
 
     [Fact]
+    public async Task GenerateMethod_FromRazor_InSameRazorFile_UsesEditorConfig()
+    {
+        await VerifyCodeActionAsync(
+            input: """
+                @code
+                {
+                    private void M()
+                    {
+                        [||]NewMethod();
+                    }
+                }
+                """,
+            expected: """
+                @using System
+                @code
+                {
+                    private void M()
+                    {
+                        NewMethod();
+                    }
+
+                    private void NewMethod ()
+                    {
+                        throw new NotImplementedException();
+                    }
+                }
+                """,
+            additionalFiles:
+            [
+                (".editorconfig", """
+                    root = true
+
+                    [*.razor]
+                    csharp_space_between_method_declaration_name_and_open_parenthesis = true
+                    """)
+            ],
+            codeActionName: PredefinedCodeFixProviderNames.GenerateMethod);
+    }
+
+    [Fact]
     public async Task GenerateMethod_FromRazor_InOtherRazorFile()
     {
         await VerifyCodeActionAsync(
@@ -606,6 +646,59 @@ public class GenerateMethodTests(ITestOutputHelper testOutputHelper) : CohostCod
                     <div>Hi</div>
                     @code {
                         internal void NewMethod()
+                        {
+                            throw new NotImplementedException();
+                        }
+                    }
+                    """)
+            ],
+            codeActionName: PredefinedCodeFixProviderNames.GenerateMethod);
+    }
+
+    [Fact]
+    public async Task GenerateMethod_FromRazor_InOtherRazorFile_UsesEditorConfig()
+    {
+        await VerifyCodeActionAsync(
+            input: """
+                @code {
+                    private void M()
+                    {
+                        var x= new OtherComponent();
+                        x.[||]NewMethod();
+                    }
+                }
+                """,
+            expected: """
+                @code {
+                    private void M()
+                    {
+                        var x= new OtherComponent();
+                        x.NewMethod();
+                    }
+                }
+                """,
+            additionalFiles:
+            [
+                (FilePath("OtherComponent.razor"), """
+                    <div>Hi</div>
+                    """),
+                (".editorconfig", """
+                    root = true
+
+                    [File1.razor]
+                    csharp_space_between_method_declaration_name_and_open_parenthesis = false
+
+                    [OtherComponent.razor]
+                    csharp_space_between_method_declaration_name_and_open_parenthesis = true
+                    """)
+            ],
+            additionalExpectedFiles:
+            [
+                (FileUri("OtherComponent.razor"), """
+                    @using System
+                    <div>Hi</div>
+                    @code {
+                        internal void NewMethod ()
                         {
                             throw new NotImplementedException();
                         }

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/CodeActions/GeneratePropertyTests.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/CodeActions/GeneratePropertyTests.cs
@@ -47,6 +47,48 @@ public class GeneratePropertyTests(ITestOutputHelper testOutputHelper) : CohostC
     }
 
     [Fact]
+    public async Task GenerateProperty_FromCodeBlock_ExistingCodeBlock_UsesEditorConfig()
+    {
+        var input = """
+            @code
+            {
+                private (int, string) M()
+                {
+                    return [||]NewProperty;
+                }
+            }
+            """;
+
+        var expected = """
+            @code
+            {
+                private (int, string) M()
+                {
+                    return NewProperty;
+                }
+
+                public (int,string) NewProperty { get; private set; }
+            }
+            """;
+
+        await VerifyCodeActionAsync(
+            input,
+            expected,
+            PredefinedCodeFixProviderNames.GenerateVariable,
+            codeActionIndex: PropertyActionIndex,
+            makeDiagnosticsRequest: true,
+            additionalFiles:
+            [
+                (".editorconfig", """
+                    root = true
+
+                    [*.razor]
+                    csharp_space_after_comma = false
+                    """)
+            ]);
+    }
+
+    [Fact]
     public async Task GenerateProperty_FromImplicitExpression_WithoutCodeBlock()
     {
         var input = """

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/CodeActions/GenerateTypeTests.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/CodeActions/GenerateTypeTests.cs
@@ -44,6 +44,45 @@ public class GenerateTypeTests(ITestOutputHelper testOutputHelper) : CohostCodeA
             makeDiagnosticsRequest: true);
 
     [Fact]
+    public Task GenerateType_FromCodeBlock_ExistingCodeBlock_UsesEditorConfig()
+        => VerifyCodeActionAsync(
+            input: """
+                @code
+                {
+                    private object M()
+                    {
+                        return new [||]MissingType();
+                    }
+                }
+                """,
+            expected: """
+                @code
+                {
+                    private object M()
+                    {
+                        return new MissingType();
+                    }
+
+                    private class MissingType {
+                        public MissingType() {
+                        }
+                    }
+                }
+                """,
+            codeActionName: PredefinedCodeFixProviderNames.GenerateType,
+            codeActionIndex: 1,
+            makeDiagnosticsRequest: true,
+            additionalFiles:
+            [
+                (".editorconfig", """
+                    root = true
+
+                    [*.razor]
+                    csharp_new_line_before_open_brace = none
+                    """)
+            ]);
+
+    [Fact]
     public Task GenerateType_FromCodeBlock_ExistingCodeBlock_Struct()
         => VerifyCodeActionAsync(
             input: """

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/CodeActions/ImplementAbstractClassTests.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/CodeActions/ImplementAbstractClassTests.cs
@@ -101,6 +101,52 @@ public class ImplementAbstractClassTests(ITestOutputHelper testOutputHelper) : C
     }
 
     [Fact]
+    public async Task ImplementAbstractClass_FromGenericInheritsDirective_ExistingCodeBlock_UsesEditorConfig()
+    {
+        await VerifyCodeActionAsync(
+            input: """
+                @inherits [||]GenericBase<int>
+
+                @code
+                {
+                    private int value = 1;
+                }
+                """,
+            expected: """
+                @inherits GenericBase<int>
+
+                @code
+                {
+                    private int value = 1;
+
+                    protected override int Transform (int value)
+                    {
+                        throw new NotImplementedException();
+                    }
+                }
+                """,
+            additionalFiles:
+            [
+                (".editorconfig", """
+                    root = true
+
+                    [*.razor]
+                    csharp_space_between_method_declaration_name_and_open_parenthesis = true
+                    """),
+                (FilePath("GenericBase.cs"), """
+                    namespace SomeProject;
+
+                    public abstract class GenericBase<T>
+                    {
+                        protected abstract T Transform(T value);
+                    }
+                    """)
+            ],
+            codeActionName: PredefinedCodeFixProviderNames.ImplementAbstractClass,
+            makeDiagnosticsRequest: true);
+    }
+
+    [Fact]
     public async Task ImplementAbstractClass_FromInheritsDirective_WholeTypeRange_ExistingCodeBlock()
     {
         await VerifyBaseComponentCodeActionAsync(

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/CodeActions/ImplementInterfaceTests.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/CodeActions/ImplementInterfaceTests.cs
@@ -47,6 +47,46 @@ public class ImplementInterfaceTests(ITestOutputHelper testOutputHelper) : Cohos
     }
 
     [Fact]
+    public async Task ImplementInterface_ExistingCodeBlock_UsesEditorConfig()
+    {
+        await VerifyCodeActionAsync(
+            input: """
+                @implements IMyInter[||]face
+
+                @code {
+                }
+                """,
+            expected: """
+                @implements IMyInterface
+
+                @code {
+                    public void M ()
+                    {
+                        throw new NotImplementedException();
+                    }
+                }
+                """,
+            additionalFiles:
+            [
+                (".editorconfig", """
+                    root = true
+
+                    [*.razor]
+                    csharp_space_between_method_declaration_name_and_open_parenthesis = true
+                    """),
+                (FilePath("IMyInterface.cs"), """
+                    public interface IMyInterface
+                    {
+                        void M();
+                    }
+                    """)
+            ],
+            codeActionName: PredefinedCodeFixProviderNames.ImplementInterface,
+            codeActionIndex: 0,
+            makeDiagnosticsRequest: true);
+    }
+
+    [Fact]
     public async Task ImplementInterface_WithoutCodeBlock()
     {
         await VerifyCodeActionAsync(

--- a/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Cohost/CohostRoslynCodeActionTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Cohost/CohostRoslynCodeActionTest.cs
@@ -61,6 +61,53 @@ public class CohostRoslynCodeActionTest(ITestOutputHelper testOutputHelper) : Co
             codeActionName: PredefinedCodeFixProviderNames.GenerateMethod);
 
     [Fact]
+    public Task GenerateMethod_NoCodeBlock_UsesEditorConfig()
+        => VerifyCodeActionAsync(
+            csharpFile: """
+                using SomeProject;
+                using Microsoft.AspNetCore.Components;
+
+                public class C
+                {
+                    private void M()
+                    {
+                        new Component().$$NewMethod();
+                    }
+                }
+                """,
+            razorFile: """
+                This is a Razor document.
+
+                <Component></Component>
+
+                The end.
+                """,
+            expectedRazorFile: """
+                @using System
+                This is a Razor document.
+
+                <Component></Component>
+
+                The end.
+                @code {
+                    internal void NewMethod ()
+                    {
+                        throw new NotImplementedException();
+                    }
+                }
+                """,
+            codeActionName: PredefinedCodeFixProviderNames.GenerateMethod,
+            additionalFiles:
+            [
+                (".editorconfig", """
+                    root = true
+
+                    [*.razor]
+                    csharp_space_between_method_declaration_name_and_open_parenthesis = true
+                    """)
+            ]);
+
+    [Fact]
     public async Task GenerateMethod_NoCodeBlock_CodeBlockBraceOnNextLine()
     {
         ClientSettingsManager.Update(ClientSettingsManager.GetClientSettings().AdvancedSettings with { CodeBlockBraceOnNextLine = true });
@@ -673,6 +720,7 @@ public class CohostRoslynCodeActionTest(ITestOutputHelper testOutputHelper) : Co
         return composition
             .AddParts(typeof(RazorSourceGeneratedDocumentSpanMappingService))
             .AddParts(typeof(RazorSourceGeneratedDocumentSpanMappingServiceWrapper))
+            .AddParts(typeof(RazorSourceGeneratedDocumentAnalyzerConfigOptionsProvider))
             .AddParts(typeof(ExportableRemoteServiceInvoker));
     }
 
@@ -681,9 +729,13 @@ public class CohostRoslynCodeActionTest(ITestOutputHelper testOutputHelper) : Co
         TestCode razorFile,
         TestCode expectedRazorFile,
         string codeActionName,
-        int childActionIndex = 0)
+        int childActionIndex = 0,
+        (string fileName, string contents)[]? additionalFiles = null)
     {
-        var razorDocument = CreateProjectAndRazorDocument(razorFile.Text, documentFilePath: FilePath("Component.razor"), additionalFiles: [(FilePath("File.cs"), csharpFile.Text)]);
+        (string fileName, string contents)[] projectFiles = additionalFiles is null
+            ? [(FilePath("File.cs"), csharpFile.Text)]
+            : additionalFiles.Prepend((FilePath("File.cs"), csharpFile.Text)).ToArray();
+        var razorDocument = CreateProjectAndRazorDocument(razorFile.Text, documentFilePath: FilePath("Component.razor"), additionalFiles: projectFiles);
         var project = razorDocument.Project;
         var csharpDocument = project.Documents.First();
         var solution = csharpDocument.Project.Solution;

--- a/src/Workspaces/Core/Portable/CodeActions/CodeAction_Cleanup.cs
+++ b/src/Workspaces/Core/Portable/CodeActions/CodeAction_Cleanup.cs
@@ -7,10 +7,13 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.AddImport;
 using Microsoft.CodeAnalysis.CaseCorrection;
 using Microsoft.CodeAnalysis.CodeCleanup;
+using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Remote;
 using Microsoft.CodeAnalysis.Shared.Extensions;
@@ -136,13 +139,36 @@ public abstract partial class CodeAction
                 // Only care about documents that support syntax.  Non-C#/VB files can't be cleaned.
                 if (document.SupportsSyntaxTree)
                 {
-                    var codeActionOptions = await document.GetCodeCleanupOptionsAsync(cancellationToken).ConfigureAwait(false);
+                    var codeActionOptions = await GetCodeActionCleanupOptionsAsync(document, cancellationToken).ConfigureAwait(false);
                     documentIdsAndOptions.Add((documentId, codeActionOptions));
                 }
             }
 
             return documentIdsAndOptions.ToImmutableAndClear();
         }
+    }
+
+    private static async ValueTask<CodeCleanupOptions> GetCodeActionCleanupOptionsAsync(
+        Document document,
+        CancellationToken cancellationToken)
+    {
+        // A source-generated document can represent a different host document whose analyzer-config
+        // options should govern code-action cleanup. For example, Razor maps generated C# back to its
+        // originating .razor or .cshtml document so cleanup uses formatting rules matching that file.
+        if (document is SourceGeneratedDocument sourceGeneratedDocument &&
+            document.Project.Solution.Services.GetService<ISourceGeneratedDocumentAnalyzerConfigOptionsProvider>() is { } sourceGeneratedOptionsProvider &&
+            await sourceGeneratedOptionsProvider.GetOptionsAsync(sourceGeneratedDocument, cancellationToken).ConfigureAwait(false) is { } sourceGeneratedOptions)
+        {
+            var structuredOptions = StructuredAnalyzerConfigOptions.TryGetStructuredOptions(sourceGeneratedOptions, out var options)
+                ? options
+                : StructuredAnalyzerConfigOptions.Create(sourceGeneratedOptions);
+
+            return structuredOptions.GetCodeCleanupOptions(
+                document.Project.GetExtendedLanguageServices().LanguageServices,
+                document.AllowImportsInHiddenRegions());
+        }
+
+        return await document.GetCodeCleanupOptionsAsync(cancellationToken).ConfigureAwait(false);
     }
 
     internal static async ValueTask<Document> CleanupDocumentAsync(Document document, CodeCleanupOptions options, CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/Workspace/Host/DocumentService/ISourceGeneratedDocumentAnalyzerConfigOptionsProvider.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/DocumentService/ISourceGeneratedDocumentAnalyzerConfigOptionsProvider.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.Host;
+
+internal interface ISourceGeneratedDocumentAnalyzerConfigOptionsProvider : IWorkspaceService
+{
+    /// <summary>
+    /// Allows a host to supply analyzer-config options for code-action cleanup when a source-generated
+    /// document represents another host document.
+    /// </summary>
+    /// <returns>
+    /// The options to use for <paramref name="sourceGeneratedDocument"/>, or <see langword="null"/> to use normal lookup.
+    /// </returns>
+    ValueTask<AnalyzerConfigOptions?> GetOptionsAsync(SourceGeneratedDocument sourceGeneratedDocument, CancellationToken cancellationToken);
+}


### PR DESCRIPTION
Further work on https://github.com/dotnet/roslyn/issues/85310

Previous work meant Razor considers C# formatting options defined in `*.{razor,cshtml}` sections in `.editorconfig` files during document formatting. This PR adds an extension point so Razor can hook in to code action cleanup, and instead of formatting options for that coming from the editorconfig options defined for the generated C# document, which is essentially impossible, Razor redirects things so that the options for the owning Razor document are used instead.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85128)