### PR TITLE
Enable CI for dev/* branches

### DIFF
--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -8,6 +8,7 @@ trigger:
     - release/*
     - features/*
     - demos/*
+    - dev/*
     exclude:
     # Since the version of VS on the integration VM images are a moving target,
     # we are unable to reliably run integration tests on servicing branches.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,6 +6,7 @@ trigger:
 - release/*
 - features/*
 - demos/*
+- dev/*
 
 # Branches that trigger builds on PR
 pr:


### PR DESCRIPTION
The benefits PR stacks as each stacked PR should be against a dev/ branch.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85144)