### PR TITLE
Remove testRunName from MacOS CI leg

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -331,7 +331,6 @@ stages:
     # https://github.com/dotnet/runtime/issues/97186
     - template: eng/pipelines/test-unix-job.yml
       parameters:
-        testRunName: 'Test macOS Debug'
         jobName: Test_macOS_Debug
         testArtifactName: Transport_Artifacts_macOS_Debug
         configuration: Debug


### PR DESCRIPTION
When testRunName is given the template tries to publish xunit results. However when running Helix tests there are no results because those will be captured by the monitor job.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85136)