### PR TITLE
Skip Roslyn SDK VSIX preparation under Core MSBuild

### DIFF
--- a/src/RoslynSdk/VisualStudio.Roslyn.SDK/Test/Roslyn.SDK.IntegrationTests/Roslyn.SDK.IntegrationTests.csproj
+++ b/src/RoslynSdk/VisualStudio.Roslyn.SDK/Test/Roslyn.SDK.IntegrationTests/Roslyn.SDK.IntegrationTests.csproj
@@ -41,7 +41,7 @@
   <Target Name="PrepareVsixProjectReferences"
           BeforeTargets="ResolveProjectReferences"
           DependsOnTargets="PrepareProjectReferences"
-          Condition="'$(UsingToolVSSDK)' == 'true'">
+          Condition="'$(UsingToolVSSDK)' == 'true' and '$(MSBuildRuntimeType)' != 'Core'">
     <MSBuild
       Projects="@(_MSBuildProjectReferenceExistent)"
       Targets="VSIXContainerProjectOutputGroup"


### PR DESCRIPTION
## Summary

- skip Roslyn SDK VSIX project-reference preparation under Core MSBuild
- preserve the existing VSIX preparation behavior under desktop MSBuild
- align the condition with Arcade's VSSDK target import boundary

The unified VMR build uses Core MSBuild, where Arcade intentionally does not import `Microsoft.VsSDK.targets`. The integration test project was nevertheless requesting `VSIXContainerProjectOutputGroup`, causing MSB4057.

## Validation

- `dotnet build .\src\RoslynSdk\VisualStudio.Roslyn.SDK\Test\Roslyn.SDK.IntegrationTests\Roslyn.SDK.IntegrationTests.csproj --no-restore -c Release -v:minimal`
- confirmed build 1578070 evaluated the project with `DotNetBuildFromVMR=True`, `MSBuildRuntimeType=Core`, and `UsingToolVSSDK=true`

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85137)