### PR TITLE
Treat extension members as declared in the enclosing static type

### DIFF
--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -10109,6 +10109,28 @@ AnonymousTypes(
             MainDescription("string extension<string>(string).Goo()"),
             NullabilityAnalysis(""));
 
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/80648")]
+    public Task TestModernExtension8()
+        => TestWithOptionsAsync(
+            CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview),
+            """
+            static class Extensions
+            {
+                extension(string s)
+                {
+                    private string Goo() => s;
+                }
+
+                static void M()
+                {
+            #nullable enable
+                    "".$$Goo();
+                }
+            }
+            """,
+            MainDescription("string extension(string).Goo()"),
+            NullabilityAnalysis(string.Format(FeaturesResources._0_is_not_nullable_aware, "Goo")));
+
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72780")]
     public Task TestLocalVariableComment1()
         => TestAsync(

--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -10121,9 +10121,9 @@ AnonymousTypes(
                     private string Goo() => s;
                 }
 
-            #nullable enable
                 static void M()
                 {
+            #nullable enable
                     "".$$Goo();
                 }
             }

--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -10106,7 +10106,7 @@ AnonymousTypes(
                 }
             }
             """,
-            MainDescription("string extension<string>(string).Goo()"),
+            MainDescription($"string extension<string>(string).Goo()"),
             NullabilityAnalysis(""));
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/80648")]
@@ -10128,7 +10128,7 @@ AnonymousTypes(
                 }
             }
             """,
-            MainDescription("string extension(string).Goo()"),
+            MainDescription($"string extension(string).Goo()"),
             NullabilityAnalysis(string.Format(FeaturesResources._0_is_not_nullable_aware, "Goo")));
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72780")]

--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -10121,9 +10121,9 @@ AnonymousTypes(
                     private string Goo() => s;
                 }
 
+            #nullable enable
                 static void M()
                 {
-            #nullable enable
                     "".$$Goo();
                 }
             }

