### PR TITLE
Ignore spurious TypeScript diagnostics caused by Razor code

### DIFF
--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Diagnostics/RazorTranslateDiagnosticsService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Diagnostics/RazorTranslateDiagnosticsService.cs
@@ -332,6 +332,7 @@ internal sealed class RazorTranslateDiagnosticsService(IDocumentMappingService d
 
         return str switch
         {
+            TypeScriptErrorCodes.ExpressionExpected => IsSemicolonAfterCSharpExpression(diagnostic, sourceText, syntaxTree),
             CSSErrorCodes.UnrecognizedBlockType => IsEscapedAtSign(diagnostic, sourceText),
             CSSErrorCodes.MissingOpeningBrace or
             CSSErrorCodes.MissingClassNameAfterDot or
@@ -346,6 +347,23 @@ internal sealed class RazorTranslateDiagnosticsService(IDocumentMappingService d
             HtmlErrorCodes.TooFewElementsErrorCode => IsAnyFilteredTooFewElementsError(diagnostic, sourceText, syntaxTree),
             _ => false,
         };
+
+        static bool IsSemicolonAfterCSharpExpression(LspDiagnostic diagnostic, SourceText sourceText, RazorSyntaxTree syntaxTree)
+        {
+            if (!sourceText.TryGetAbsoluteIndex(diagnostic.Range.Start, out var absoluteIndex) ||
+                absoluteIndex == 0 ||
+                absoluteIndex >= sourceText.Length ||
+                sourceText[absoluteIndex] != ';')
+            {
+                return false;
+            }
+
+            var owner = syntaxTree.Root.FindInnermostNode(absoluteIndex - 1);
+            var expression = owner?.FirstAncestorOrSelf<SyntaxNode>(
+                static n => n is CSharpExplicitExpressionSyntax or CSharpImplicitExpressionSyntax);
+
+            return expression?.Span.End == absoluteIndex;
+        }
 
         static bool IsEscapedAtSign(LspDiagnostic diagnostic, SourceText sourceText)
         {

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Diagnostics/TypeScriptErrorCodes.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Diagnostics/TypeScriptErrorCodes.cs
@@ -1,0 +1,9 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.CodeAnalysis.Remote.Razor.Diagnostics;
+
+internal static class TypeScriptErrorCodes
+{
+    public const string ExpressionExpected = "TS1109";
+}

--- a/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Cohost/CohostDocumentPullDiagnosticsTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Cohost/CohostDocumentPullDiagnosticsTest.cs
@@ -125,6 +125,57 @@ public partial class CohostDocumentPullDiagnosticsTest
             }]);
     }
 
+    [Fact, WorkItem("https://github.com/dotnet/razor/issues/13251")]
+    public Task FilterTypeScriptExpressionExpectedAfterRazorExpression()
+    {
+        TestCode input = """
+            <script>
+                const values = @Html.Raw("[]");
+                const next = 0;
+            </script>
+            """;
+
+        return VerifyDiagnosticsAsync(
+            input,
+            htmlResponse: [new VSInternalDiagnosticReport
+            {
+                Diagnostics =
+                [
+                    new LspDiagnostic
+                    {
+                        Code = "TS1109",
+                        Range = SourceText.From(input.Text).GetRange(new TextSpan(input.Text.IndexOf(';'), 1))
+                    }
+                ]
+            }],
+            fileKind: RazorFileKind.Legacy);
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/razor/issues/13251")]
+    public Task DoNotFilterTypeScriptExpressionExpectedInJavaScript()
+    {
+        TestCode input = """
+            <script>
+                const values = {|TS1109:;|}
+            </script>
+            """;
+
+        return VerifyDiagnosticsAsync(
+            input,
+            htmlResponse: [new VSInternalDiagnosticReport
+            {
+                Diagnostics =
+                [
+                    new LspDiagnostic
+                    {
+                        Code = "TS1109",
+                        Range = SourceText.From(input.Text).GetRange(input.NamedSpans["TS1109"].First())
+                    }
+                ]
+            }],
+            fileKind: RazorFileKind.Legacy);
+    }
+
     [Fact]
     public Task Html()
     {


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/13251

When a razor file has:

```
<script>
    var x = @goo;
</script>
```

TypeScript sees `var x = /**/;` and complains about the semi-colon. Since we know better, it's safe to filter out that diagnostic. This is the first TS diagnostic we're doing this to, but we do it with Html and CSS diagnostics all the time.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85129)