### PR TITLE
Special-case nullable walker to understand `lock (null)` in legacy mode

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/LockBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LockBinder.cs
@@ -43,10 +43,18 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (exprType is null)
             {
-                if (expr.ConstantValueOpt != ConstantValue.Null || Compilation.FeatureStrictEnabled) // Dev10 allows the null literal.
+                var isNullConstant = expr.ConstantValueOpt == ConstantValue.Null;
+
+                if (!isNullConstant || Compilation.FeatureStrictEnabled) // Dev10 allows the null literal.
                 {
                     Error(diagnostics, ErrorCode.ERR_LockNeedsReference, exprSyntax, expr.Display);
                     hasErrors = true;
+                }
+                else if (isNullConstant)
+                {
+                    // If we are in a legacy mode, also produce a conversion from 'null' to object type
+                    // so that nullability analysis can report that as a null dereference
+                    expr = CreateConversion(expr, Compilation.ObjectType, diagnostics);
                 }
             }
             else if (!exprType.IsReferenceType && (exprType.IsValueType || Compilation.FeatureStrictEnabled))

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_ILockStatement.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_ILockStatement.cs
@@ -104,9 +104,12 @@ public class C1
 ";
             string expectedOperationTree = @"
 ILockOperation (OperationKind.Lock, Type: null) (Syntax: 'lock (null) ... }')
-  Expression: 
-    ILiteralOperation (OperationKind.Literal, Type: null, Constant: null) (Syntax: 'null')
-  Body: 
+  Expression:
+    IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Object, Constant: null, IsImplicit) (Syntax: 'null')
+      Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: True, IsUserDefined: False) (MethodSymbol: null)
+      Operand:
+        ILiteralOperation (OperationKind.Literal, Type: null, Constant: null) (Syntax: 'null')
+  Body:
     IBlockOperation (0 statements) (OperationKind.Block, Type: null) (Syntax: '{ ... }')
 ";
             var expectedDiagnostics = DiagnosticDescription.None;

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NullableReferenceTypesTests.cs
@@ -1095,6 +1095,70 @@ class C
                 );
         }
 
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/76597")]
+        public void LockStatement_Null_LegacyBehavior()
+        {
+            var comp = CreateCompilation("""
+                class C
+                {
+                    void M()
+                    {
+                        lock (null)
+                        {
+                        }
+                    }
+                }
+                """, options: WithNullableEnable());
+            comp.VerifyDiagnostics(
+                // (5,15): warning CS8602: Dereference of a possibly null reference.
+                //         lock (null)
+                Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "null").WithLocation(5, 15));
+
+            var tree = comp.SyntaxTrees.Single();
+            var semanticModel = comp.GetSemanticModel(tree);
+
+            var lockNode = tree.GetRoot().DescendantNodes().OfType<LockStatementSyntax>().Single();
+
+            var lockExpressionTypeInfo = semanticModel.GetTypeInfo(lockNode.Expression);
+            Assert.Null(lockExpressionTypeInfo.Type);
+            Assert.Equal("System.Object?", lockExpressionTypeInfo.ConvertedType.ToTestDisplayString());
+
+            var lockExpressionConversion = semanticModel.GetConversion(lockNode.Expression);
+            Assert.Equal(Conversion.ImplicitReference, lockExpressionConversion);
+        }
+
+        [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/76597")]
+        public void LockStatement_Null_Strict()
+        {
+            var comp = CreateCompilation("""
+                class C
+                {
+                    void M()
+                    {
+                        lock (null)
+                        {
+                        }
+                    }
+                }
+                """, parseOptions: TestOptions.Regular.WithStrictFeature(), options: WithNullableEnable());
+            comp.VerifyDiagnostics(
+                // (5,15): error CS0185: '<null>' is not a reference type as required by the lock statement
+                //         lock (null)
+                Diagnostic(ErrorCode.ERR_LockNeedsReference, "null").WithArguments("<null>").WithLocation(5, 15));
+
+            var tree = comp.SyntaxTrees.Single();
+            var semanticModel = comp.GetSemanticModel(tree);
+
+            var lockNode = tree.GetRoot().DescendantNodes().OfType<LockStatementSyntax>().Single();
+
+            var lockExpressionTypeInfo = semanticModel.GetTypeInfo(lockNode.Expression);
+            Assert.Null(lockExpressionTypeInfo.Type);
+            Assert.Null(lockExpressionTypeInfo.ConvertedType);
+
+            var lockExpressionConversion = semanticModel.GetConversion(lockNode.Expression);
+            Assert.Equal(Conversion.Identity, lockExpressionConversion);
+        }
+
         [Fact, WorkItem(33537, "https://github.com/dotnet/roslyn/issues/33537")]
         public void SuppressOnNullLiteralInAs()
         {


### PR DESCRIPTION
Fixes: https://github.com/dotnet/roslyn/issues/76597

`lock (maybeNullExpr)` has already been handled (see test above newly added ones). The only problem was `lock (null)`. It exists only in legacy mode (strict makes it an error), so that `null` can sneak into runtime and cause `ArgumentNullException`. It wasn't handled because that `null` was never assigned a type. Made `NullableWalker` recognize this case and report it separately

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85182)