### PR TITLE
Don't report a parameter named by InterpolatedStringHandlerArgument

### DIFF
--- a/src/Analyzers/CSharp/Tests/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
@@ -1861,7 +1861,7 @@ public sealed class RemoveUnusedParametersTests : AbstractCSharpDiagnosticProvid
             """);
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/76578")]
-    public Task TestInterpolatedStringHandlerArgument()
+    public Task TestInterpolatedStringHandlerArgumentAttribute()
         => TestDiagnosticMissingAsync("""
             using System.Runtime.CompilerServices;
 

--- a/src/Analyzers/CSharp/Tests/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
@@ -1860,6 +1860,29 @@ public sealed class RemoveUnusedParametersTests : AbstractCSharpDiagnosticProvid
             }
             """);
 
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/76578")]
+    public Task TestInterpolatedStringHandlerArgument()
+        => TestDiagnosticMissingAsync("""
+            using System.Runtime.CompilerServices;
+
+            [InterpolatedStringHandler]
+            public struct MyInterpolatedStringHandler
+            {
+                public MyInterpolatedStringHandler(int literalLength, int formattedCount, bool x)
+                {
+                    _ = x;
+                }
+            }
+
+            public class C
+            {
+                public void M(bool x, [InterpolatedStringHandlerArgument(nameof(x))] MyInterpolatedStringHandler y)
+                {
+                    _ = y;
+                }
+            }
+            """);
+
     public static IEnumerable<object[]> NonIntTypes()
     {
         yield return ["byte"];

--- a/src/Analyzers/CSharp/Tests/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
+++ b/src/Analyzers/CSharp/Tests/RemoveUnusedParametersAndValues/RemoveUnusedParametersTests.cs
@@ -1861,7 +1861,7 @@ public sealed class RemoveUnusedParametersTests : AbstractCSharpDiagnosticProvid
             """);
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/76578")]
-    public Task TestInterpolatedStringHandlerArgumentAttribute()
+    public Task TestInterpolatedStringHandlerArgumentAttribute_SingleArgument()
         => TestDiagnosticMissingAsync("""
             using System.Runtime.CompilerServices;
 
@@ -1879,6 +1879,30 @@ public sealed class RemoveUnusedParametersTests : AbstractCSharpDiagnosticProvid
                 public void M(bool x, [InterpolatedStringHandlerArgument(nameof(x))] MyInterpolatedStringHandler y)
                 {
                     _ = y;
+                }
+            }
+            """);
+
+    [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/76578")]
+    public Task TestInterpolatedStringHandlerArgumentAttribute_MultipleArguments()
+        => TestDiagnosticMissingAsync("""
+            using System.Runtime.CompilerServices;
+
+            [InterpolatedStringHandler]
+            public struct MyInterpolatedStringHandler
+            {
+                public MyInterpolatedStringHandler(int literalLength, int formattedCount, bool x, bool y)
+                {
+                    _ = x;
+                    _ = y;
+                }
+            }
+
+            public class C
+            {
+                public void M(bool x, bool y, [InterpolatedStringHandlerArgument(nameof(x), nameof(y))] MyInterpolatedStringHandler z)
+                {
+                    _ = z;
                 }
             }
             """);

--- a/src/Analyzers/Core/Analyzers/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.cs
@@ -321,7 +321,7 @@ internal abstract partial class AbstractRemoveUnusedParametersAndValuesDiagnosti
                             continue;
                         }
 