--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -10086,6 +10086,29 @@ AnonymousTypes(
             """,
             MainDescription($"Extensions.extension(System.String)"));
 
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/80648")]
+    public Task TestModernExtension7()
+        => TestWithOptionsAsync(
+            CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview),
+            """
+            #nullable enable
+
+            static class Extensions
+            {
+                static void M()
+                {
+                    "".$$Goo();
+                }
+
+                extension<T>(T s)
+                {
+                    private T Goo() => s;
+                }
+            }
+            """,
+            MainDescription("string extension<string>(string).Goo()"),
+            NullabilityAnalysis(""));
+
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/72780")]
     public Task TestLocalVariableComment1()
         => TestAsync(

--- a/src/EditorFeatures/Test2/Extensions/ISymbolExtensionsTests.vb
+++ b/src/EditorFeatures/Test2/Extensions/ISymbolExtensionsTests.vb
@@ -127,7 +127,7 @@ class Outer
         End Function
 
         <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/80648")>
-        Public Async Function TestIsAccessibleWithin_PrivateExtensionMemberFromOtherType() As Task
+        Public Async Function TestIsAccessibleWithin_PrivateExtensionMember_FromOtherType() As Task
             Dim workspace =
 <Workspace>
     <Project Language="C#" CommonReferences="true" LanguageVersion="preview">

--- a/src/EditorFeatures/Test2/Extensions/ISymbolExtensionsTests.vb
+++ b/src/EditorFeatures/Test2/Extensions/ISymbolExtensionsTests.vb
@@ -126,5 +126,31 @@ class Outer
             Await TestIsAccessibleWithinAsync(workspace, True)
         End Function
 
+        <Fact, WorkItem("https://github.com/dotnet/roslyn/issues/80648")>
+        Public Async Function TestIsAccessibleWithin_PrivateExtensionMemberFromOtherType() As Task
+            Dim workspace =
+<Workspace>
+    <Project Language="C#" CommonReferences="true" LanguageVersion="preview">
+        <Document>
+static class Extensions
+{
+    extension(string s)
+    {
+        private void Goo() { }
+    }
+}
+
+class C
+{
+    void M()
+    {
+        "".$$Goo();
+    }
+}        </Document>
+    </Project>
+</Workspace>
+            Await TestIsAccessibleWithinAsync(workspace, False)
+        End Function
+
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/Extensions/ISymbolExtensionsTests.vb
+++ b/src/EditorFeatures/Test2/Extensions/ISymbolExtensionsTests.vb
@@ -139,7 +139,6 @@ static class Extensions
         private void Goo() { }
     }
 }
-
 class C
 {
     void M()

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Extensions/Symbols/ISymbolExtensions_Accessibility.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Extensions/Symbols/ISymbolExtensions_Accessibility.cs
@@ -333,10 +333,8 @@ internal static partial class ISymbolExtensions
     // enclosing static type.  Keep in sync with AccessCheck.IsMemberAccessible in the compiler.
     private static INamedTypeSymbol GetDeclaringTypeForAccessibility(INamedTypeSymbol containingType)
 #if !OLDER_ROSLYN
-        => containingType is { IsExtension: true, ContainingType: { } enclosingType } ? enclosingType : containingType;
+        => containingType is { IsExtension: true, ContainingType: { } extensionEnclosingType } ? extensionEnclosingType : containingType;
 #else
-        // Extension blocks cannot be represented in the Roslyn version these projects build against, so there is
-        // never anything to redirect here.
         => containingType;
 #endif
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Extensions/Symbols/ISymbolExtensions_Accessibility.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Extensions/Symbols/ISymbolExtensions_Accessibility.cs
@@ -267,9 +267,14 @@ internal static partial class ISymbolExtensions
 
         // For the purpose of accessibility checks, extension members are considered to be declared within the
         // enclosing static type.  Keep in sync with AccessCheck.IsMemberAccessible in the compiler.
+#if !OLDER_ROSLYN
         var declaringType = containingType.IsExtension && containingType.ContainingType is { } extensionEnclosingType
             ? extensionEnclosingType
             : containingType;
+#else
+        // Extension blocks cannot be represented in the Roslyn version these projects build against.
+        var declaringType = containingType;
+#endif
 
         var originalContainingType = declaringType.OriginalDefinition;
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Extensions/Symbols/ISymbolExtensions_Accessibility.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Extensions/Symbols/ISymbolExtensions_Accessibility.cs
@@ -256,7 +256,6 @@ internal static partial class ISymbolExtensions
 
         failedThroughTypeCheck = false;
 
-        var originalContainingType = containingType.OriginalDefinition;
         var withinNamedType = within as INamedTypeSymbol;
         var withinAssembly = (within as IAssemblySymbol) ?? ((INamedTypeSymbol)within).ContainingAssembly;
 
@@ -265,6 +264,14 @@ internal static partial class ISymbolExtensions
         {
             return false;
         }
+
+        // For the purpose of accessibility checks, extension members are considered to be declared within the
+        // enclosing static type.  Keep in sync with AccessCheck.IsMemberAccessible in the compiler.
+        var declaringType = containingType.IsExtension && containingType.ContainingType is { } extensionEnclosingType
+            ? extensionEnclosingType
+            : containingType;
+
+        var originalContainingType = declaringType.OriginalDefinition;
 
         switch (declaredAccessibility)
         {
@@ -284,7 +291,7 @@ internal static partial class ISymbolExtensions
                 // type) can access previous submission's private top-level members. Previous
                 // submissions are treated like outer classes for the current submission - the
                 // inner class can access private members of the outer class.
-                if (withinAssembly.IsInteractive && containingType.IsScriptClass)
+                if (withinAssembly.IsInteractive && declaringType.IsScriptClass)
                 {
                     return true;
                 }
@@ -295,10 +302,10 @@ internal static partial class ISymbolExtensions
             case Accessibility.Internal:
                 // An internal type is accessible if we're in the same assembly or we have
                 // friend access to the assembly it was defined in.
-                return withinAssembly.IsSameAssemblyOrHasFriendAccessTo(containingType.ContainingAssembly);
+                return withinAssembly.IsSameAssemblyOrHasFriendAccessTo(declaringType.ContainingAssembly);
 
             case Accessibility.ProtectedAndInternal:
-                if (!withinAssembly.IsSameAssemblyOrHasFriendAccessTo(containingType.ContainingAssembly))
+                if (!withinAssembly.IsSameAssemblyOrHasFriendAccessTo(declaringType.ContainingAssembly))
                 {
                     // We require internal access.  If we don't have it, then this symbol is
                     // definitely not accessible to us.
@@ -309,7 +316,7 @@ internal static partial class ISymbolExtensions
                 return IsProtectedSymbolAccessible(withinNamedType, withinAssembly, throughType, originalContainingType, out failedThroughTypeCheck);
 
             case Accessibility.ProtectedOrInternal:
-                if (withinAssembly.IsSameAssemblyOrHasFriendAccessTo(containingType.ContainingAssembly))
+                if (withinAssembly.IsSameAssemblyOrHasFriendAccessTo(declaringType.ContainingAssembly))
                 {
                     // If we have internal access to this symbol, then that's sufficient.  no
                     // need to do the complicated protected case.

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Extensions/Symbols/ISymbolExtensions_Accessibility.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Extensions/Symbols/ISymbolExtensions_Accessibility.cs
@@ -265,17 +265,7 @@ internal static partial class ISymbolExtensions
             return false;
         }
 
-        // For the purpose of accessibility checks, extension members are considered to be declared within the
-        // enclosing static type.  Keep in sync with AccessCheck.IsMemberAccessible in the compiler.
-#if !OLDER_ROSLYN
-        var declaringType = containingType.IsExtension && containingType.ContainingType is { } extensionEnclosingType
-            ? extensionEnclosingType
-            : containingType;
-#else
-        // Extension blocks cannot be represented in the Roslyn version these projects build against.
-        var declaringType = containingType;
-#endif
-
+        var declaringType = GetDeclaringTypeForAccessibility(containingType);
         var originalContainingType = declaringType.OriginalDefinition;
 
         switch (declaredAccessibility)
@@ -339,6 +329,17 @@ internal static partial class ISymbolExtensions
                 throw ExceptionUtilities.UnexpectedValue(declaredAccessibility);
         }
     }
+
+    // For the purpose of accessibility checks, extension members are considered to be declared within the
+    // enclosing static type.  Keep in sync with AccessCheck.IsMemberAccessible in the compiler.
+    private static INamedTypeSymbol GetDeclaringTypeForAccessibility(INamedTypeSymbol containingType)
+#if !OLDER_ROSLYN
+        => containingType is { IsExtension: true, ContainingType: { } enclosingType } ? enclosingType : containingType;
+#else
+        // Extension blocks cannot be represented in the Roslyn version these projects build against, so there is
+        // never anything to redirect here.
+        => containingType;
+#endif
 
     // Is a protected symbol inside "originalContainingType" accessible from within "within",
     // which much be a named type or an assembly.

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Extensions/Symbols/ISymbolExtensions_Accessibility.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Extensions/Symbols/ISymbolExtensions_Accessibility.cs
@@ -256,6 +256,8 @@ internal static partial class ISymbolExtensions
 
         failedThroughTypeCheck = false;
 
+        var declaringType = GetDeclaringTypeForAccessibility(containingType);
+        var originalContainingType = declaringType.OriginalDefinition;
         var withinNamedType = within as INamedTypeSymbol;
         var withinAssembly = (within as IAssemblySymbol) ?? ((INamedTypeSymbol)within).ContainingAssembly;
 
@@ -264,9 +266,6 @@ internal static partial class ISymbolExtensions
         {
             return false;
         }
-
-        var declaringType = GetDeclaringTypeForAccessibility(containingType);
-        var originalContainingType = declaringType.OriginalDefinition;
 
         switch (declaredAccessibility)
         {


### PR DESCRIPTION
The IDE's ISymbolExtensions.IsMemberAccessible resolved a member's accessibility against its ContainingType. For a member declared in an extension block that container is the extension type itself, so a private extension member looked inaccessible from the enclosing static class even though the compiler binds it fine.

AccessCheck.IsMemberAccessible in the compiler already redirects to the enclosing static type in this case; the Workspaces copy did not, so the two disagreed.

One user-visible consequence is quick info. CommonSemanticQuickInfoProvider collects symbols from GetSymbolsFromToken (accessibility filtered) and from GetMemberGroup (not filtered), and runs nullability analysis on the first one. Member group symbols carry no nullable annotations, so once the accessibility filter dropped the correctly annotated symbol, a private extension member fell back to the oblivious one and reported "'M' is not nullable aware.", while the same member declared internal or public reported nothing.

Note on the diff: only the `Accessibility.Private` arm can actually change behaviour here.  The
`containingType` -> `declaringType` substitutions in the `IsScriptClass` and `ContainingAssembly`
checks are no-ops, since an extension block shares its enclosing type's assembly and `protected`
is an error inside one.

They are there because the compiler makes the same split, and keeping it makes the two easier to
compare.  [`AccessCheck.IsMemberAccessible`](https://github.com/dotnet/roslyn/blob/main/src/Compilers/CSharp/Portable/Binder/Semantics/AccessCheck.cs#L319) keeps the *un-redirected* containing type
for its `IsNamedTypeAccessible` check, because the extension block itself still has to be
accessible, and only then passes the *redirected* type into
[`IsNonPublicMemberAccessible`](https://github.com/dotnet/roslyn/blob/main/src/Compilers/CSharp/Portable/Binder/Semantics/AccessCheck.cs#L330-L339), which uses it for every non-public check.
This change puts the boundary in the same place: `IsNamedTypeAccessible` still receives
`containingType`, and everything from the accessibility switch onwards receives `declaringType`.

This is my first PR to this repo, so please do point out anything that does not match the conventions here and I will get it sorted.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85176)


Fixes #80648



