### PR TITLE
Fix completion crash with stale linked documents

### DIFF
--- a/src/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
+++ b/src/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs
@@ -498,14 +498,16 @@ internal sealed class LspWorkspaceManager : IDocumentChangeTracker, ILspService
     {
         foreach (var (uriInWorkspace, documentsForUri) in documentsInWorkspace)
         {
-            // We're comparing text, so we can take any of the linked documents.
-            var firstDocument = documentsForUri.First();
-            var isTextEquivalent = await AreChecksumsEqualAsync(firstDocument, _trackedDocuments[uriInWorkspace].SourceText, cancellationToken).ConfigureAwait(false);
-
-            if (!isTextEquivalent)
+            var lspText = _trackedDocuments[uriInWorkspace].SourceText;
+            foreach (var document in documentsForUri)
             {
-                _logger.LogWarning($"Text for {uriInWorkspace} did not match document text {firstDocument.Id} in workspace's {firstDocument.Project.Solution.WorkspaceKind} current solution");
-                return false;
+                // Linked documents can temporarily have different text when only part of the linked set has been updated.
+                var isTextEquivalent = await AreChecksumsEqualAsync(document, lspText, cancellationToken).ConfigureAwait(false);
+                if (!isTextEquivalent)
+                {
+                    _logger.LogWarning($"Text for {uriInWorkspace} did not match document text {document.Id} in workspace's {document.Project.Solution.WorkspaceKind} current solution");
+                    return false;
+                }
             }
         }
 

--- a/src/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Completion/CompletionTests.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.LanguageServer.Handler.Completion;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Text;
 using Roslyn.LanguageServer.Protocol;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -48,6 +49,43 @@ public sealed class CompletionTests : AbstractLanguageServerProtocolTests
 
     public CompletionTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
     {
+    }
+
+    [Fact]
+    public async Task TestGetCompletionsWithStaleLinkedDocumentAsync()
+    {
+        var filePath = TestHelpers.CreateAbsolutePath("C.cs");
+        var workspaceXml = $$"""
+            <Workspace>
+                <Project Language="C#" CommonReferences="true" AssemblyName="CSProj1">
+                    <Document FilePath="{{filePath}}">Con{|caret:|}</Document>
+                </Project>
+                <Project Language="C#" CommonReferences="true" AssemblyName="CSProj2">
+                    <Document IsLinkFile="true" LinkFilePath="{{filePath}}" LinkAssemblyName="CSProj1"></Document>
+                </Project>
+            </Workspace>
+            """;
+
+        await using var testLspServer = await CreateXmlTestLspServerAsync(
+            workspaceXml,
+            mutatingLspWorkspace: false,
+            initializationOptions: new() { ClientCapabilities = s_vsCompletionCapabilities });
+
+        var workspaceDocuments = testLspServer.TestWorkspace.CurrentSolution.Projects.SelectMany(static p => p.Documents).ToArray();
+        Assert.Equal(2, workspaceDocuments.Length);
+        await testLspServer.TestWorkspace.ChangeDocumentAsync(workspaceDocuments[1].Id, SourceText.From(""));
+
+        var caretLocation = testLspServer.GetLocations("caret").Single();
+        await testLspServer.OpenDocumentAsync(caretLocation.DocumentUri, "Con");
+
+        var completionParams = CreateCompletionParams(
+            caretLocation,
+            invokeKind: LSP.VSInternalCompletionInvokeKind.Explicit,
+            triggerCharacter: "\0",
+            triggerKind: LSP.CompletionTriggerKind.Invoked);
+
+        var results = await RunGetCompletionsAsync(testLspServer, completionParams).ConfigureAwait(false);
+        Assert.Contains(results.Items, static item => item.Label == "class");
     }
 
     [Theory, CombinatorialData]

--- a/src/LanguageServer/ProtocolUnitTests/Workspaces/LspWorkspaceManagerTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Workspaces/LspWorkspaceManagerTests.cs
@@ -50,6 +50,42 @@ public sealed class LspWorkspaceManagerTests(ITestOutputHelper testOutputHelper)
         Assert.Equal(testLspServer.GetCurrentSolution(), closedDocument!.Project.Solution);
     }
 
+    [Fact]
+    public async Task TestForksWhenLinkedDocumentTextDoesNotMatchAsync()
+    {
+        var filePath = TestHelpers.CreateAbsolutePath("C.cs");
+        var workspaceXml = $"""
+            <Workspace>
+                <Project Language="C#" CommonReferences="true" AssemblyName="CSProj1">
+                    <Document FilePath="{filePath}">Console</Document>
+                </Project>
+                <Project Language="C#" CommonReferences="true" AssemblyName="CSProj2">
+                    <Document IsLinkFile="true" LinkFilePath="{filePath}" LinkAssemblyName="CSProj1"></Document>
+                </Project>
+            </Workspace>
+            """;
+
+        await using var testLspServer = await CreateXmlTestLspServerAsync(workspaceXml, mutatingLspWorkspace: false);
+        var workspaceDocuments = testLspServer.TestWorkspace.CurrentSolution.Projects.SelectMany(static p => p.Documents).ToArray();
+        Assert.Equal(2, workspaceDocuments.Length);
+        await testLspServer.TestWorkspace.ChangeDocumentAsync(workspaceDocuments[1].Id, SourceText.From(""));
+
+        workspaceDocuments = testLspServer.TestWorkspace.CurrentSolution.Projects.SelectMany(static p => p.Documents).ToArray();
+        Assert.Equal("Console", (await workspaceDocuments[0].GetTextAsync(CancellationToken.None)).ToString());
+        Assert.Equal("", (await workspaceDocuments[1].GetTextAsync(CancellationToken.None)).ToString());
+
+        var documentUri = workspaceDocuments[0].GetURI();
+        await testLspServer.OpenDocumentAsync(documentUri, "Console");
+
+        var (_, lspDocument) = await GetLspWorkspaceAndDocumentAsync(documentUri, testLspServer).ConfigureAwait(false);
+        Assert.NotNull(lspDocument);
+        Assert.NotSame(testLspServer.TestWorkspace.CurrentSolution, lspDocument.Project.Solution);
+
+        var lspDocuments = lspDocument.Project.Solution.Projects.SelectMany(static p => p.Documents);
+        foreach (var document in lspDocuments)
+            Assert.Equal("Console", (await document.GetTextAsync(CancellationToken.None)).ToString());
+    }
+
     [Theory, CombinatorialData]
     public async Task TestLspUsesWorkspaceInstanceOnChangesAsync(bool mutatingLspWorkspace)
     {


### PR DESCRIPTION
Fixes: #82476
 
Ensure LSP text synchronization checks every document associated with a URI, rather than only the first linked document. If any linked document is stale, this causes the existing solution-forking path to synchronize every document associated with the URI before the request is processed
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85134)