-                        if (argument.Kind == TypedConstantKind.Array
+                        if (argument.Kind is TypedConstantKind.Array
                                 ? argument.Values.Any(static (value, name) => Equals(value.Value, name), parameter.Name)
                                 : Equals(argument.Value, parameter.Name))
                         {

--- a/src/Analyzers/Core/Analyzers/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.cs
@@ -7,6 +7,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.CodeAnalysis.CodeStyle;
@@ -26,6 +27,7 @@ internal abstract partial class AbstractRemoveUnusedParametersAndValuesDiagnosti
         ImmutableHashSet<INamedTypeSymbol> attributeSetForMethodsToIgnore,
         DeserializationConstructorCheck deserializationConstructorCheck,
         INamedTypeSymbol? iCustomMarshaler,
+        INamedTypeSymbol? interpolatedStringHandlerArgumentAttribute,
         SymbolStartAnalysisContext symbolStartAnalysisContext)
     {
         private readonly AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer _compilationAnalyzer = compilationAnalyzer;
@@ -35,6 +37,7 @@ internal abstract partial class AbstractRemoveUnusedParametersAndValuesDiagnosti
         private readonly DeserializationConstructorCheck _deserializationConstructorCheck = deserializationConstructorCheck;
         private readonly ConcurrentDictionary<IMethodSymbol, bool> _methodsUsedAsDelegates = [];
         private readonly INamedTypeSymbol? _iCustomMarshaler = iCustomMarshaler;
+        private readonly INamedTypeSymbol? _interpolatedStringHandlerArgumentAttribute = interpolatedStringHandlerArgumentAttribute;
         private readonly SymbolStartAnalysisContext _symbolStartAnalysisContext = symbolStartAnalysisContext;
 
         /// <summary>
@@ -52,6 +55,7 @@ internal abstract partial class AbstractRemoveUnusedParametersAndValuesDiagnosti
             var eventsArgType = context.Compilation.EventArgsType();
             var deserializationConstructorCheck = new DeserializationConstructorCheck(context.Compilation);
             var iCustomMarshaler = context.Compilation.GetTypeByMetadataName(typeof(ICustomMarshaler).FullName!);
+            var interpolatedStringHandlerArgumentAttribute = context.Compilation.GetTypeByMetadataName(typeof(InterpolatedStringHandlerArgumentAttribute).FullName!);
 
             context.RegisterSymbolStartAction(symbolStartContext =>
             {
@@ -66,7 +70,7 @@ internal abstract partial class AbstractRemoveUnusedParametersAndValuesDiagnosti
                 // as that would lead to duplicate diagnostics being reported from symbol end action callbacks
                 // for unrelated named types.
                 var symbolAnalyzer = new SymbolStartAnalyzer(analyzer, eventsArgType, attributeSetForMethodsToIgnore,
-                    deserializationConstructorCheck, iCustomMarshaler, symbolStartContext);
+                    deserializationConstructorCheck, iCustomMarshaler, interpolatedStringHandlerArgumentAttribute, symbolStartContext);
                 symbolAnalyzer.OnSymbolStart(symbolStartContext);
             }, SymbolKind.NamedType);
 
@@ -260,6 +264,14 @@ internal abstract partial class AbstractRemoveUnusedParametersAndValuesDiagnosti
                 return false;
             }
 
+            // A parameter named by an 'InterpolatedStringHandlerArgument' attribute on another parameter is
+            // passed to the handler's constructor at the call site, so it is used even when the method body
+            // contains no reference to it.
+            if (IsInterpolatedStringHandlerArgument(parameter, method, _interpolatedStringHandlerArgumentAttribute))
+            {
+                return false;
+            }
+
             var methodSyntax = method.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax(cancellationToken);
             if (_compilationAnalyzer.ReturnsThrow(methodSyntax))
             {
@@ -285,6 +297,46 @@ internal abstract partial class AbstractRemoveUnusedParametersAndValuesDiagnosti
             }
 
             return true;
