### PR TITLE
[demo/sdk-insertionnet11] Avoid language server publishing pack downloads

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
@@ -21,8 +21,12 @@
     <!-- List of runtime identifiers that we want to publish an executable for. -->
     <RuntimeIdentifiers>win-x64;win-arm64;linux-x64;linux-arm64;linux-musl-x64;linux-musl-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
 
-    <!-- Publish ready to run executables when we're publishing platform specific executables. -->
-    <PublishReadyToRun Condition="'$(Configuration)' == 'Release' ">true</PublishReadyToRun>
+    <!-- This perf-test snapshot only needs managed builds, not native/R2R publishing.
+         Avoid downloading runtime/apphost packs that may not be published during SDK insertions. -->
+    <EnableRuntimePackDownload>false</EnableRuntimePackDownload>
+    <EnableAppHostPackDownload>false</EnableAppHostPackDownload>
+    <UseAppHost>false</UseAppHost>
+    <PublishReadyToRun>false</PublishReadyToRun>
 
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary

Avoid downloading SDK runtime, apphost, and Crossgen2 packs while restoring the frozen Roslyn source used by the VS performance tests. During SDK insertions the installed targeting pack can be newer than the corresponding runtime packages available on the configured feeds.

This is intentionally limited to `demo/sdk-insertionnet11`:

- Keep the existing runtime identifier list and RID-dependent NuGet graph.
- Disable runtime/apphost pack downloads.
- Disable apphost generation so a managed build does not require an unavailable native host pack.
- Disable ReadyToRun publishing.

The project still builds its framework-dependent managed application. This snapshot no longer produces a native executable launcher or supports the normal multi-RID/ReadyToRun shipping workflow. It still requires the compile-time targeting pack supplied by the selected SDK/VS installation.

Related history: https://github.com/dotnet/roslyn/pull/77845 and https://github.com/dotnet/roslyn/pull/82154. A general solution that preserves shipping packaging is being planned separately; this PR does not reintroduce packaging orchestration.

## Validation

Validated against the actual project with .NET SDK 10.0.110 / MSBuild 18.0.11:

- Debug and Release `ProcessFrameworkReferences` evaluations retain all eight RIDs and return empty `PackageDownload`, `RuntimePack`, `AppHostPack`, and `Crossgen2Pack` collections.
- `dotnet restore src\LanguageServer\Microsoft.CodeAnalysis.LanguageServer\Microsoft.CodeAnalysis.LanguageServer.csproj -p:Configuration=Release` succeeds without property overrides.
- `dotnet build src\LanguageServer\Microsoft.CodeAnalysis.LanguageServer\Microsoft.CodeAnalysis.LanguageServer.csproj --no-restore -c Release` succeeds with 0 warnings and 0 errors.
- Actual restored assets contain no SDK runtime/apphost/Crossgen2 packages.
- Managed DLL, `.deps.json`, and `.runtimeconfig.json` are present; the DLL is IL-only and no native apphost is emitted.
- The focused diff, whitespace, and preserved UTF-8 BOM have been checked.

The first `--no-restore` build failed with the expected NETSDK1004 on the fresh worktree; the subsequent explicit restore and no-restore build passed. Debug was evaluated rather than built. Publishing and unit tests were not run because this change targets the restore/build configuration of a non-publishing perf snapshot. This is not a reproduction of the exact VS performance-test VM.