### PR TITLE
Publish Windows PDBs for Roslyn SDK

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -137,7 +137,7 @@
   <!-- Arcade features -->
   <PropertyGroup>
     <UsingToolVSSDK Condition="$([MSBuild]::IsOSPlatform('Windows'))">true</UsingToolVSSDK>
-    <UsingToolPdbConverter>false</UsingToolPdbConverter>
+    <UsingToolPdbConverter>true</UsingToolPdbConverter>
     <UsingToolSymbolUploader>true</UsingToolSymbolUploader>
     <UsingToolNuGetRepack>true</UsingToolNuGetRepack>
     <!-- Avoid attempting IBC on platforms where ngen won't work, or the IBC tooling won't work -->

--- a/src/RoslynSdk/VisualStudio.Roslyn.SDK/ComponentDebugger/Roslyn.ComponentDebugger.csproj
+++ b/src/RoslynSdk/VisualStudio.Roslyn.SDK/ComponentDebugger/Roslyn.ComponentDebugger.csproj
@@ -8,6 +8,7 @@
     <Nullable>enable</Nullable>
     <UseWpf>true</UseWpf>
     <NoWarn>$(NoWarn);NU1603;NU1605</NoWarn>
+    <PublishWindowsPdb>true</PublishWindowsPdb>
   </PropertyGroup>
   <ItemGroup>
     <Page Remove="ComponentDebuggerLaunchProfile.xaml" />

--- a/src/RoslynSdk/VisualStudio.Roslyn.SDK/Roslyn.SDK.Template.Wizard/Roslyn.SDK.Template.Wizard.csproj
+++ b/src/RoslynSdk/VisualStudio.Roslyn.SDK/Roslyn.SDK.Template.Wizard/Roslyn.SDK.Template.Wizard.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
     <AssemblyName>Roslyn.SDK.Template.Wizard</AssemblyName>
+    <PublishWindowsPdb>true</PublishWindowsPdb>
   </PropertyGroup>
 
   <!-- Package References -->

--- a/src/RoslynSdk/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/Roslyn.SyntaxVisualizer.Control.csproj
+++ b/src/RoslynSdk/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Control/Roslyn.SyntaxVisualizer.Control.csproj
@@ -7,6 +7,7 @@
     <IsProductComponent>false</IsProductComponent>
     <UseWpf>true</UseWpf>
     <UseWindowsForms>true</UseWindowsForms>
+    <PublishWindowsPdb>true</PublishWindowsPdb>
   </PropertyGroup>
 
   <!-- Package References -->

--- a/src/RoslynSdk/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.DgmlHelper/Roslyn.SyntaxVisualizer.DgmlHelper.vbproj
+++ b/src/RoslynSdk/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.DgmlHelper/Roslyn.SyntaxVisualizer.DgmlHelper.vbproj
@@ -3,6 +3,7 @@
     <TargetFramework>net472</TargetFramework>
     <IsProductComponent>false</IsProductComponent>
     <RootNamespace></RootNamespace>
+    <PublishWindowsPdb>true</PublishWindowsPdb>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/RoslynSdk/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/Roslyn.SyntaxVisualizer.Extension.csproj
+++ b/src/RoslynSdk/VisualStudio.Roslyn.SDK/SyntaxVisualizer/Roslyn.SyntaxVisualizer.Extension/Roslyn.SyntaxVisualizer.Extension.csproj
@@ -8,6 +8,7 @@
     <IsProductComponent>false</IsProductComponent>
     <UseWpf>true</UseWpf>
     <GenerateResourceUsePreserializedResources Condition="'$(MSBuildRuntimeType)' == 'Core'">true</GenerateResourceUsePreserializedResources>
+    <PublishWindowsPdb>true</PublishWindowsPdb>
 
     <!-- VSIX -->
     <CreateVsixContainer>false</CreateVsixContainer>


### PR DESCRIPTION
Fixes the missing symbols reported by DevDiv work item 3058528: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/3058528/

The Roslyn SDK VSIX ships five assemblies whose embedded or portable PDBs were not compatible with the legacy VS insertion symbol store. Enable Windows PDB publishing for those projects and re-enable Arcade's CI-only PDB converter so SymStore.targets converts the PDBs and Publish.proj includes them in the symbol-server payload.

Validation:
- dotnet build src/RoslynSdk/VisualStudio.Roslyn.SDK/Roslyn.SDK/Roslyn.SDK.csproj --no-restore --configuration Release --nologo
- Confirmed all five projects evaluate PublishWindowsPdb=true and UsingToolPdbConverter=true.