+
+            static bool IsInterpolatedStringHandlerArgument(
+                IParameterSymbol parameter,
+                IMethodSymbol method,
+                INamedTypeSymbol? interpolatedStringHandlerArgumentAttributeType)
+            {
+                if (interpolatedStringHandlerArgumentAttributeType is null)
+                    return false;
+
+                foreach (var otherParameter in method.Parameters)
+                {
+                    if (otherParameter.Equals(parameter))
+                        continue;
+
+                    foreach (var attribute in otherParameter.GetAttributes())
+                    {
+                        if (!interpolatedStringHandlerArgumentAttributeType.Equals(attribute.AttributeClass))
+                            continue;
+
+                        // The attribute has both a 'string' and a 'params string[]' constructor.
+                        foreach (var constructorArgument in attribute.ConstructorArguments)
+                        {
+                            if (constructorArgument.Kind == TypedConstantKind.Array)
+                            {
+                                foreach (var value in constructorArgument.Values)
+                                {
+                                    if (Equals(value.Value, parameter.Name))
+                                        return true;
+                                }
+                            }
+                            else if (Equals(constructorArgument.Value, parameter.Name))
+                            {
+                                return true;
+                            }
+                        }
+                    }
+                }
+
+                return false;
+            }
 
             static bool IsInterpolatedStringHandlerMandatoryConstructorParameter(
                 IParameterSymbol parameter,

--- a/src/Analyzers/Core/Analyzers/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.cs
+++ b/src/Analyzers/Core/Analyzers/RemoveUnusedParametersAndValues/AbstractRemoveUnusedParametersAndValuesDiagnosticAnalyzer.SymbolStartAnalyzer.cs
@@ -313,24 +313,19 @@ internal abstract partial class AbstractRemoveUnusedParametersAndValuesDiagnosti
 
                     foreach (var attribute in otherParameter.GetAttributes())
                     {
-                        if (!interpolatedStringHandlerArgumentAttributeType.Equals(attribute.AttributeClass))
-                            continue;
-
-                        // The attribute has both a 'string' and a 'params string[]' constructor.
-                        foreach (var constructorArgument in attribute.ConstructorArguments)
+                        // Both constructors of the attribute take a single argument: either one parameter
+                        // name, or an array of them.
+                        if (!interpolatedStringHandlerArgumentAttributeType.Equals(attribute.AttributeClass) ||
+                            attribute.ConstructorArguments is not [var argument])
                         {
-                            if (constructorArgument.Kind == TypedConstantKind.Array)
-                            {
-                                foreach (var value in constructorArgument.Values)
-                                {
-                                    if (Equals(value.Value, parameter.Name))
-                                        return true;
-                                }
-                            }
-                            else if (Equals(constructorArgument.Value, parameter.Name))
-                            {
-                                return true;
-                            }
+                            continue;
+                        }
+
+                        if (argument.Kind == TypedConstantKind.Array
+                                ? argument.Values.Any(static (value, name) => Equals(value.Value, name), parameter.Name)
+                                : Equals(argument.Value, parameter.Name))
+                        {
+                            return true;
                         }
                     }
                 }


### PR DESCRIPTION
Fixes #76578

IDE0060 reported a parameter as unused when it is named by an `InterpolatedStringHandlerArgument` attribute on another parameter:

```csharp
public void M(bool x, [InterpolatedStringHandlerArgument(nameof(x))] MyInterpolatedStringHandler y)
{
    _ = y;   // IDE0060 fires on 'x'
}
```

`x` is passed to the handler's constructor at the call site, so it is used even though the method body never mentions it.

The analyzer already knew about interpolated string handlers, but only about the two mandatory `int` parameters of a handler's own constructor (`IsInterpolatedStringHandlerMandatoryConstructorParameter`, added for #58168). That is a different attribute — `InterpolatedStringHandlerAttribute` applied to the handler type — and it does not cover a parameter named by `InterpolatedStringHandlerArgumentAttribute` on a sibling parameter.

`IsUnusedParameterCandidate` already exempts a number of parameters that are used somewhere other than the method body: event handler signatures, methods used as delegates, interface implementations and overrides, `Conditional`-attributed methods, deserialization constructors, `ICustomMarshaler.GetInstance`, and the two mandatory `int` parameters of a handler constructor.  This is another case of the same kind, where the use lives in an attribute on a sibling parameter.

## Change

Resolve `InterpolatedStringHandlerArgumentAttribute` alongside the other well-known types in `CreateAndRegisterActions`, and skip a parameter that any sibling parameter names in that attribute. Both of the attribute's constructors are handled, `(string)` and `(params string[])`, since either can name the parameter.

The change is strictly narrowing: it can only suppress diagnostics, and only for parameters named in that attribute.

## Test

`TestInterpolatedStringHandlerArgument` covers the case from the issue. I verified it fails without the change, with `IDE0060: Parameter 'x' can be removed if it is not part of a shipped public API`, and passes with it.

The rest of `RemoveUnusedParametersTests` stays green in both projects that compile this analyzer — `Microsoft.CodeAnalysis.CSharp.Features.UnitTests` (135/135) and `Microsoft.CodeAnalysis.CSharp.CodeStyle.UnitTests` (134/134) — on net10.0 and net472.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85178)
