### PR TITLE
[Add options to] skip formatting in script and style blocks with complex Razor expressions

### DIFF
--- a/.github/instructions/Razor.instructions.md
+++ b/.github/instructions/Razor.instructions.md
@@ -61,7 +61,9 @@ their original sub-tree layout
 - **Visual Studio options**: Register Razor Advanced settings in
   `Microsoft.VisualStudio.RazorExtension\UnifiedSettings\razor.registration.json`, localize
   their UI text in `VSPackage.resx`, read them through `OptionsStorage`, and add remotely consumed
-  values to `ClientAdvancedSettings` so `IClientSettingsManager` synchronizes changes live.
+  values to `ClientAdvancedSettings` so `IClientSettingsManager` synchronizes changes live. Whenever
+  `razor.registration.json` changes, also change the `CacheTag` in
+  `Microsoft.VisualStudio.RazorExtension\Microsoft.VisualStudio.RazorExtension.Custom.pkgdef`.
 
 ## Adding OOP Remote Services
 

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Formatting/CohostDocumentFormattingEndpoint.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Formatting/CohostDocumentFormattingEndpoint.cs
@@ -81,10 +81,12 @@ internal sealed class CohostDocumentFormattingEndpoint(
         var sourceText = await razorDocument.GetTextAsync(cancellationToken).ConfigureAwait(false);
         var htmlChanges = htmlEdits.SelectAsArray(sourceText.GetTextChange);
 
+        var settings = _clientSettingsManager.GetClientSettings().AdvancedSettings;
         var options = RazorFormattingOptions.From(
             request.Options,
-            _clientSettingsManager.GetClientSettings().AdvancedSettings.CodeBlockBraceOnNextLine,
-            _clientSettingsManager.GetClientSettings().AdvancedSettings.AttributeIndentStyle,
+            settings.CodeBlockBraceOnNextLine,
+            settings.AttributeIndentStyle,
+            settings.IgnoreIndentationInScriptOrStyleBlocksWithComplexRazor,
             csharpSyntaxFormattingOptions);
 
         _logger.LogDebug($"Calling OOP with the {htmlChanges.Length} html edits, so it can fill in the rest");

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Formatting/CohostOnTypeFormattingEndpoint.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Formatting/CohostOnTypeFormattingEndpoint.cs
@@ -119,7 +119,12 @@ internal sealed class CohostOnTypeFormattingEndpoint(
         }
 
         var csharpSyntaxFormattingOptions = CSharpFormattingOptionsHelper.GetCSharpSyntaxFormattingOptions(razorDocument, cancellationToken);
-        var options = RazorFormattingOptions.From(request.Options, clientSettings.AdvancedSettings.CodeBlockBraceOnNextLine, clientSettings.AdvancedSettings.AttributeIndentStyle, csharpSyntaxFormattingOptions);
+        var options = RazorFormattingOptions.From(
+            request.Options,
+            clientSettings.AdvancedSettings.CodeBlockBraceOnNextLine,
+            clientSettings.AdvancedSettings.AttributeIndentStyle,
+            clientSettings.AdvancedSettings.IgnoreIndentationInScriptOrStyleBlocksWithComplexRazor,
+            csharpSyntaxFormattingOptions);
 
         _logger.LogDebug($"Calling OOP with the {htmlChanges.Length} html edits, so it can fill in the rest");
         var remoteResult = await _remoteServiceInvoker.TryInvokeAsync<IRemoteFormattingService, ImmutableArray<TextChange>>(

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Formatting/CohostRangeFormattingEndpoint.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Formatting/CohostRangeFormattingEndpoint.cs
@@ -84,10 +84,12 @@ internal sealed class CohostRangeFormattingEndpoint(
         var htmlChanges = htmlEdits.SelectAsArray(sourceText.GetTextChange);
 
         var csharpSyntaxFormattingOptions = CSharpFormattingOptionsHelper.GetCSharpSyntaxFormattingOptions(razorDocument, cancellationToken);
+        var settings = _clientSettingsManager.GetClientSettings().AdvancedSettings;
         var options = RazorFormattingOptions.From(
             request.Options,
-            _clientSettingsManager.GetClientSettings().AdvancedSettings.CodeBlockBraceOnNextLine,
-            _clientSettingsManager.GetClientSettings().AdvancedSettings.AttributeIndentStyle,
+            settings.CodeBlockBraceOnNextLine,
+            settings.AttributeIndentStyle,
+            settings.IgnoreIndentationInScriptOrStyleBlocksWithComplexRazor,
             csharpSyntaxFormattingOptions,
             fromPaste);
 

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/OnAutoInsert/CohostOnAutoInsertEndpoint.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/OnAutoInsert/CohostOnAutoInsertEndpoint.cs
@@ -94,8 +94,9 @@ internal sealed class CohostOnAutoInsertEndpoint(
         var clientSettings = _clientSettingsManager.GetClientSettings();
         var razorFormattingOptions = RazorFormattingOptions.From(
             request.Options,
-            codeBlockBraceOnNextLine: clientSettings.AdvancedSettings.CodeBlockBraceOnNextLine,
-            attributeIndentStyle: clientSettings.AdvancedSettings.AttributeIndentStyle,
+            clientSettings.AdvancedSettings.CodeBlockBraceOnNextLine,
+            clientSettings.AdvancedSettings.AttributeIndentStyle,
+            clientSettings.AdvancedSettings.IgnoreIndentationInScriptOrStyleBlocksWithComplexRazor,
             csharpSyntaxFormattingOptions);
         var resolvedCSharpSyntaxFormattingOptions = CSharpFormattingOptionsHelper.GetResolvedCSharpSyntaxFormattingOptions(razorFormattingOptions);
         razorFormattingOptions = razorFormattingOptions with

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/RazorFormattingOptions.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/RazorFormattingOptions.cs
@@ -23,28 +23,43 @@ internal readonly record struct RazorFormattingOptions
     public CSharpSyntaxFormattingOptions CSharpSyntaxFormattingOptions { get; init; } = CSharpSyntaxFormattingOptions.Default;
     [DataMember(Order = 5)]
     public bool FromPaste { get; init; } = false;
+    [DataMember(Order = 6)]
+    public bool IgnoreIndentationInScriptOrStyleBlocksWithComplexRazor { get; init; } = true;
 
     public RazorFormattingOptions()
     {
     }
 
-    public static RazorFormattingOptions From(LspFormattingOptions options, bool codeBlockBraceOnNextLine, AttributeIndentStyle attributeIndentStyle, CSharpSyntaxFormattingOptions csharpSyntaxFormattingOptions)
+    public static RazorFormattingOptions From(
+        LspFormattingOptions options,
+        bool codeBlockBraceOnNextLine,
+        AttributeIndentStyle attributeIndentStyle,
+        bool ignoreIndentationInScriptOrStyleBlocksWithComplexRazor,
+        CSharpSyntaxFormattingOptions csharpSyntaxFormattingOptions)
         => new()
         {
             InsertSpaces = options.InsertSpaces,
             TabSize = options.TabSize,
             CodeBlockBraceOnNextLine = codeBlockBraceOnNextLine,
             AttributeIndentStyle = attributeIndentStyle,
+            IgnoreIndentationInScriptOrStyleBlocksWithComplexRazor = ignoreIndentationInScriptOrStyleBlocksWithComplexRazor,
             CSharpSyntaxFormattingOptions = csharpSyntaxFormattingOptions,
         };
 
-    public static RazorFormattingOptions From(LspFormattingOptions options, bool codeBlockBraceOnNextLine, AttributeIndentStyle attributeIndentStyle, CSharpSyntaxFormattingOptions csharpSyntaxFormattingOptions, bool fromPaste)
+    public static RazorFormattingOptions From(
+        LspFormattingOptions options,
+        bool codeBlockBraceOnNextLine,
+        AttributeIndentStyle attributeIndentStyle,
+        bool ignoreIndentationInScriptOrStyleBlocksWithComplexRazor,
+        CSharpSyntaxFormattingOptions csharpSyntaxFormattingOptions,
+        bool fromPaste)
         => new()
         {
             InsertSpaces = options.InsertSpaces,
             TabSize = options.TabSize,
             CodeBlockBraceOnNextLine = codeBlockBraceOnNextLine,
             AttributeIndentStyle = attributeIndentStyle,
+            IgnoreIndentationInScriptOrStyleBlocksWithComplexRazor = ignoreIndentationInScriptOrStyleBlocksWithComplexRazor,
             CSharpSyntaxFormattingOptions = csharpSyntaxFormattingOptions,
             FromPaste = fromPaste
         };

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/RazorSyntaxFacts.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/RazorSyntaxFacts.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.CodeAnalysis.Text;
 using RazorSyntaxNode = Microsoft.AspNetCore.Razor.Language.Syntax.SyntaxNode;
+using RazorSyntaxToken = Microsoft.AspNetCore.Razor.Language.Syntax.SyntaxToken;
 
 namespace Microsoft.CodeAnalysis.Razor;
 
@@ -175,6 +176,92 @@ internal static class RazorSyntaxFacts
 
         return string.Equals(tagName, "script", StringComparison.OrdinalIgnoreCase) ||
             string.Equals(tagName, "style", StringComparison.OrdinalIgnoreCase);
+    }
+
+    internal static bool ContainsComplexRazorInScriptOrStyleBody(BaseMarkupElementSyntax element, SourceText sourceText)
+    {
+        if (!IsScriptOrStyleBlock(element) ||
+            element.StartTag is not { } startTag ||
+            element.EndTag is not { } endTag ||
+            endTag.SpanStart < startTag.EndPosition)
+        {
+            return false;
+        }
+
+        var bodySpan = TextSpan.FromBounds(startTag.EndPosition, endTag.SpanStart);
+        foreach (var token in element.DescendantTokens(bodySpan))
+        {
+            // Razor comments are projected as placeholders, which makes script/style indentation unsafe to delegate.
+            if (token.Kind == SyntaxKind.RazorCommentTransition)
+            {
+                return true;
+            }
+
+            // Only non-escaped Razor transitions can introduce code that makes the block complex.
+            if (token.Kind != SyntaxKind.Transition ||
+                IsEscapedTransition(token))
+            {
+                continue;
+            }
+
+            // Allow only single-line expressions embedded within script/style content; every other Razor construct is complex.
+            var expression = token.Parent?.AncestorsAndSelf().FirstOrDefault(
+                static node => node is CSharpImplicitExpressionSyntax or CSharpExplicitExpressionSyntax);
+            if (expression is null ||
+                !IsSingleLineInlineExpression(expression, sourceText, startTag.EndPosition, endTag.SpanStart))
+            {
+                return true;
+            }
+        }
+
+        return false;
+
+        static bool IsSingleLineInlineExpression(RazorSyntaxNode expression, SourceText sourceText, int bodyStart, int bodyEnd)
+        {
+            var linePositionSpan = sourceText.GetLinePositionSpan(expression.Span);
+            if (linePositionSpan.Start.Line != linePositionSpan.End.Line ||
+                expression.DescendantNodes().Any(static node =>
+                    node is CSharpTemplateBlockSyntax or
+                        CSharpStatementSyntax or
+                        RazorCommentBlockSyntax or
+                        RazorDirectiveSyntax))
+            {
+                return false;
+            }
+
+            var line = sourceText.Lines[linePositionSpan.Start.Line];
+            return ContainsNonWhitespace(sourceText, Math.Max(line.Start, bodyStart), expression.SpanStart) &&
+                ContainsNonWhitespace(sourceText, expression.EndPosition, Math.Min(line.End, bodyEnd));
+        }
+
+        static bool IsEscapedTransition(RazorSyntaxToken token)
+        {
+            if (IsInEphemeralTextLiteral(token))
+            {
+                return true;
+            }
+
+            var previousToken = token.GetPreviousToken();
+            return previousToken.Kind == SyntaxKind.Transition &&
+                previousToken.EndPosition == token.Position &&
+                IsInEphemeralTextLiteral(previousToken);
+        }
+
+        static bool IsInEphemeralTextLiteral(RazorSyntaxToken token)
+            => token.Parent?.AncestorsAndSelf().Any(static node => node is MarkupEphemeralTextLiteralSyntax) == true;
+
+        static bool ContainsNonWhitespace(SourceText sourceText, int start, int end)
+        {
+            for (var i = start; i < end; i++)
+            {
+                if (!char.IsWhiteSpace(sourceText[i]))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
     }
 
     internal static bool IsAttributeName(RazorSyntaxNode node, [NotNullWhen(true)] out BaseMarkupStartTagSyntax? startTag)

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Settings/ClientSettings.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Settings/ClientSettings.cs
@@ -34,6 +34,7 @@ internal record ClientSettings(
             TabSize = ClientSpaceSettings.IndentSize,
             CodeBlockBraceOnNextLine = AdvancedSettings.CodeBlockBraceOnNextLine,
             AttributeIndentStyle = AdvancedSettings.AttributeIndentStyle,
+            IgnoreIndentationInScriptOrStyleBlocksWithComplexRazor = AdvancedSettings.IgnoreIndentationInScriptOrStyleBlocksWithComplexRazor,
         };
 }
 
@@ -58,6 +59,7 @@ internal sealed record ClientAdvancedSettings(
     [property: JsonPropertyName("colorBackground")] bool ColorBackground,
     [property: JsonPropertyName("codeBlockBraceOnNextLine")] bool CodeBlockBraceOnNextLine,
     [property: JsonPropertyName("attributeIndentStyle")] AttributeIndentStyle AttributeIndentStyle,
+    [property: JsonPropertyName("ignoreIndentationInScriptOrStyleBlocksWithComplexRazor")] bool IgnoreIndentationInScriptOrStyleBlocksWithComplexRazor,
     [property: JsonPropertyName("commitElementsWithSpace")] bool CommitElementsWithSpace,
     [property: JsonPropertyName("snippetSetting")] SnippetSetting SnippetSetting,
     [property: JsonPropertyName("logLevel")] LogLevel LogLevel,
@@ -71,6 +73,7 @@ internal sealed record ClientAdvancedSettings(
                                                                 ColorBackground: false,
                                                                 CodeBlockBraceOnNextLine: false,
                                                                 AttributeIndentStyle: AttributeIndentStyle.AlignWithFirst,
+                                                                IgnoreIndentationInScriptOrStyleBlocksWithComplexRazor: true,
                                                                 CommitElementsWithSpace: true,
                                                                 SnippetSetting.All,
                                                                 LogLevel.Warning,
@@ -87,6 +90,7 @@ internal sealed record ClientAdvancedSettings(
             ColorBackground == other.ColorBackground &&
             CodeBlockBraceOnNextLine == other.CodeBlockBraceOnNextLine &&
             AttributeIndentStyle == other.AttributeIndentStyle &&
+            IgnoreIndentationInScriptOrStyleBlocksWithComplexRazor == other.IgnoreIndentationInScriptOrStyleBlocksWithComplexRazor &&
             CommitElementsWithSpace == other.CommitElementsWithSpace &&
             SnippetSetting == other.SnippetSetting &&
             LogLevel == other.LogLevel &&
@@ -104,6 +108,7 @@ internal sealed record ClientAdvancedSettings(
         hash.Add(ColorBackground);
         hash.Add(CodeBlockBraceOnNextLine);
         hash.Add(AttributeIndentStyle);
+        hash.Add(IgnoreIndentationInScriptOrStyleBlocksWithComplexRazor);
         hash.Add(CommitElementsWithSpace);
         hash.Add(SnippetSetting);
         hash.Add(LogLevel);

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Formatting/Passes/CSharpFormattingPass.CSharpDocumentGenerator.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Formatting/Passes/CSharpFormattingPass.CSharpDocumentGenerator.cs
@@ -166,6 +166,7 @@ internal partial class CSharpFormattingPass
             private readonly bool _insertSpaces = options.InsertSpaces;
             private readonly int _tabSize = options.TabSize;
             private readonly AttributeIndentStyle _attributeIndentStyle = options.AttributeIndentStyle;
+            private readonly bool _ignoreIndentationInScriptOrStyleBlocksWithComplexRazor = options.IgnoreIndentationInScriptOrStyleBlocksWithComplexRazor;
             private readonly CSharpSyntaxFormattingOptions _csharpSyntaxFormattingOptions = options.CSharpSyntaxFormattingOptions;
             private readonly StringBuilder _builder = builder;
             private readonly ImmutableArray<LineInfo>.Builder _lineInfoBuilder = lineInfoBuilder;
@@ -187,13 +188,12 @@ internal partial class CSharpFormattingPass
             /// </remarks>
             private int? _honourHtmlFormattingUntilLine;
             /// <summary>
-            /// The line number of the last line of a block where formatting should be completely ignored
+            /// The line number of the last line of a block where C# formatting should be ignored
             /// </summary>
             /// <remarks>
-            /// Some Html constructs, namely &lt;textarea&gt; and &lt;pre&gt;, should not be formatted at all, and we essentially
-            /// need to treat them as multiline Razor comments. This field is used to track the line number of the last line of such
-            /// an element, so we can ignore every line in it without having to do lots of tree traversal to check "are we parented
-            /// by a pre tag" etc.
+            /// Some Html constructs, such as &lt;textarea&gt; and &lt;pre&gt;, should not be formatted. Script/style bodies with
+            /// complex Razor use this to preserve the indentation from the input to this pass after Html formatting has run.
+            /// This field tracks the last ignored line so we can avoid repeatedly traversing the syntax tree.
             /// </remarks>
             private int? _ignoreUntilLine;
 
@@ -214,8 +214,6 @@ internal partial class CSharpFormattingPass
                         _currentToken = root.FindToken(firstNonWhitespacePosition);
 
                         var length = _builder.Length;
-                        _lineInfoBuilder.Add(Visit(_currentToken.Parent));
-                        Debug.Assert(_builder.Length > length, "Didn't output any generated code!");
 
                         // If there are C# mappings on this line, we want to output additional lines that represent the C# blocks.
                         while (iMapping < sourceMappings.Length)
@@ -231,7 +229,8 @@ internal partial class CSharpFormattingPass
                                 // We've found a span mapping that means there is some C# on this line, so if its an explicit or implicit expression
                                 // we need to format it, but separately to the rest of the document.
                                 var node = root.FindInnermostNode(originalSpan.AbsoluteIndex);
-                                if (node is CSharpExpressionLiteralSyntax)
+                                if (_ignoreUntilLine is null &&
+                                    node is CSharpExpressionLiteralSyntax)
                                 {
                                     AddAdditionalLineFormattingContent(additionalLinesBuilder, node, originalSpan);
                                 }
@@ -243,6 +242,9 @@ internal partial class CSharpFormattingPass
                                 break;
                             }
                         }
+
+                        _lineInfoBuilder.Add(Visit(_currentToken.Parent));
+                        Debug.Assert(_builder.Length > length, "Didn't output any generated code!");
                     }
                     else if (_documentMappingService.IsInStringLiteral(_codeDocument, _csharpSyntaxRoot, _declSyntaxRoot, line.Start, multilineOnly: false))
                     {
@@ -682,7 +684,18 @@ internal partial class CSharpFormattingPass
                     var honouredEndLine = GetLineNumber(closeAngle) - 1;
                     if (honouredEndLine > _currentLine.LineNumber)
                     {
-                        _honourHtmlFormattingUntilLine = honouredEndLine;
+                        if (_ignoreIndentationInScriptOrStyleBlocksWithComplexRazor &&
+                            RazorSyntaxFacts.ContainsComplexRazorInScriptOrStyleBody(node.ParentElement, _sourceText))
+                        {
+                            if (GetLineNumber(node.CloseAngle) == _currentLine.LineNumber)
+                            {
+                                _ignoreUntilLine = GetElementBodyEndLine(node);
+                            }
+                        }
+                        else
+                        {
+                            _honourHtmlFormattingUntilLine = honouredEndLine;
+                        }
                     }
                 }
 
@@ -858,11 +871,37 @@ internal partial class CSharpFormattingPass
                         // If this is the last line of a tag that shouldn't be indented, honour that
                         _ignoreUntilLine = GetLineNumber(startTag.GetEndTag()?.CloseAngle ?? startTag.CloseAngle);
                     }
+                    else if (_ignoreIndentationInScriptOrStyleBlocksWithComplexRazor &&
+                        GetLineNumber(node) == GetLineNumber(startTag.CloseAngle) &&
+                        startTag.ParentElement is { } element &&
+                        RazorSyntaxFacts.IsScriptOrStyleBlock(element) &&
+                        RazorSyntaxFacts.ContainsComplexRazorInScriptOrStyleBody(element, _sourceText))
+                    {
+                        // A multiline start tag reaches this path on its final attribute line. Start ignoring after that so
+                        // only the body keeps its indentation; otherwise the start tag's continuation lines would be ignored too.
+                        var ignoredEndLine = GetElementBodyEndLine(startTag);
+                        if (ignoredEndLine > _currentLine.LineNumber)
+                        {
+                            _ignoreUntilLine = ignoredEndLine;
+                        }
+                    }
 
                     return EmitCurrentLineAsComment(htmlIndentLevel: htmlIndentLevel, additionalIndentation: additionalIndentation);
                 }
 
                 return null;
+            }
+
+            private int GetElementBodyEndLine(BaseMarkupStartTagSyntax startTag)
+            {
+                var endTag = startTag.GetEndTag();
+                Debug.Assert(endTag is not null);
+
+                var endTagLine = _sourceText.Lines.GetLineFromPosition(endTag.SpanStart);
+                // Exclude a line containing only the end tag, but include it when body content appears before the end tag.
+                return endTagLine.GetFirstNonWhitespacePosition() == endTag.SpanStart
+                    ? endTagLine.LineNumber - 1
+                    : endTagLine.LineNumber;
             }
 
             private LineInfo EmitCollectionExpressionAssignmentLine(int htmlIndentLevel = 0, int? additionalIndentation = null)
@@ -1361,7 +1400,8 @@ internal partial class CSharpFormattingPass
 
             private LineInfo EmitCurrentLineWithNoFormatting()
             {
-                _builder.AppendLine();
+                // Keep ignored nonblank lines distinguishable from actual blank lines when mapping the formatted document back.
+                _builder.AppendLine("//");
                 return CreateLineInfo(processIndentation: false);
             }
 

--- a/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Formatting/Passes/HtmlFormattingPass.cs
+++ b/src/Razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Formatting/Passes/HtmlFormattingPass.cs
@@ -88,7 +88,10 @@ internal sealed partial class HtmlFormattingPass(
     {
         var codeDocument = context.CodeDocument;
         var originalText = codeDocument.Source.Text;
-        var (scriptAndStyleSpans, razorCommentSpans) = BuildSpans(codeDocument, originalText);
+        var (scriptAndStyleSpans, razorCommentSpans) = BuildSpans(
+            codeDocument,
+            originalText,
+            context.Options.IgnoreIndentationInScriptOrStyleBlocksWithComplexRazor);
 
         var csharpSyntaxTree = await context.OriginalSnapshot.GetCSharpSyntaxTreeAsync(declarationDocument: false, cancellationToken).ConfigureAwait(false);
         var csharpSyntaxRoot = await csharpSyntaxTree.GetRootAsync(cancellationToken).ConfigureAwait(false);
@@ -309,7 +312,8 @@ internal sealed partial class HtmlFormattingPass(
     /// </summary>
     private static (ImmutableArray<TextSpan> ScriptAndStyleSpans, ImmutableArray<TextSpan> RazorCommentSpans) BuildSpans(
         RazorCodeDocument codeDocument,
-        SourceText sourceText)
+        SourceText sourceText,
+        bool ignoreIndentationInScriptOrStyleBlocksWithComplexRazor)
     {
         var syntaxRoot = codeDocument.GetRequiredSyntaxRoot();
 
@@ -334,7 +338,17 @@ internal sealed partial class HtmlFormattingPass(
                 var end = firstNonWhitespace == endTag.SpanStart
                     ? endTagLine.Start
                     : firstNonWhitespace.GetValueOrDefault() + 1;
-                scriptStyleBuilder.Add(TextSpan.FromBounds(startTag.EndPosition, end));
+                if (end <= startTag.EndPosition)
+                {
+                    continue;
+                }
+
+                var span = TextSpan.FromBounds(startTag.EndPosition, end);
+                if (!ignoreIndentationInScriptOrStyleBlocksWithComplexRazor ||
+                    !RazorSyntaxFacts.ContainsComplexRazorInScriptOrStyleBody(element, sourceText))
+                {
+                    scriptStyleBuilder.Add(span);
+                }
             }
             else if (node is RazorCommentBlockSyntax comment)
             {

--- a/src/Razor/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostInlineCompletionEndpoint.cs
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostInlineCompletionEndpoint.cs
@@ -105,10 +105,12 @@ internal sealed class CohostInlineCompletionEndpoint(
         if (result.Range is not null)
         {
             var csharpSyntaxFormattingOptions = CSharpFormattingOptionsHelper.GetCSharpSyntaxFormattingOptions(razorDocument, cancellationToken);
+            var settings = _clientSettingsManager.GetClientSettings().AdvancedSettings;
             var options = RazorFormattingOptions.From(
                 formattingOptions,
-                _clientSettingsManager.GetClientSettings().AdvancedSettings.CodeBlockBraceOnNextLine,
-                _clientSettingsManager.GetClientSettings().AdvancedSettings.AttributeIndentStyle,
+                settings.CodeBlockBraceOnNextLine,
+                settings.AttributeIndentStyle,
+                settings.IgnoreIndentationInScriptOrStyleBlocksWithComplexRazor,
                 csharpSyntaxFormattingOptions);
             var span = result.Range.ToLinePositionSpan();
             var formattedInfo = await _remoteServiceInvoker.TryInvokeAsync<IRemoteInlineCompletionService, FormattedInlineCompletionInfo?>(

--- a/src/Razor/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Options/OptionsStorage.cs
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Options/OptionsStorage.cs
@@ -105,6 +105,7 @@ internal class OptionsStorage : IAdvancedSettingsStorage, IDisposable
             GetBool(SettingsNames.ColorBackground, defaultValue: false),
             GetBool(SettingsNames.CodeBlockBraceOnNextLine, defaultValue: false),
             GetEnum(SettingsNames.AttributeIndentStyle, AttributeIndentStyle.AlignWithFirst),
+            GetBool(SettingsNames.IgnoreIndentationInScriptOrStyleBlocksWithComplexRazor, defaultValue: true),
             GetBool(SettingsNames.CommitElementsWithSpace, defaultValue: true),
             GetEnum(SettingsNames.Snippets, SnippetSetting.All),
             GetEnum(SettingsNames.LogLevel, LogLevel.Warning),

--- a/src/Razor/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Options/SettingsNames.cs
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Options/SettingsNames.cs
@@ -13,6 +13,7 @@ internal static class SettingsNames
     public const string ColorBackground = UnifiedCollection + ".colorBackground";
     public const string CodeBlockBraceOnNextLine = UnifiedCollection + ".codeBlockBraceOnNextLine";
     public const string AttributeIndentStyle = UnifiedCollection + ".attributeIndentStyle";
+    public const string IgnoreIndentationInScriptOrStyleBlocksWithComplexRazor = UnifiedCollection + ".ignoreIndentationInScriptOrStyleBlocksWithComplexRazor";
     public const string CommitElementsWithSpace = UnifiedCollection + ".commitElementsWithSpace";
     public const string Snippets = UnifiedCollection + ".snippets";
     public const string LogLevel = UnifiedCollection + ".logLevel";
@@ -27,6 +28,7 @@ internal static class SettingsNames
         ColorBackground,
         CodeBlockBraceOnNextLine,
         AttributeIndentStyle,
+        IgnoreIndentationInScriptOrStyleBlocksWithComplexRazor,
         CommitElementsWithSpace,
         Snippets,
         LogLevel,

--- a/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
@@ -45,4 +45,4 @@
 [$RootKey$\SettingsManifests\{13b72f58-279e-49e0-a56d-296be02f0805}]
 @="Microsoft.VisualStudio.RazorExtension.RazorPackage"
 "ManifestPath"="$PackageFolder$\UnifiedSettings\razor.registration.json"
-"CacheTag"=qword:A925EEC5A7C20391
+"CacheTag"=qword:B4A714AD3B860EEB

--- a/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension/UnifiedSettings/razor.registration.json
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension/UnifiedSettings/razor.registration.json
@@ -101,6 +101,12 @@
       "title": "@Setting_AttributeIndentStyleDisplayName;{13b72f58-279e-49e0-a56d-296be02f0805}",
       "description": "@Setting_AttributeIndentStyleDescription;{13b72f58-279e-49e0-a56d-296be02f0805}"
     },
+    "languages.razor.advanced.ignoreIndentationInScriptOrStyleBlocksWithComplexRazor": {
+      "type": "boolean",
+      "default": true,
+      "title": "@Setting_IgnoreIndentationInScriptOrStyleBlocksWithComplexRazorDisplayName;{13b72f58-279e-49e0-a56d-296be02f0805}",
+      "description": "@Setting_IgnoreIndentationInScriptOrStyleBlocksWithComplexRazorDescription;{13b72f58-279e-49e0-a56d-296be02f0805}"
+    },
     "languages.razor.advanced.commitElementsWithSpace": {
       "type": "boolean",
       "default": true,

--- a/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension/VSPackage.resx
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension/VSPackage.resx
@@ -168,6 +168,12 @@
   <data name="Setting_CodeBlockBraceOnNextLineDisplayName" xml:space="preserve">
     <value>Code/functions block open brace on next line</value>
   </data>
+  <data name="Setting_IgnoreIndentationInScriptOrStyleBlocksWithComplexRazorDescription" xml:space="preserve">
+    <value>If true, preserves source indentation inside script and style blocks that contain Razor statements, blocks, directives, comments, templates, or standalone expressions</value>
+  </data>
+  <data name="Setting_IgnoreIndentationInScriptOrStyleBlocksWithComplexRazorDisplayName" xml:space="preserve">
+    <value>Ignore indentation in script or style blocks with complex Razor</value>
+  </data>
   <data name="Setting_ColorBackgroundDescription" xml:space="preserve">
     <value>If true, gives C# code in Razor files a background color</value>
   </data>

--- a/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.cs.xlf
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.cs.xlf
@@ -137,6 +137,16 @@
         <target state="translated">Formátovat při psaní</target>
         <note />
       </trans-unit>
+      <trans-unit id="Setting_IgnoreIndentationInScriptOrStyleBlocksWithComplexRazorDescription">
+        <source>If true, preserves source indentation inside script and style blocks that contain Razor statements, blocks, directives, comments, templates, or standalone expressions</source>
+        <target state="new">If true, preserves source indentation inside script and style blocks that contain Razor statements, blocks, directives, comments, templates, or standalone expressions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Setting_IgnoreIndentationInScriptOrStyleBlocksWithComplexRazorDisplayName">
+        <source>Ignore indentation in script or style blocks with complex Razor</source>
+        <target state="new">Ignore indentation in script or style blocks with complex Razor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Setting_LogLevelCritical">
         <source>Critical</source>
         <target state="translated">Kritická</target>

--- a/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.de.xlf
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.de.xlf
@@ -137,6 +137,16 @@
         <target state="translated">Bei Eingabe formatieren</target>
         <note />
       </trans-unit>
+      <trans-unit id="Setting_IgnoreIndentationInScriptOrStyleBlocksWithComplexRazorDescription">
+        <source>If true, preserves source indentation inside script and style blocks that contain Razor statements, blocks, directives, comments, templates, or standalone expressions</source>
+        <target state="new">If true, preserves source indentation inside script and style blocks that contain Razor statements, blocks, directives, comments, templates, or standalone expressions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Setting_IgnoreIndentationInScriptOrStyleBlocksWithComplexRazorDisplayName">
+        <source>Ignore indentation in script or style blocks with complex Razor</source>
+        <target state="new">Ignore indentation in script or style blocks with complex Razor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Setting_LogLevelCritical">
         <source>Critical</source>
         <target state="translated">Kritisch</target>

--- a/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.es.xlf
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.es.xlf
@@ -137,6 +137,16 @@
         <target state="translated">Dar formato al escribir</target>
         <note />
       </trans-unit>
+      <trans-unit id="Setting_IgnoreIndentationInScriptOrStyleBlocksWithComplexRazorDescription">
+        <source>If true, preserves source indentation inside script and style blocks that contain Razor statements, blocks, directives, comments, templates, or standalone expressions</source>
+        <target state="new">If true, preserves source indentation inside script and style blocks that contain Razor statements, blocks, directives, comments, templates, or standalone expressions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Setting_IgnoreIndentationInScriptOrStyleBlocksWithComplexRazorDisplayName">
+        <source>Ignore indentation in script or style blocks with complex Razor</source>
+        <target state="new">Ignore indentation in script or style blocks with complex Razor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Setting_LogLevelCritical">
         <source>Critical</source>
         <target state="translated">Crítico</target>

--- a/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.fr.xlf
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.fr.xlf
@@ -137,6 +137,16 @@
         <target state="translated">Mettre en forme sur le type</target>
         <note />
       </trans-unit>
+      <trans-unit id="Setting_IgnoreIndentationInScriptOrStyleBlocksWithComplexRazorDescription">
+        <source>If true, preserves source indentation inside script and style blocks that contain Razor statements, blocks, directives, comments, templates, or standalone expressions</source>
+        <target state="new">If true, preserves source indentation inside script and style blocks that contain Razor statements, blocks, directives, comments, templates, or standalone expressions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Setting_IgnoreIndentationInScriptOrStyleBlocksWithComplexRazorDisplayName">
+        <source>Ignore indentation in script or style blocks with complex Razor</source>
+        <target state="new">Ignore indentation in script or style blocks with complex Razor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Setting_LogLevelCritical">
         <source>Critical</source>
         <target state="translated">Critique</target>

--- a/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.it.xlf
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.it.xlf
@@ -137,6 +137,16 @@
         <target state="translated">Formattare durante la digitazione</target>
         <note />
       </trans-unit>
+      <trans-unit id="Setting_IgnoreIndentationInScriptOrStyleBlocksWithComplexRazorDescription">
+        <source>If true, preserves source indentation inside script and style blocks that contain Razor statements, blocks, directives, comments, templates, or standalone expressions</source>
+        <target state="new">If true, preserves source indentation inside script and style blocks that contain Razor statements, blocks, directives, comments, templates, or standalone expressions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Setting_IgnoreIndentationInScriptOrStyleBlocksWithComplexRazorDisplayName">
+        <source>Ignore indentation in script or style blocks with complex Razor</source>
+        <target state="new">Ignore indentation in script or style blocks with complex Razor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Setting_LogLevelCritical">
         <source>Critical</source>
         <target state="translated">Critico</target>

--- a/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.ja.xlf
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.ja.xlf
@@ -137,6 +137,16 @@
         <target state="translated">入力時に書式設定</target>
         <note />
       </trans-unit>
+      <trans-unit id="Setting_IgnoreIndentationInScriptOrStyleBlocksWithComplexRazorDescription">
+        <source>If true, preserves source indentation inside script and style blocks that contain Razor statements, blocks, directives, comments, templates, or standalone expressions</source>
+        <target state="new">If true, preserves source indentation inside script and style blocks that contain Razor statements, blocks, directives, comments, templates, or standalone expressions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Setting_IgnoreIndentationInScriptOrStyleBlocksWithComplexRazorDisplayName">
+        <source>Ignore indentation in script or style blocks with complex Razor</source>
+        <target state="new">Ignore indentation in script or style blocks with complex Razor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Setting_LogLevelCritical">
         <source>Critical</source>
         <target state="translated">重大</target>

--- a/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.ko.xlf
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.ko.xlf
@@ -137,6 +137,16 @@
         <target state="translated">형식의 서식</target>
         <note />
       </trans-unit>
+      <trans-unit id="Setting_IgnoreIndentationInScriptOrStyleBlocksWithComplexRazorDescription">
+        <source>If true, preserves source indentation inside script and style blocks that contain Razor statements, blocks, directives, comments, templates, or standalone expressions</source>
+        <target state="new">If true, preserves source indentation inside script and style blocks that contain Razor statements, blocks, directives, comments, templates, or standalone expressions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Setting_IgnoreIndentationInScriptOrStyleBlocksWithComplexRazorDisplayName">
+        <source>Ignore indentation in script or style blocks with complex Razor</source>
+        <target state="new">Ignore indentation in script or style blocks with complex Razor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Setting_LogLevelCritical">
         <source>Critical</source>
         <target state="translated">위험</target>

--- a/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.pl.xlf
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.pl.xlf
@@ -137,6 +137,16 @@
         <target state="translated">Formatuj według typu</target>
         <note />
       </trans-unit>
+      <trans-unit id="Setting_IgnoreIndentationInScriptOrStyleBlocksWithComplexRazorDescription">
+        <source>If true, preserves source indentation inside script and style blocks that contain Razor statements, blocks, directives, comments, templates, or standalone expressions</source>
+        <target state="new">If true, preserves source indentation inside script and style blocks that contain Razor statements, blocks, directives, comments, templates, or standalone expressions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Setting_IgnoreIndentationInScriptOrStyleBlocksWithComplexRazorDisplayName">
+        <source>Ignore indentation in script or style blocks with complex Razor</source>
+        <target state="new">Ignore indentation in script or style blocks with complex Razor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Setting_LogLevelCritical">
         <source>Critical</source>
         <target state="translated">Krytyczny</target>

--- a/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.pt-BR.xlf
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.pt-BR.xlf
@@ -137,6 +137,16 @@
         <target state="translated">Formatar no tipo</target>
         <note />
       </trans-unit>
+      <trans-unit id="Setting_IgnoreIndentationInScriptOrStyleBlocksWithComplexRazorDescription">
+        <source>If true, preserves source indentation inside script and style blocks that contain Razor statements, blocks, directives, comments, templates, or standalone expressions</source>
+        <target state="new">If true, preserves source indentation inside script and style blocks that contain Razor statements, blocks, directives, comments, templates, or standalone expressions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Setting_IgnoreIndentationInScriptOrStyleBlocksWithComplexRazorDisplayName">
+        <source>Ignore indentation in script or style blocks with complex Razor</source>
+        <target state="new">Ignore indentation in script or style blocks with complex Razor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Setting_LogLevelCritical">
         <source>Critical</source>
         <target state="translated">Crítico</target>

--- a/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.ru.xlf
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.ru.xlf
@@ -137,6 +137,16 @@
         <target state="translated">Форматировать по типу</target>
         <note />
       </trans-unit>
+      <trans-unit id="Setting_IgnoreIndentationInScriptOrStyleBlocksWithComplexRazorDescription">
+        <source>If true, preserves source indentation inside script and style blocks that contain Razor statements, blocks, directives, comments, templates, or standalone expressions</source>
+        <target state="new">If true, preserves source indentation inside script and style blocks that contain Razor statements, blocks, directives, comments, templates, or standalone expressions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Setting_IgnoreIndentationInScriptOrStyleBlocksWithComplexRazorDisplayName">
+        <source>Ignore indentation in script or style blocks with complex Razor</source>
+        <target state="new">Ignore indentation in script or style blocks with complex Razor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Setting_LogLevelCritical">
         <source>Critical</source>
         <target state="translated">Критический</target>

--- a/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.tr.xlf
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.tr.xlf
@@ -137,6 +137,16 @@
         <target state="translated">Yazarken biçimlendir</target>
         <note />
       </trans-unit>
+      <trans-unit id="Setting_IgnoreIndentationInScriptOrStyleBlocksWithComplexRazorDescription">
+        <source>If true, preserves source indentation inside script and style blocks that contain Razor statements, blocks, directives, comments, templates, or standalone expressions</source>
+        <target state="new">If true, preserves source indentation inside script and style blocks that contain Razor statements, blocks, directives, comments, templates, or standalone expressions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Setting_IgnoreIndentationInScriptOrStyleBlocksWithComplexRazorDisplayName">
+        <source>Ignore indentation in script or style blocks with complex Razor</source>
+        <target state="new">Ignore indentation in script or style blocks with complex Razor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Setting_LogLevelCritical">
         <source>Critical</source>
         <target state="translated">Kritik</target>

--- a/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.zh-Hans.xlf
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.zh-Hans.xlf
@@ -137,6 +137,16 @@
         <target state="translated">键入时设置格式</target>
         <note />
       </trans-unit>
+      <trans-unit id="Setting_IgnoreIndentationInScriptOrStyleBlocksWithComplexRazorDescription">
+        <source>If true, preserves source indentation inside script and style blocks that contain Razor statements, blocks, directives, comments, templates, or standalone expressions</source>
+        <target state="new">If true, preserves source indentation inside script and style blocks that contain Razor statements, blocks, directives, comments, templates, or standalone expressions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Setting_IgnoreIndentationInScriptOrStyleBlocksWithComplexRazorDisplayName">
+        <source>Ignore indentation in script or style blocks with complex Razor</source>
+        <target state="new">Ignore indentation in script or style blocks with complex Razor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Setting_LogLevelCritical">
         <source>Critical</source>
         <target state="translated">严重</target>

--- a/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.zh-Hant.xlf
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.zh-Hant.xlf
@@ -137,6 +137,16 @@
         <target state="translated">輸入時格式化</target>
         <note />
       </trans-unit>
+      <trans-unit id="Setting_IgnoreIndentationInScriptOrStyleBlocksWithComplexRazorDescription">
+        <source>If true, preserves source indentation inside script and style blocks that contain Razor statements, blocks, directives, comments, templates, or standalone expressions</source>
+        <target state="new">If true, preserves source indentation inside script and style blocks that contain Razor statements, blocks, directives, comments, templates, or standalone expressions</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Setting_IgnoreIndentationInScriptOrStyleBlocksWithComplexRazorDisplayName">
+        <source>Ignore indentation in script or style blocks with complex Razor</source>
+        <target state="new">Ignore indentation in script or style blocks with complex Razor</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Setting_LogLevelCritical">
         <source>Critical</source>
         <target state="translated">危急</target>

--- a/src/Razor/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/Services/CohostConfigurationChangedService.cs
+++ b/src/Razor/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/Services/CohostConfigurationChangedService.cs
@@ -50,6 +50,7 @@ internal sealed class CohostConfigurationChangedService(
                 //TODO: new ConfigurationItem { Section = "razor.format.enable" },
                 new ConfigurationItem { Section = "razor.format.code_block_brace_on_next_line" },
                 new ConfigurationItem { Section = "razor.format.attribute_indent_style" },
+                new ConfigurationItem { Section = "razor.format.ignore_indentation_in_script_or_style_blocks_with_complex_razor" },
                 new ConfigurationItem { Section = "razor.completion.commit_elements_with_space" },
                 // Note: VS Code settings use snake_case, so this is "auto_closing_tags" not "autoClosingTags"
                 // TypeScript code in the VS Code extension converts between camelCase and snake_case
@@ -75,9 +76,10 @@ internal sealed class CohostConfigurationChangedService(
         {
             CodeBlockBraceOnNextLine = GetBooleanOptionValue(TryGetElement(jsonArray, 0), settings.CodeBlockBraceOnNextLine),
             AttributeIndentStyle = GetEnumOptionValue(TryGetElement(jsonArray, 1), settings.AttributeIndentStyle),
-            CommitElementsWithSpace = GetBooleanOptionValue(TryGetElement(jsonArray, 2), settings.CommitElementsWithSpace),
-            AutoClosingTags = GetBooleanOptionValue(TryGetElement(jsonArray, 3), settings.AutoClosingTags),
-            ShowAllCSharpCodeActions = GetBooleanOptionValue(TryGetElement(jsonArray, 4), settings.ShowAllCSharpCodeActions),
+            IgnoreIndentationInScriptOrStyleBlocksWithComplexRazor = GetBooleanOptionValue(TryGetElement(jsonArray, 2), settings.IgnoreIndentationInScriptOrStyleBlocksWithComplexRazor),
+            CommitElementsWithSpace = GetBooleanOptionValue(TryGetElement(jsonArray, 3), settings.CommitElementsWithSpace),
+            AutoClosingTags = GetBooleanOptionValue(TryGetElement(jsonArray, 4), settings.AutoClosingTags),
+            ShowAllCSharpCodeActions = GetBooleanOptionValue(TryGetElement(jsonArray, 5), settings.ShowAllCSharpCodeActions),
         };
     }
 

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Formatting/DocumentFormattingTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Formatting/DocumentFormattingTest.cs
@@ -1566,7 +1566,7 @@ public class DocumentFormattingTest(ITestOutputHelper testOutput) : DocumentForm
                     @if (showGrid)
                     {
                         <text>
-                              const ids = grid.getIds();
+                            const ids = grid.getIds();
                         </text>
                     }
                 </script>
@@ -15957,6 +15957,316 @@ public class DocumentFormattingTest(ITestOutputHelper testOutput) : DocumentForm
                 """,
             fileKind: RazorFileKind.Legacy,
             validateHtmlFormattedMatchesWebTools: true);
+    }
+
+    [Fact]
+    public Task LegacyDocumentWithJavaScriptFormattingChanges()
+    {
+        return RunFormattingTestAsync(
+            input: """
+                @page
+                @using System.Globalization
+                @model IndexModel
+                @{
+                    ViewData["Title"] = "Home page";
+                }
+
+                <div class="col col-2">
+                    <partial name="_StatCounterCard" model='@new StatCounterCardModel
+                    {
+                    Title = "Last Date",
+                    Subtitle = "Last date subtitle",
+                    IsPlaceholderLoading = false,
+                    StaticValue = (Model.LatestDate == null || Model.LatestDate == DateTime.MinValue)
+                    ? null
+                    : Model.LatestDate?. ToString("d", CultureInfo.CurrentCulture)
+                    }' />
+                </div>
+
+                @section scripts {
+                    <script>
+                        $(document).ready(function() {
+                            const config = {
+                                numbers: [],
+                                strings: []
+                            };
+
+                                @foreach (var num in Model.Q.Numbers)
+                                {
+                                    @:config.numbers.push(@num);
+                            }
+
+                                @foreach (var str in Model.Q.Strings)
+                                {
+                                    @:config.strings.push("@str");
+                            }
+                                        })
+                    </script>
+                }
+                """,
+            htmlFormatted: """
+                @page
+                @using System.Globalization
+                @model IndexModel
+                @{
+                    ViewData["Title"] = "Home page";
+                }
+
+                <div class="col col-2">
+                    <partial name="_StatCounterCard" model='@new StatCounterCardModel
+                    {
+                    Title = "Last Date",
+                    Subtitle = "Last date subtitle",
+                    IsPlaceholderLoading = false,
+                    StaticValue = (Model.LatestDate == null || Model.LatestDate == DateTime.MinValue)
+                    ? null
+                    : Model.LatestDate?. ToString("d", CultureInfo.CurrentCulture)
+                    }' />
+                </div>
+
+                @section scripts {
+                <script>
+                    $(document).ready(function() {
+                        const config = {
+                            numbers: [],
+                            strings: []
+                        };
+
+                            @foreach (var num in Model.Q.Numbers)
+                            {
+                                @:config.numbers.push(@num);
+                        }
+
+                            @foreach (var str in Model.Q.Strings)
+                            {
+                                @:config.strings.push("@str");
+                        }
+                                    })
+                </script>
+                }
+                """,
+            expected: """
+                @page
+                @using System.Globalization
+                @model IndexModel
+                @{
+                    ViewData["Title"] = "Home page";
+                }
+
+                <div class="col col-2">
+                    <partial name="_StatCounterCard" model='@new StatCounterCardModel
+                             {
+                                 Title = "Last Date",
+                                 Subtitle = "Last date subtitle",
+                                 IsPlaceholderLoading = false,
+                                 StaticValue = (Model.LatestDate == null || Model.LatestDate == DateTime.MinValue)
+                             ? null
+                             : Model.LatestDate?.ToString("d", CultureInfo.CurrentCulture)
+                             }' />
+                </div>
+
+                @section scripts {
+                    <script>
+                        $(document).ready(function() {
+                            const config = {
+                                numbers: [],
+                                strings: []
+                            };
+
+                                @foreach (var num in Model.Q.Numbers)
+                                {
+                                    @:config.numbers.push(@num);
+                            }
+
+                                @foreach (var str in Model.Q.Strings)
+                                {
+                                    @:config.strings.push("@str");
+                            }
+                                        })
+                    </script>
+                }
+                """,
+            fileKind: RazorFileKind.Legacy,
+            codeBlockBraceOnNextLine: true);
+    }
+
+    [Fact]
+    public Task ComplexScriptPreservesSourceIndentationWithTabs()
+    {
+        return RunFormattingTestAsync(
+            input: """
+                <div>
+                <script>
+                		const config = {
+                			value: 1
+                		};
+                		@if (condition)
+                		{
+                			@:config.value++;
+                		}
+                </script>
+                </div>
+                """,
+            htmlFormatted: """
+                <div>
+                	<script>
+                		const config = {
+                			value: 1
+                		};
+                		@if (condition)
+                		{
+                			@:config.value++;
+                		}
+                	</script>
+                </div>
+                """,
+            expected: """
+                <div>
+                	<script>
+                		const config = {
+                			value: 1
+                		};
+                		@if (condition)
+                		{
+                			@:config.value++;
+                		}
+                	</script>
+                </div>
+                """,
+            insertSpaces: false,
+            tabSize: 4);
+    }
+
+    [Fact]
+    public Task ComplexScriptPreservesSourceIndentation()
+    {
+        return RunFormattingTestAsync(
+            input: """
+                <script>
+                    value=1;
+                    @* Keep this comment. *@
+                </script>
+                """,
+            htmlFormatted: """
+                <script>
+                    value=1;
+                    @* Keep this comment. *@
+                </script>
+                """,
+            expected: """
+                <script>
+                    value=1;
+                    @* Keep this comment. *@
+                </script>
+                """);
+    }
+
+    [Fact]
+    public Task ComplexScriptFormatsIndentationWhenOptionDisabled()
+    {
+        return RunFormattingTestAsync(
+            input: """
+                <script>
+                    value=1;
+                    @* Keep this comment. *@
+                </script>
+                """,
+            htmlFormatted: """
+                <script>
+                    value=1;
+                    @* Keep this comment. *@
+                </script>
+                """,
+            expected: """
+                <script>
+                    value=1;
+                    @* Keep this comment. *@
+                </script>
+                """,
+            ignoreIndentationInScriptOrStyleBlocksWithComplexRazor: false);
+    }
+
+    [Fact]
+    public Task ComplexScriptWithMultilineStartTagPreservesOnlyBodyIndentation()
+    {
+        return RunFormattingTestAsync(
+            input: """
+                <script
+                type="text/javascript">
+                        @foreach (var item in items)
+                        {
+                            @:use(item);
+                        }
+                </script>
+                """,
+            htmlFormatted: """
+                <script type="text/javascript">
+                    @foreach (var item in items)
+                    {
+                        @:use(item);
+                    }
+                </script>
+                """,
+            expected: """
+                <script type="text/javascript">
+                        @foreach (var item in items)
+                        {
+                            @:use(item);
+                        }
+                </script>
+                """);
+    }
+
+    [Fact]
+    public Task ComplexScriptWithMultilineStartTagDoesNotAffectFollowingContent()
+    {
+        return RunFormattingTestAsync(
+            input: """
+                <script
+                type="application/json">@Model.Value</script>
+                @{
+                var value=1;
+                }
+                """,
+            htmlFormatted: """
+                <script type="application/json">@Model.Value</script>
+                @{
+                var value=1;
+                }
+                """,
+            expected: """
+                <script type="application/json">@Model.Value</script>
+                @{
+                    var value = 1;
+                }
+                """);
+    }
+
+    [Fact]
+    public Task ComplexScriptPreservesIndentationWhenEndTagSharesBodyLine()
+    {
+        return RunFormattingTestAsync(
+            input: """
+                <script>
+                        @if (condition)
+                        {
+                            value++;
+                        }</script>
+                """,
+            htmlFormatted: """
+                <script>
+                    @if (condition)
+                    {
+                        value++;
+                    }</script>
+                """,
+            expected: """
+                <script>
+                        @if (condition)
+                        {
+                            value++;
+                        }</script>
+                """);
     }
 
     private (string fileName, string contents)[] GetCheckBoxButtonComponentFiles()

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Formatting/DocumentFormattingTestBase.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Formatting/DocumentFormattingTestBase.cs
@@ -37,6 +37,7 @@ public abstract class DocumentFormattingTestBase(ITestOutputHelper testOutputHel
         bool inGlobalNamespace = false,
         bool codeBlockBraceOnNextLine = false,
         AttributeIndentStyle attributeIndentStyle = AttributeIndentStyle.AlignWithFirst,
+        bool ignoreIndentationInScriptOrStyleBlocksWithComplexRazor = true,
         bool insertSpaces = true,
         int tabSize = 4,
         bool allowDiagnostics = false,
@@ -101,7 +102,16 @@ public abstract class DocumentFormattingTestBase(ITestOutputHelper testOutputHel
             ? spans.First()
             : default;
 
-        var edits = await GetFormattingEditsAsync(document, htmlEdits, span, codeBlockBraceOnNextLine, attributeIndentStyle, insertSpaces, tabSize);
+        var edits = await GetFormattingEditsAsync(
+            document,
+            htmlEdits,
+            span,
+            codeBlockBraceOnNextLine,
+            attributeIndentStyle,
+            insertSpaces,
+            tabSize,
+            csharpSyntaxFormattingOptions: null,
+            ignoreIndentationInScriptOrStyleBlocksWithComplexRazor);
 
         if (edits is null)
         {
@@ -124,7 +134,8 @@ public abstract class DocumentFormattingTestBase(ITestOutputHelper testOutputHel
         AttributeIndentStyle attributeIndentStyle,
         bool insertSpaces,
         int tabSize,
-        CSharpSyntaxFormattingOptions? csharpSyntaxFormattingOptions = null)
+        CSharpSyntaxFormattingOptions? csharpSyntaxFormattingOptions,
+        bool ignoreIndentationInScriptOrStyleBlocksWithComplexRazor)
     {
         var requestInvoker = new TestHtmlRequestInvoker([(Methods.TextDocumentFormattingName, htmlEdits)]);
 
@@ -132,6 +143,7 @@ public abstract class DocumentFormattingTestBase(ITestOutputHelper testOutputHel
         {
             CodeBlockBraceOnNextLine = codeBlockBraceOnNextLine,
             AttributeIndentStyle = attributeIndentStyle,
+            IgnoreIndentationInScriptOrStyleBlocksWithComplexRazor = ignoreIndentationInScriptOrStyleBlocksWithComplexRazor,
         });
 
         var edits = await GetFormattingEditsInternalAsync(span, insertSpaces, tabSize, document, requestInvoker, ClientSettingsManager, csharpSyntaxFormattingOptions);

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Formatting/HtmlFormattingTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Formatting/HtmlFormattingTest.cs
@@ -686,7 +686,16 @@ public class HtmlFormattingTest(ITestOutputHelper testOutput) : DocumentFormatti
         formattingService.GetTestAccessor().SetFormattingLoggerFactory(new TestFormattingLoggerFactory(TestOutputHelper));
 
         var htmlEdits = new TextEdit[0];
-        var edits = await GetFormattingEditsAsync(document, htmlEdits, span: default, options.CodeBlockBraceOnNextLine, attributeIndentStyle, options.InsertSpaces, options.TabSize);
+        var edits = await GetFormattingEditsAsync(
+            document,
+            htmlEdits,
+            span: default,
+            options.CodeBlockBraceOnNextLine,
+            attributeIndentStyle,
+            options.InsertSpaces,
+            options.TabSize,
+            csharpSyntaxFormattingOptions: null,
+            ignoreIndentationInScriptOrStyleBlocksWithComplexRazor: false);
 
         Assert.NotNull(edits);
 

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.UnitTests/ClientSettingsJsonSerializationTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.UnitTests/ClientSettingsJsonSerializationTest.cs
@@ -24,6 +24,7 @@ public class ClientSettingsJsonSerializationTest
                 ColorBackground: true,
                 CodeBlockBraceOnNextLine: true,
                 AttributeIndentStyle: AttributeIndentStyle.IndentByOne,
+                IgnoreIndentationInScriptOrStyleBlocksWithComplexRazor: false,
                 CommitElementsWithSpace: false,
                 SnippetSetting: SnippetSetting.None,
                 LogLevel: LogLevel.Trace,
@@ -61,6 +62,8 @@ public class ClientSettingsJsonSerializationTest
         Assert.True(codeBlockBraceOnNextLine.GetBoolean());
         Assert.True(advancedSettings.TryGetProperty("attributeIndentStyle", out var attributeIndentStyle));
         Assert.Equal((int)AttributeIndentStyle.IndentByOne, attributeIndentStyle.GetInt32());
+        Assert.True(advancedSettings.TryGetProperty("ignoreIndentationInScriptOrStyleBlocksWithComplexRazor", out var ignoreIndentationInScriptOrStyleBlocksWithComplexRazor));
+        Assert.False(ignoreIndentationInScriptOrStyleBlocksWithComplexRazor.GetBoolean());
         Assert.True(advancedSettings.TryGetProperty("commitElementsWithSpace", out var commitElementsWithSpace));
         Assert.False(commitElementsWithSpace.GetBoolean());
         Assert.True(advancedSettings.TryGetProperty("snippetSetting", out var snippetSetting));

--- a/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Cohost/Formatting/FormattingLogTest.LegacyRazorFormattingOptions.cs
+++ b/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Cohost/Formatting/FormattingLogTest.LegacyRazorFormattingOptions.cs
@@ -20,6 +20,7 @@ public partial class FormattingLogTest
         public int TabSize { get; init; } = 4;
         public bool CodeBlockBraceOnNextLine { get; init; }
         public AttributeIndentStyle AttributeIndentStyle { get; init; } = AttributeIndentStyle.AlignWithFirst;
+        public bool IgnoreIndentationInScriptOrStyleBlocksWithComplexRazor { get; init; } = true;
         public RazorCSharpSyntaxFormattingOptions? CSharpSyntaxFormattingOptions { get; init; }
         public bool FromPaste { get; init; }
 
@@ -34,6 +35,7 @@ public partial class FormattingLogTest
                 TabSize = TabSize,
                 CodeBlockBraceOnNextLine = CodeBlockBraceOnNextLine,
                 AttributeIndentStyle = AttributeIndentStyle,
+                IgnoreIndentationInScriptOrStyleBlocksWithComplexRazor = IgnoreIndentationInScriptOrStyleBlocksWithComplexRazor,
                 CSharpSyntaxFormattingOptions = CSharpSyntaxFormattingOptions?.ToCSharpSyntaxFormattingOptions()
                     ?? Microsoft.CodeAnalysis.CSharp.Formatting.CSharpSyntaxFormattingOptions.Default,
                 FromPaste = FromPaste,

--- a/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Cohost/Formatting/FormattingLogTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Cohost/Formatting/FormattingLogTest.cs
@@ -113,7 +113,7 @@ public partial class FormattingLogTest(ITestOutputHelper testOutput) : DocumentF
         var formattingService = (RazorFormattingService)OOPExportProvider.GetExportedValue<IRazorFormattingService>();
         formattingService.GetTestAccessor().SetFormattingLoggerFactory(new TestFormattingLoggerFactory(TestOutputHelper));
 
-        var edits = await GetFormattingEditsAsync(document, htmlEdits, span, options.CodeBlockBraceOnNextLine, options.AttributeIndentStyle, options.InsertSpaces, options.TabSize, options.CSharpSyntaxFormattingOptions);
+        var edits = await GetFormattingEditsAsync(document, htmlEdits, span, options.CodeBlockBraceOnNextLine, options.AttributeIndentStyle, options.InsertSpaces, options.TabSize, options.CSharpSyntaxFormattingOptions, options.IgnoreIndentationInScriptOrStyleBlocksWithComplexRazor);
 
         // If we have a FinalFormattedDocument from the user, then we want this test to fail until the bug is fixed, and the output changes
         if (edits is not null && GetResource(testName, "FinalFormattedDocument.txt") is { } finalFormattedDocumentFile)

--- a/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Settings/ClientSettingsManagerTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.UnitTests/Settings/ClientSettingsManagerTest.cs
@@ -91,6 +91,7 @@ public class ClientSettingsManagerTest(ITestOutputHelper testOutput) : VisualStu
             ColorBackground: true,
             CodeBlockBraceOnNextLine: false,
             AttributeIndentStyle: AttributeIndentStyle.AlignWithFirst,
+            IgnoreIndentationInScriptOrStyleBlocksWithComplexRazor: false,
             CommitElementsWithSpace: false,
             SnippetSetting: SnippetSetting.All,
             LogLevel: LogLevel.None,

--- a/src/Razor/src/Razor/test/Microsoft.VisualStudioCode.RazorExtension.UnitTests/CohostConfigurationChangedServiceTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.VisualStudioCode.RazorExtension.UnitTests/CohostConfigurationChangedServiceTest.cs
@@ -21,16 +21,18 @@ public class CohostConfigurationChangedServiceTest(ITestOutputHelper testOutput)
         // If the defaults for these settings change, the json parsing could break and we might not know
         Assert.False(settings.CodeBlockBraceOnNextLine);
         Assert.Equal(AttributeIndentStyle.AlignWithFirst, settings.AttributeIndentStyle);
+        Assert.True(settings.IgnoreIndentationInScriptOrStyleBlocksWithComplexRazor);
         Assert.True(settings.CommitElementsWithSpace);
 
         var json = (JsonArray)JsonNode.Parse("""
-            ["true", "indentByOne", "false"]
+            ["true", "indentByOne", "false", "false"]
             """).AssumeNotNull();
 
         var updatedSettings = CohostConfigurationChangedService.TestAccessor.UpdateSettingsFromJson(settings, json);
 
         Assert.True(updatedSettings.CodeBlockBraceOnNextLine);
         Assert.Equal(AttributeIndentStyle.IndentByOne, updatedSettings.AttributeIndentStyle);
+        Assert.False(updatedSettings.IgnoreIndentationInScriptOrStyleBlocksWithComplexRazor);
         Assert.False(updatedSettings.CommitElementsWithSpace);
     }
 
@@ -44,25 +46,27 @@ public class CohostConfigurationChangedServiceTest(ITestOutputHelper testOutput)
 
         // Test with autoClosingTags set to false
         var json = (JsonArray)JsonNode.Parse("""
-            ["true", "indentByOne", "false", "false"]
+            ["true", "indentByOne", "false", "false", "false"]
             """).AssumeNotNull();
 
         var updatedSettings = CohostConfigurationChangedService.TestAccessor.UpdateSettingsFromJson(settings, json);
 
         Assert.True(updatedSettings.CodeBlockBraceOnNextLine);
         Assert.Equal(AttributeIndentStyle.IndentByOne, updatedSettings.AttributeIndentStyle);
+        Assert.False(updatedSettings.IgnoreIndentationInScriptOrStyleBlocksWithComplexRazor);
         Assert.False(updatedSettings.CommitElementsWithSpace);
         Assert.False(updatedSettings.AutoClosingTags);
 
         // Test with autoClosingTags set to true
         var json2 = (JsonArray)JsonNode.Parse("""
-            ["false", "alignWithFirst", "true", "true"]
+            ["false", "alignWithFirst", "true", "true", "true"]
             """).AssumeNotNull();
 
         var updatedSettings2 = CohostConfigurationChangedService.TestAccessor.UpdateSettingsFromJson(settings, json2);
 
         Assert.False(updatedSettings2.CodeBlockBraceOnNextLine);
         Assert.Equal(AttributeIndentStyle.AlignWithFirst, updatedSettings2.AttributeIndentStyle);
+        Assert.True(updatedSettings2.IgnoreIndentationInScriptOrStyleBlocksWithComplexRazor);
         Assert.True(updatedSettings2.CommitElementsWithSpace);
         Assert.True(updatedSettings2.AutoClosingTags);
     }

--- a/src/Razor/src/Razor/test/Microsoft.VisualStudioCode.RazorExtension.UnitTests/RemoteClientSettingsServiceTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.VisualStudioCode.RazorExtension.UnitTests/RemoteClientSettingsServiceTest.cs
@@ -66,6 +66,7 @@ public class RemoteClientSettingsServiceTest(ITestOutputHelper testOutput) : Coh
                 ColorBackground: true,
                 CodeBlockBraceOnNextLine: true,
                 AttributeIndentStyle: AttributeIndentStyle.IndentByOne,
+                IgnoreIndentationInScriptOrStyleBlocksWithComplexRazor: false,
                 CommitElementsWithSpace: false,
                 SnippetSetting: SnippetSetting.None,
                 LogLevel: LogLevel.Trace,


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/85661

Shamelessly repeating what I wrote in one of the commits, unfortunately due to how we emit Html from the Razor document, the downstream formatters have no choice but to make formatting decisions that are not great. Without fundamentally re-writing how we do that emitting, and/or more like without having to parse CSS and JavaScript ourselves, the best we can do for now is simply avoid formatting and hopefully not break users code.

Commit-at-a-time review would be simplest I imagine.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85142)