### PR TITLE
Stabilize transitive directive reload test

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/MiscellaneousFiles/FileBasedProgramsWorkspaceTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/MiscellaneousFiles/FileBasedProgramsWorkspaceTests.cs
@@ -1208,7 +1208,7 @@ public sealed class FileBasedProgramsWorkspaceTests(ITestOutputHelper testOutput
         var fileChangeTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         fileChangeContext.FileChanged += (_, e) =>
         {
-            if (e.FilePath == appCsFile.Path)
+            if (PathUtilities.Comparer.Equals(e.FilePath, appCsFile.Path))
                 fileChangeTcs.TrySetResult();
         };
 
@@ -1217,7 +1217,7 @@ public sealed class FileBasedProgramsWorkspaceTests(ITestOutputHelper testOutput
         var appCsEndPosition = appCsSourceText.Lines.GetLinePosition(appCsSourceText.Length);
         await testLspServer.InsertTextAsync(appCsUri, (Line: appCsEndPosition.Line, Column: appCsEndPosition.Character, Text: Environment.NewLine));
 
-        await fileChangeTcs.Task.WaitAsync(TimeSpan.FromSeconds(30));
+        await fileChangeTcs.Task.WaitAsync(TestHelpers.HangMitigatingTimeout);
         await WaitForProjectLoad(appCsUri, testLspServer);
 
         // Get the Util.cs document again

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/MiscellaneousFiles/FileBasedProgramsWorkspaceTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/MiscellaneousFiles/FileBasedProgramsWorkspaceTests.cs
@@ -883,7 +883,7 @@ public sealed class FileBasedProgramsWorkspaceTests(ITestOutputHelper testOutput
         appCsFile.WriteAllText(newAppCsText);
 
         // Wait for the file change event to be delivered, ensuring the reload is enqueued.
-        await fileChangeTcs.Task.WaitAsync(TimeSpan.FromSeconds(30));
+        await fileChangeTcs.Task.WaitAsync(TestHelpers.HangMitigatingTimeout);
         await WaitForProjectLoad(appCsUri, testLspServer);
 
         // Now the document is a miscellaneous file

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/MiscellaneousFiles/FileBasedProgramsWorkspaceTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/MiscellaneousFiles/FileBasedProgramsWorkspaceTests.cs
@@ -1205,7 +1205,7 @@ public sealed class FileBasedProgramsWorkspaceTests(ITestOutputHelper testOutput
         // the FileSystemWatcher has delivered the event that enqueues the reload.
         var fileChangeWatcher = testLspServer.GetRequiredLspService<IFileChangeWatcher>();
         using var fileChangeContext = fileChangeWatcher.CreateContext([new WatchedDirectory(Path.GetDirectoryName(appCsFile.Path)!, extensionFilters: [])]);
-        var fileChangeTcs = new TaskCompletionSource();
+        var fileChangeTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         fileChangeContext.FileChanged += (_, e) =>
         {
             if (e.FilePath == appCsFile.Path)

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/MiscellaneousFiles/FileBasedProgramsWorkspaceTests.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/MiscellaneousFiles/FileBasedProgramsWorkspaceTests.cs
@@ -1201,10 +1201,23 @@ public sealed class FileBasedProgramsWorkspaceTests(ITestOutputHelper testOutput
         );
 
         // Trivial edit+save of the App.cs file will trigger a reload though.
+        // Subscribe before writing to disk so the workspace waiter cannot finish before
+        // the FileSystemWatcher has delivered the event that enqueues the reload.
+        var fileChangeWatcher = testLspServer.GetRequiredLspService<IFileChangeWatcher>();
+        using var fileChangeContext = fileChangeWatcher.CreateContext([new WatchedDirectory(Path.GetDirectoryName(appCsFile.Path)!, extensionFilters: [])]);
+        var fileChangeTcs = new TaskCompletionSource();
+        fileChangeContext.FileChanged += (_, e) =>
+        {
+            if (e.FilePath == appCsFile.Path)
+                fileChangeTcs.TrySetResult();
+        };
+
         appCsFile.WriteAllText(appCsText + Environment.NewLine);
         var appCsSourceText = SourceText.From(appCsText);
         var appCsEndPosition = appCsSourceText.Lines.GetLinePosition(appCsSourceText.Length);
         await testLspServer.InsertTextAsync(appCsUri, (Line: appCsEndPosition.Line, Column: appCsEndPosition.Character, Text: Environment.NewLine));
+
+        await fileChangeTcs.Task.WaitAsync(TimeSpan.FromSeconds(30));
         await WaitForProjectLoad(appCsUri, testLspServer);
 
         // Get the Util.cs document again


### PR DESCRIPTION
Fixes the unrelated `TestMultiFile_EditTransitiveDirective` failure observed while validating #85133 in Azure DevOps build 1579046.

The test wrote the entry-point file and immediately waited for workspace operations. On slower CI machines, that waiter could complete before the file watcher delivered the change and enqueued the project reload, leaving the expected `Util2` diagnostic in the workspace. Subscribe before writing the file and wait for the matching file-change notification before waiting for project load.

The intermediate assertion continues to reproduce #85112; this only stabilizes the final reload assertion.

Validation:
- Reproduced the failure locally before the change.
- Focused test passes both `mutatingLspWorkspace` variants.
- Repeated the focused test five times (10 total test cases), all passing.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85138)