### PR TITLE
Simplify partial modifier lookahead naming

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1663,6 +1663,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             // Otherwise, scanning that same token as a possible type would recurse through IsTrueIdentifier.
             this.EatToken(); // partial
 
+            if (onlyForTypeDeclarations)
+            {
+                // Type and namespace declarations are straightforward: skip the modifier list and
+                // require a well-known declaration keyword such as 'class', 'struct', or 'namespace'.
+                while (GetModifierExcludingScoped(this.CurrentToken) != DeclarationModifiers.None)
+                {
+                    this.EatToken();
+                }
+
+                return this.IsTypeOrNamespaceDeclarationStart();
+            }
+
             var partialConstructorsEnabled = IsFeatureEnabled(MessageID.IDS_FeaturePartialEventsAndConstructors);
 
             while (true)
@@ -1671,21 +1683,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
                 if (modifier == DeclarationModifiers.None)
                 {
-                    // Handle type and namespace declaration heads here. Member declaration heads are
-                    // handled by the shared check below, which also disambiguates contextual modifiers.
                     if (this.IsTypeOrNamespaceDeclarationStart())
                         return true;
                 }
                 else
                 {
-                    // Namespace lookahead must skip all modifiers and require a type or namespace
-                    // declaration head. It must not accept a member such as 'partial int M()'.
-                    if (onlyForTypeDeclarations)
-                    {
-                        this.EatToken();
-                        continue;
-                    }
-
                     // A non-contextual modifier token cannot be the name of a member returning
                     // 'partial', so its presence proves that the initial 'partial' is a modifier.
                     if (this.CurrentToken.Kind != SyntaxKind.IdentifierToken)
@@ -1711,7 +1713,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 // With no modifier, this checks the final declaration head. With a contextual modifier,
                 // it checks whether that token instead starts a member return type, such as 'async' in
                 // 'partial async M()'.
-                if (!onlyForTypeDeclarations && isMemberDeclarationStart())
+                if (isMemberDeclarationStart())
                     return true;
 
                 if (modifier == DeclarationModifiers.None)

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1659,10 +1659,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
             using var beforePartialResetPoint = this.GetDisposableResetPoint(resetOnDispose: true);
 
-            if (isPartialModifierInTypeOrNamespaceDeclaration())
-                return true;
-
-            return isPartialModifierInMemberDeclaration();
+            return isPartialModifierInTypeOrNamespaceDeclaration() ||
+                isPartialModifierInMemberDeclaration();
 
             bool isPartialModifierInTypeOrNamespaceDeclaration()
             {

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1687,16 +1687,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 // Otherwise, scanning that same token as a possible type would recurse through IsTrueIdentifier.
                 this.EatToken(); // partial
 
+                // With partial constructors enabled, 'partial Identifier(' starts a constructor.
+                // In earlier versions, 'partial' is the return type and the identifier is the member name.
+                if (IsFeatureEnabled(MessageID.IDS_FeaturePartialEventsAndConstructors) &&
+                    isIdentifierFollowedByOpenParen(peekIndex: 0))
+                {
+                    return true;
+                }
+
                 while (true)
                 {
-                    // A partial constructor name may itself look like a contextual modifier, as in
-                    // 'partial async()', so check for it before classifying the current token.
-                    if (IsFeatureEnabled(MessageID.IDS_FeaturePartialEventsAndConstructors) &&
-                        isIdentifierFollowedByOpenParen(peekIndex: 0))
-                    {
-                        return true;
-                    }
-
                     var modifier = GetModifierExcludingScoped(this.CurrentToken);
 
                     if (modifier == DeclarationModifiers.None)

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1399,6 +1399,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                             break;
                         }
 
+                    case DeclarationModifiers.Async:
+                        if (!ShouldContextualKeywordBeTreatedAsModifier(parsingStatementNotDeclaration: false))
+                        {
+                            return;
+                        }
+
+                        modTok = ConvertToKeyword(this.EatToken());
+                        break;
+
                     case DeclarationModifiers.File:
                     case DeclarationModifiers.Closed:
                     case DeclarationModifiers.Required:
@@ -1413,11 +1422,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                                 _ => throw ExceptionUtilities.UnexpectedValue(newMod),
                             };
 
-                            // When the feature is enabled, the associated contextual keyword is always a keyword
-                            // if not escaped. Otherwise, conservatively determine whether it is intended as a
-                            // modifier so binding can report the language-version diagnostic. Top-level statements
-                            // must always be disambiguated because the keyword may instead be a local name.
-                            if ((!IsFeatureEnabled(requiredFeature) || forTopLevelStatements) &&
+                            // Outside top-level statements, an enabled contextual modifier is unambiguous.
+                            // Otherwise, it may be an identifier, so use the usual contextual-keyword heuristic.
+                            var needsDisambiguation = !IsFeatureEnabled(requiredFeature) || forTopLevelStatements;
+                            if (needsDisambiguation &&
                                 !ShouldContextualKeywordBeTreatedAsModifier(parsingStatementNotDeclaration: false))
                             {
                                 return;
@@ -1427,15 +1435,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                             modTok = ConvertToKeyword(EatToken());
                             break;
                         }
-
-                    case DeclarationModifiers.Async:
-                        if (!ShouldContextualKeywordBeTreatedAsModifier(parsingStatementNotDeclaration: false))
-                        {
-                            return;
-                        }
-
-                        modTok = ConvertToKeyword(this.EatToken());
-                        break;
 
                     default:
                         modTok = this.EatToken();

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -875,8 +875,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 case SyntaxKind.NamespaceKeyword:
                     return true;
                 case SyntaxKind.IdentifierToken:
-                    // `allowMembers: false`: A type member such as 'partial int M()' cannot start a namespace body.
-                    return this.IsPartialModifierInDeclarationHead(allowMembers: false);
+                    // `includingForMembers: false`: A type member such as 'partial int M()' cannot start a namespace body.
+                    return this.IsCurrentTokenDefinitelyPartialModifier(includingForMembers: false);
                 default:
                     return IsPossibleStartOfTypeDeclaration(this.CurrentToken.Kind);
             }
@@ -1369,9 +1369,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 switch (newMod)
                 {
                     case DeclarationModifiers.Partial:
-                        // `allowMembers: true`: ParseModifiers is shared by types and members, such as
+                        // `includingForMembers: true`: ParseModifiers is shared by types and members, such as
                         // 'partial class C' and 'partial void M()'.
-                        if (!this.IsPartialModifierInDeclarationHead(allowMembers: true))
+                        if (!this.IsCurrentTokenDefinitelyPartialModifier(includingForMembers: true))
                             return;
 
                         modTok = ConvertToKeyword(this.EatToken());
@@ -1533,10 +1533,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
             // If 'partial' starts a declaration, the preceding token is also a modifier,
             // as in 'closed partial ref struct'.
-            // `allowMembers: true`: The preceding modifier may belong to either a type or a member, such as
+            // `includingForMembers: true`: The preceding modifier may belong to either a type or a member, such as
             // 'public partial class C' or 'public partial void M()'.
             if (!parsingStatementNotDeclaration &&
-                this.IsPartialModifierInDeclarationHead(allowMembers: true))
+                this.IsCurrentTokenDefinitelyPartialModifier(includingForMembers: true))
             {
                 return true;
             }
@@ -1648,9 +1648,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         }
 
         /// <summary>
-        /// Classifies <c>partial</c> in a declaration head, including misplaced forms for binding to diagnose.
+        /// Determines whether the current token is definitely a <c>partial</c> modifier,
+        /// including misplaced forms for binding to diagnose.
         /// </summary>
-        private bool IsPartialModifierInDeclarationHead(bool allowMembers)
+        private bool IsCurrentTokenDefinitelyPartialModifier(bool includingForMembers)
         {
             if (this.CurrentToken.ContextualKind != SyntaxKind.PartialKeyword)
                 return false;
@@ -1692,7 +1693,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
             bool shouldStopSkippingModifiers()
             {
-                if (!allowMembers)
+                if (!includingForMembers)
                     return false;
 
                 // A non-contextual modifier proves that the initial 'partial' belongs to a member.
@@ -1718,7 +1719,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             bool isMemberDeclarationStart()
             {
                 // Namespace lookahead must not accept member-only forms such as 'partial int M()'.
-                if (!allowMembers)
+                if (!includingForMembers)
                     return false;
 
                 // 'event' cannot begin another member form, so parse 'partial event' as an event in every
@@ -6045,7 +6046,7 @@ parse_member_name:;
         {
             if (this.CurrentToken.Kind == SyntaxKind.IdentifierToken)
             {
-                if (!IsCurrentTokenPartialKeywordOfPartialMemberOrType() &&
+                if (!IsCurrentTokenDefinitelyPartialModifier(includingForMembers: true) &&
                     !IsCurrentTokenQueryKeywordInQuery() &&
                     !IsCurrentTokenWhereOfConstraintClause())
                 {
@@ -6092,7 +6093,7 @@ parse_member_name:;
                 // show the correct parameter help in this case.  So, when we see "partial" we check if it's being used
                 // as an identifier or as a contextual keyword.  If it's the latter then we bail out.  See
                 // Bug: vswhidbey/542125
-                if (IsCurrentTokenPartialKeywordOfPartialMemberOrType() || IsCurrentTokenQueryKeywordInQuery())
+                if (this.IsCurrentTokenDefinitelyPartialModifier(includingForMembers: true) || IsCurrentTokenQueryKeywordInQuery())
                 {
                     var result = CreateMissingIdentifierToken();
                     result = this.AddError(result, ErrorCode.ERR_InvalidExprTerm, this.CurrentToken.Text);
@@ -6117,13 +6118,6 @@ parse_member_name:;
         private bool IsCurrentTokenQueryKeywordInQuery()
         {
             return this.IsInQuery && this.IsCurrentTokenQueryContextualKeyword;
-        }
-
-        private bool IsCurrentTokenPartialKeywordOfPartialMemberOrType()
-        {
-            // `allowMembers: true`: Identifier parsing must stop before a type or member declaration, such as
-            // 'partial class C' or 'partial public void M()'.
-            return this.IsPartialModifierInDeclarationHead(allowMembers: true);
         }
 
         private bool IsCurrentTokenFieldInKeywordContext()
@@ -6196,7 +6190,7 @@ parse_member_name:;
             }
 
             if (this.IsCurrentTokenWhereOfConstraintClause() ||
-                this.IsCurrentTokenPartialKeywordOfPartialMemberOrType())
+                this.IsCurrentTokenDefinitelyPartialModifier(includingForMembers: true))
             {
                 return _syntaxFactory.TypeParameter(
                     attrs,

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1678,43 +1678,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 if (isIdentifierFollowedByOpenParen(peekIndex: 0))
                     return IsFeatureEnabled(MessageID.IDS_FeaturePartialEventsAndConstructors);
 
-                while (GetModifierExcludingScoped(this.CurrentToken) is var modifier)
+                while (GetModifierExcludingScoped(this.CurrentToken) != DeclarationModifiers.None)
                 {
-                    if (modifier == DeclarationModifiers.None)
-                    {
-                        // No modifier-like token remains, so the current token must start the member itself.
-
-                        // Case 1: 'event' cannot begin another member form, so parse 'partial event'
-                        // as an event in every language version. Binding reports the feature diagnostic
-                        // when necessary.
-                        if (this.CurrentToken.Kind == SyntaxKind.EventKeyword)
-                            return true;
-
-                        // Case 2: 'implicit' and 'explicit' can only start conversion operators, so
-                        // 'partial' is a modifier even when the operator declaration is incomplete.
-                        if (this.CurrentToken.Kind is SyntaxKind.ImplicitKeyword or SyntaxKind.ExplicitKeyword)
-                            return true;
-
-                        // Case 3: Otherwise, require a return type followed by a member name, as in
-                        // 'partial int M()'.
-                        return this.IsTypeFollowedByMemberName();
-                    }
-
-                    // Case 4: Before a non-contextual modifier, as in 'partial static', the initial
+                    // Before a non-contextual modifier, as in 'partial static', the initial
                     // 'partial' is unambiguously a modifier.
                     if (this.CurrentToken.Kind != SyntaxKind.IdentifierToken)
                         return true;
 
-                    // Case 5: A contextual modifier followed by 'Identifier(' either starts a method
+                    // A contextual modifier followed by 'Identifier(' either starts a method
                     // return type, as in 'partial async C()', or is another modifier on a partial
-                    // constructor, as in 'partial partial C()'. Either way, the initial 'partial'
-                    // is a modifier. This does not fall through to Case 6 for the latter form in
-                    // C# 14: scanning the second 'partial' as a type reenters this helper and classifies
-                    // it as a modifier, so IsTypeFollowedByMemberName() returns false.
+                    // constructor, as in 'partial partial C()'. Either way, the initial 'partial' is
+                    // a modifier. For the latter form in C# 14, scanning the second 'partial' as a type
+                    // reenters this helper and classifies it as a modifier, so IsTypeFollowedByMemberName()
+                    // returns false.
                     if (isIdentifierFollowedByOpenParen(peekIndex: 1))
                         return true;
 
-                    // Case 6: A contextual modifier may otherwise be the member's return type, such as
+                    // A contextual modifier may otherwise be the member's return type, such as
                     // the second 'partial' in 'partial partial P { get; }'.
                     if (this.IsTypeFollowedByMemberName())
                         return true;
@@ -1722,7 +1702,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                     this.EatToken();
                 }
 
-                throw ExceptionUtilities.Unreachable();
+                // No modifier-like token remains, so the current token must start the member itself.
+
+                // 'event' cannot begin another member form, so parse 'partial event' as an event in
+                // every language version. Binding reports the feature diagnostic when necessary.
+                if (this.CurrentToken.Kind == SyntaxKind.EventKeyword)
+                    return true;
+
+                // 'implicit' and 'explicit' can only start conversion operators, so 'partial' is a
+                // modifier even when the operator declaration is incomplete.
+                if (this.CurrentToken.Kind is SyntaxKind.ImplicitKeyword or SyntaxKind.ExplicitKeyword)
+                    return true;
+
+                // Otherwise, require a return type followed by a member name, as in 'partial int M()'.
+                return this.IsTypeFollowedByMemberName();
             }
 
             bool isIdentifierFollowedByOpenParen(int peekIndex)

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1710,15 +1710,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                         if (isPartialConstructorName(peekIndex: 1))
                             return true;
 
-                        // Do not call isMemberDeclarationStart() for consecutive 'partial' tokens. It
-                        // reaches IsTypeFollowedByMemberName(), which scans the current 'partial' as a
-                        // possible type and reenters IsCurrentTokenDefinitelyPartialModifier(). Consume
-                        // one token here so long modifier chains are processed iteratively.
-                        if (this.PeekToken(1).ContextualKind == SyntaxKind.PartialKeyword)
-                        {
-                            this.EatToken();
-                            continue;
-                        }
                     }
 
                     // Case 4: Any contextual modifier may instead be the member's return type, such as 'async'

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1700,19 +1700,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                     if (this.CurrentToken.Kind != SyntaxKind.IdentifierToken)
                         return true;
 
-                    // Case 3: Another contextual 'partial' needs special handling for partial constructors
-                    // and repeated modifier chains.
-                    if (modifier == DeclarationModifiers.Partial)
-                    {
-                        // With partial constructors enabled, the current token is a second 'partial'
-                        // modifier before the constructor name in 'partial partial C()'. In earlier
-                        // versions, it is instead the member's return type.
-                        if (isPartialConstructorName(peekIndex: 1))
-                            return true;
-
-                    }
-
-                    // Case 4: Any contextual modifier may instead be the member's return type, such as 'async'
+                    // Case 3: A contextual modifier may instead be the member's return type, such as 'async'
                     // in 'partial async M()'.
                     if (isMemberDeclarationStart())
                         return true;
@@ -1736,18 +1724,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 // With partial constructors enabled, the current token is the constructor name after
                 // the initial modifier in 'partial C()'. In earlier versions, 'partial' is the return
                 // type and the current identifier is the member name.
-                if (isPartialConstructorName(peekIndex: 0))
+                if (isCurrentTokenPartialConstructorName())
                     return true;
 
                 // Otherwise, require a return type followed by a member name, as in 'partial int M()'.
                 return this.IsTypeFollowedByMemberName();
             }
 
-            bool isPartialConstructorName(int peekIndex)
+            bool isCurrentTokenPartialConstructorName()
             {
                 return IsFeatureEnabled(MessageID.IDS_FeaturePartialEventsAndConstructors) &&
-                    this.PeekToken(peekIndex).Kind == SyntaxKind.IdentifierToken &&
-                    this.PeekToken(peekIndex + 1).Kind == SyntaxKind.OpenParenToken;
+                    this.CurrentToken.Kind == SyntaxKind.IdentifierToken &&
+                    this.PeekToken(1).Kind == SyntaxKind.OpenParenToken;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1695,8 +1695,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                     if (modifier == DeclarationModifiers.None)
                         return isMemberDeclarationStart();
 
-                    // Case 2: A non-contextual modifier token cannot be the name of a member returning
-                    // 'partial', so its presence proves that the initial 'partial' is a modifier.
+                    // Case 2: Before a non-contextual modifier, as in 'partial static', the initial
+                    // 'partial' is unambiguously a modifier.
                     if (this.CurrentToken.Kind != SyntaxKind.IdentifierToken)
                         return true;
 

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1688,11 +1688,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
                 // With partial constructors enabled, 'partial Identifier(' starts a constructor.
                 // In earlier versions, 'partial' is the return type and the identifier is the member name.
-                if (IsFeatureEnabled(MessageID.IDS_FeaturePartialEventsAndConstructors) &&
-                    isIdentifierFollowedByOpenParen(peekIndex: 0))
-                {
-                    return true;
-                }
+                if (isIdentifierFollowedByOpenParen(peekIndex: 0))
+                    return IsFeatureEnabled(MessageID.IDS_FeaturePartialEventsAndConstructors);
 
                 while (true)
                 {

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1722,21 +1722,32 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 if (this.CurrentToken.Kind is SyntaxKind.ImplicitKeyword or SyntaxKind.ExplicitKeyword)
                     return true;
 
+                // In 'partial partial C()', the initial 'partial' is a modifier in every language
+                // version. The current 'partial' is the return type in C# 13 and another modifier
+                // on a partial constructor in C# 14.
+                if (this.CurrentToken.ContextualKind == SyntaxKind.PartialKeyword &&
+                    isIdentifierFollowedByOpenParen(peekIndex: 1))
+                {
+                    return true;
+                }
+
                 // With partial constructors enabled, the current token is the constructor name after
                 // the initial modifier in 'partial C()'. In earlier versions, 'partial' is the return
                 // type and the current identifier is the member name.
-                if (isCurrentTokenPartialConstructorName())
+                if (IsFeatureEnabled(MessageID.IDS_FeaturePartialEventsAndConstructors) &&
+                    isIdentifierFollowedByOpenParen(peekIndex: 0))
+                {
                     return true;
+                }
 
                 // Otherwise, require a return type followed by a member name, as in 'partial int M()'.
                 return this.IsTypeFollowedByMemberName();
             }
 
-            bool isCurrentTokenPartialConstructorName()
+            bool isIdentifierFollowedByOpenParen(int peekIndex)
             {
-                return IsFeatureEnabled(MessageID.IDS_FeaturePartialEventsAndConstructors) &&
-                    this.CurrentToken.Kind == SyntaxKind.IdentifierToken &&
-                    this.PeekToken(1).Kind == SyntaxKind.OpenParenToken;
+                return this.PeekToken(peekIndex).Kind == SyntaxKind.IdentifierToken &&
+                    this.PeekToken(peekIndex + 1).Kind == SyntaxKind.OpenParenToken;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1703,6 +1703,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                     // Case 3: A contextual modifier may instead be the member's return type, such as
                     // the second 'partial' in 'partial partial P { get; }', or 'async' in
                     // 'partial async M()'.
+                    //
+                    // If it is followed by 'Identifier(', then it either starts a method return type,
+                    // as in 'partial async C()', or is another modifier on a partial constructor, as
+                    // in 'partial partial C()'. Either way, the initial 'partial' is a modifier.
+                    if (isIdentifierFollowedByOpenParen(peekIndex: 1))
+                        return true;
+
                     if (isMemberDeclarationStart())
                         return true;
 
@@ -1721,15 +1728,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 // even when the operator declaration is incomplete.
                 if (this.CurrentToken.Kind is SyntaxKind.ImplicitKeyword or SyntaxKind.ExplicitKeyword)
                     return true;
-
-                // In 'partial partial C()', the initial 'partial' is a modifier in every language
-                // version. The current 'partial' is the return type in C# 13 and another modifier
-                // on a partial constructor in C# 14.
-                if (this.CurrentToken.ContextualKind == SyntaxKind.PartialKeyword &&
-                    isIdentifierFollowedByOpenParen(peekIndex: 1))
-                {
-                    return true;
-                }
 
                 // With partial constructors enabled, the current token is the constructor name after
                 // the initial modifier in 'partial C()'. In earlier versions, 'partial' is the return

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -875,8 +875,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 case SyntaxKind.NamespaceKeyword:
                     return true;
                 case SyntaxKind.IdentifierToken:
-                    // `includingForMembers: false`: A type member such as 'partial int M()' cannot start a namespace body.
-                    return this.IsCurrentTokenDefinitelyPartialModifier(includingForMembers: false);
+                    // `onlyForTypeDeclarations: true`: A type member such as 'partial int M()' cannot start a namespace body.
+                    return this.IsCurrentTokenDefinitelyPartialModifier(onlyForTypeDeclarations: true);
                 default:
                     return IsPossibleStartOfTypeDeclaration(this.CurrentToken.Kind);
             }
@@ -1369,9 +1369,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 switch (newMod)
                 {
                     case DeclarationModifiers.Partial:
-                        // `includingForMembers: true`: ParseModifiers is shared by types and members, such as
+                        // `onlyForTypeDeclarations: false`: ParseModifiers is shared by types and members, such as
                         // 'partial class C' and 'partial void M()'.
-                        if (!this.IsCurrentTokenDefinitelyPartialModifier(includingForMembers: true))
+                        if (!this.IsCurrentTokenDefinitelyPartialModifier(onlyForTypeDeclarations: false))
                             return;
 
                         modTok = ConvertToKeyword(this.EatToken());
@@ -1533,10 +1533,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
             // If 'partial' starts a declaration, the preceding token is also a modifier,
             // as in 'closed partial ref struct'.
-            // `includingForMembers: true`: The preceding modifier may belong to either a type or a member, such as
+            // `onlyForTypeDeclarations: false`: The preceding modifier may belong to either a type or a member, such as
             // 'public partial class C' or 'public partial void M()'.
             if (!parsingStatementNotDeclaration &&
-                this.IsCurrentTokenDefinitelyPartialModifier(includingForMembers: true))
+                this.IsCurrentTokenDefinitelyPartialModifier(onlyForTypeDeclarations: false))
             {
                 return true;
             }
@@ -1647,7 +1647,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         /// Determines whether the current token is definitely a <c>partial</c> modifier,
         /// including misplaced forms for binding to diagnose.
         /// </summary>
-        private bool IsCurrentTokenDefinitelyPartialModifier(bool includingForMembers)
+        private bool IsCurrentTokenDefinitelyPartialModifier(bool onlyForTypeDeclarations)
         {
             if (this.CurrentToken.ContextualKind != SyntaxKind.PartialKeyword)
                 return false;
@@ -1680,7 +1680,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 {
                     // Namespace lookahead must skip all modifiers and require a type or namespace
                     // declaration head. It must not accept a member such as 'partial int M()'.
-                    if (!includingForMembers)
+                    if (onlyForTypeDeclarations)
                     {
                         this.EatToken();
                         continue;
@@ -1711,7 +1711,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 // With no modifier, this checks the final declaration head. With a contextual modifier,
                 // it checks whether that token instead starts a member return type, such as 'async' in
                 // 'partial async M()'.
-                if (includingForMembers && isMemberDeclarationStart())
+                if (!onlyForTypeDeclarations && isMemberDeclarationStart())
                     return true;
 
                 if (modifier == DeclarationModifiers.None)
@@ -6046,7 +6046,7 @@ parse_member_name:;
         {
             if (this.CurrentToken.Kind == SyntaxKind.IdentifierToken)
             {
-                if (!IsCurrentTokenDefinitelyPartialModifier(includingForMembers: true) &&
+                if (!IsCurrentTokenDefinitelyPartialModifier(onlyForTypeDeclarations: false) &&
                     !IsCurrentTokenQueryKeywordInQuery() &&
                     !IsCurrentTokenWhereOfConstraintClause())
                 {
@@ -6093,7 +6093,7 @@ parse_member_name:;
                 // show the correct parameter help in this case.  So, when we see "partial" we check if it's being used
                 // as an identifier or as a contextual keyword.  If it's the latter then we bail out.  See
                 // Bug: vswhidbey/542125
-                if (this.IsCurrentTokenDefinitelyPartialModifier(includingForMembers: true) || IsCurrentTokenQueryKeywordInQuery())
+                if (this.IsCurrentTokenDefinitelyPartialModifier(onlyForTypeDeclarations: false) || IsCurrentTokenQueryKeywordInQuery())
                 {
                     var result = CreateMissingIdentifierToken();
                     result = this.AddError(result, ErrorCode.ERR_InvalidExprTerm, this.CurrentToken.Text);
@@ -6190,7 +6190,7 @@ parse_member_name:;
             }
 
             if (this.IsCurrentTokenWhereOfConstraintClause() ||
-                this.IsCurrentTokenDefinitelyPartialModifier(includingForMembers: true))
+                this.IsCurrentTokenDefinitelyPartialModifier(onlyForTypeDeclarations: false))
             {
                 return _syntaxFactory.TypeParameter(
                     attrs,

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1689,11 +1689,35 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
                 while (true)
                 {
+                    // A partial constructor name may itself look like a contextual modifier, as in
+                    // 'partial async()', so check for it before classifying the current token.
+                    if (IsFeatureEnabled(MessageID.IDS_FeaturePartialEventsAndConstructors) &&
+                        isIdentifierFollowedByOpenParen(peekIndex: 0))
+                    {
+                        return true;
+                    }
+
                     var modifier = GetModifierExcludingScoped(this.CurrentToken);
 
-                    // Case 1: No modifier-like token remains, so the current token must start the member itself.
                     if (modifier == DeclarationModifiers.None)
-                        return isMemberDeclarationStart();
+                    {
+                        // Case 1: No modifier-like token remains, so the current token must start the
+                        // member itself.
+
+                        // 'event' cannot begin another member form, so parse 'partial event' as an event
+                        // in every language version. Binding reports the feature diagnostic when necessary.
+                        if (this.CurrentToken.Kind == SyntaxKind.EventKeyword)
+                            return true;
+
+                        // 'implicit' and 'explicit' can only start conversion operators, so 'partial'
+                        // is a modifier even when the operator declaration is incomplete.
+                        if (this.CurrentToken.Kind is SyntaxKind.ImplicitKeyword or SyntaxKind.ExplicitKeyword)
+                            return true;
+
+                        // Otherwise, require a return type followed by a member name, as in
+                        // 'partial int M()'.
+                        return this.IsTypeFollowedByMemberName();
+                    }
 
                     // Case 2: Before a non-contextual modifier, as in 'partial static', the initial
                     // 'partial' is unambiguously a modifier.
@@ -1709,36 +1733,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
                     // Case 4: A contextual modifier may otherwise be the member's return type, such as
                     // the second 'partial' in 'partial partial P { get; }'.
-                    if (isMemberDeclarationStart())
+                    if (this.IsTypeFollowedByMemberName())
                         return true;
 
                     this.EatToken();
                 }
-            }
-
-            bool isMemberDeclarationStart()
-            {
-                // 'event' cannot begin another member form, so parse 'partial event' as an event in every
-                // language version. Binding reports the feature diagnostic when necessary.
-                if (this.CurrentToken.Kind == SyntaxKind.EventKeyword)
-                    return true;
-
-                // 'implicit' and 'explicit' can only start conversion operators, so 'partial' is a modifier
-                // even when the operator declaration is incomplete.
-                if (this.CurrentToken.Kind is SyntaxKind.ImplicitKeyword or SyntaxKind.ExplicitKeyword)
-                    return true;
-
-                // With partial constructors enabled, the current token is the constructor name after
-                // the initial modifier in 'partial C()'. In earlier versions, 'partial' is the return
-                // type and the current identifier is the member name.
-                if (IsFeatureEnabled(MessageID.IDS_FeaturePartialEventsAndConstructors) &&
-                    isIdentifierFollowedByOpenParen(peekIndex: 0))
-                {
-                    return true;
-                }
-
-                // Otherwise, require a return type followed by a member name, as in 'partial int M()'.
-                return this.IsTypeFollowedByMemberName();
             }
 
             bool isIdentifierFollowedByOpenParen(int peekIndex)

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1657,23 +1657,28 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             if (this.IsUnambiguousAnonymousFunctionModifierListFollowedByOpenParen())
                 return false;
 
-            using var _ = this.GetDisposableResetPoint(resetOnDispose: true);
+            using var resetPoint = this.GetDisposableResetPoint(resetOnDispose: true);
 
             // Consume the 'partial' being classified before scanning the declaration head.
             // Otherwise, scanning that same token as a possible type would recurse through IsTrueIdentifier.
             this.EatToken(); // partial
 
-            if (onlyForTypeDeclarations)
+            // Type and namespace declarations are straightforward: skip the modifier list and
+            // require a well-known declaration keyword such as 'class', 'struct', or 'namespace'.
+            while (GetModifierExcludingScoped(this.CurrentToken) != DeclarationModifiers.None)
             {
-                // Type and namespace declarations are straightforward: skip the modifier list and
-                // require a well-known declaration keyword such as 'class', 'struct', or 'namespace'.
-                while (GetModifierExcludingScoped(this.CurrentToken) != DeclarationModifiers.None)
-                {
-                    this.EatToken();
-                }
-
-                return this.IsTypeOrNamespaceDeclarationStart();
+                this.EatToken();
             }
+
+            if (this.IsTypeOrNamespaceDeclarationStart())
+                return true;
+
+            if (onlyForTypeDeclarations)
+                return false;
+
+            // Start over for members, where a contextual modifier may instead be the return type.
+            resetPoint.Reset();
+            this.EatToken(); // partial
 
             var partialConstructorsEnabled = IsFeatureEnabled(MessageID.IDS_FeaturePartialEventsAndConstructors);
 
@@ -1681,12 +1686,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             {
                 var modifier = GetModifierExcludingScoped(this.CurrentToken);
 
-                if (modifier == DeclarationModifiers.None)
-                {
-                    if (this.IsTypeOrNamespaceDeclarationStart())
-                        return true;
-                }
-                else
+                if (modifier != DeclarationModifiers.None)
                 {
                     // A non-contextual modifier token cannot be the name of a member returning
                     // 'partial', so its presence proves that the initial 'partial' is a modifier.
@@ -1710,9 +1710,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                     }
                 }
 
-                // With no modifier, this checks the final declaration head. With a contextual modifier,
-                // it checks whether that token instead starts a member return type, such as 'async' in
-                // 'partial async M()'.
+                // A contextual modifier may instead start the member's return type, such as
+                // 'async' in 'partial async M()'.
                 if (isMemberDeclarationStart())
                     return true;
 

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1666,8 +1666,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
                 Debug.Assert(this.CurrentToken.ContextualKind == SyntaxKind.PartialKeyword);
 
-                this.EatToken(); // partial
-
                 // Type and namespace declarations are straightforward: skip the modifier list and
                 // require a well-known declaration keyword such as 'class', 'struct', or 'namespace'.
                 while (GetModifierExcludingScoped(this.CurrentToken) != DeclarationModifiers.None)

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1691,37 +1691,37 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 {
                     var modifier = GetModifierExcludingScoped(this.CurrentToken);
 
-                    if (modifier != DeclarationModifiers.None)
+                    // Case 1: No modifier-like token remains, so the current token must start the member itself.
+                    if (modifier == DeclarationModifiers.None)
+                        return isMemberDeclarationStart();
+
+                    // Case 2: A non-contextual modifier token cannot be the name of a member returning
+                    // 'partial', so its presence proves that the initial 'partial' is a modifier.
+                    if (this.CurrentToken.Kind != SyntaxKind.IdentifierToken)
+                        return true;
+
+                    // Case 3: Another contextual 'partial' needs special handling for partial constructors
+                    // and repeated modifier chains.
+                    if (modifier == DeclarationModifiers.Partial)
                     {
-                        // A non-contextual modifier token cannot be the name of a member returning
-                        // 'partial', so its presence proves that the initial 'partial' is a modifier.
-                        if (this.CurrentToken.Kind != SyntaxKind.IdentifierToken)
+                        // The current token is a second 'partial' modifier before a constructor name,
+                        // as in 'partial partial C()'.
+                        if (isCurrentTokenPartialModifierBeforeConstructorName())
                             return true;
 
-                        if (this.CurrentToken.ContextualKind == SyntaxKind.PartialKeyword)
+                        // Process longer modifier chains one token at a time rather than recursively
+                        // scanning each 'partial' as a possible type.
+                        if (this.PeekToken(1).ContextualKind == SyntaxKind.PartialKeyword)
                         {
-                            // In C# 14, prefer the duplicate-modifier constructor interpretation of
-                            // 'partial partial C()' over treating the second 'partial' as a return type.
-                            if (canStartPartialConstructor(peekIndex: 1))
-                                return true;
-
-                            // Process longer modifier chains one token at a time rather than recursively
-                            // scanning each 'partial' as a possible type.
-                            if (this.PeekToken(1).ContextualKind == SyntaxKind.PartialKeyword)
-                            {
-                                this.EatToken();
-                                continue;
-                            }
+                            this.EatToken();
+                            continue;
                         }
                     }
 
-                    // A contextual modifier may instead start the member's return type, such as
-                    // 'async' in 'partial async M()'.
+                    // Case 4: Any contextual modifier may instead be the member's return type, such as 'async'
+                    // in 'partial async M()'.
                     if (isMemberDeclarationStart())
                         return true;
-
-                    if (modifier == DeclarationModifiers.None)
-                        return false;
 
                     this.EatToken();
                 }
@@ -1739,22 +1739,33 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 if (this.CurrentToken.Kind is SyntaxKind.ImplicitKeyword or SyntaxKind.ExplicitKeyword)
                     return true;
 
-                // Before partial constructors, 'partial C()' is a method returning 'partial'. Only prefer
-                // the constructor interpretation when the feature is enabled.
-                if (canStartPartialConstructor(peekIndex: 0))
+                // The current token is the constructor name after the initial 'partial' modifier,
+                // as in 'partial C()'.
+                if (isCurrentTokenPartialConstructorName())
                     return true;
 
                 // Otherwise, require a return type followed by a member name, as in 'partial int M()'.
                 return this.IsTypeFollowedByMemberName();
             }
 
-            // The surrounding checks establish the preceding 'partial' modifier. This returns true only
-            // when partial constructors are enabled and the following tokens can start the constructor.
-            bool canStartPartialConstructor(int peekIndex)
+            bool isCurrentTokenPartialModifierBeforeConstructorName()
             {
+                Debug.Assert(this.CurrentToken.ContextualKind == SyntaxKind.PartialKeyword);
+
+                // With partial constructors enabled, the current 'partial' is another modifier before
+                // the constructor name. In earlier versions, it is instead the member's return type.
                 return IsFeatureEnabled(MessageID.IDS_FeaturePartialEventsAndConstructors) &&
-                    this.PeekToken(peekIndex).Kind == SyntaxKind.IdentifierToken &&
-                    this.PeekToken(peekIndex + 1).Kind == SyntaxKind.OpenParenToken;
+                    this.PeekToken(1).Kind == SyntaxKind.IdentifierToken &&
+                    this.PeekToken(2).Kind == SyntaxKind.OpenParenToken;
+            }
+
+            bool isCurrentTokenPartialConstructorName()
+            {
+                // Before partial constructors, the initial 'partial' is the return type and the current
+                // identifier is the member name.
+                return IsFeatureEnabled(MessageID.IDS_FeaturePartialEventsAndConstructors) &&
+                    this.CurrentToken.Kind == SyntaxKind.IdentifierToken &&
+                    this.PeekToken(1).Kind == SyntaxKind.OpenParenToken;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1700,16 +1700,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                     if (this.CurrentToken.Kind != SyntaxKind.IdentifierToken)
                         return true;
 
-                    // Case 3: A contextual modifier may instead be the member's return type, such as
-                    // the second 'partial' in 'partial partial P { get; }', or 'async' in
-                    // 'partial async M()'.
-                    //
-                    // If it is followed by 'Identifier(', then it either starts a method return type,
-                    // as in 'partial async C()', or is another modifier on a partial constructor, as
-                    // in 'partial partial C()'. Either way, the initial 'partial' is a modifier.
+                    // Case 3: A contextual modifier followed by 'Identifier(' either starts a method
+                    // return type, as in 'partial async C()', or is another modifier on a partial
+                    // constructor, as in 'partial partial C()'. Either way, the initial 'partial'
+                    // is a modifier.
                     if (isIdentifierFollowedByOpenParen(peekIndex: 1))
                         return true;
 
+                    // Case 4: A contextual modifier may otherwise be the member's return type, such as
+                    // the second 'partial' in 'partial partial P { get; }'.
                     if (isMemberDeclarationStart())
                         return true;
 

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1704,9 +1704,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                     // and repeated modifier chains.
                     if (modifier == DeclarationModifiers.Partial)
                     {
-                        // The current token is a second 'partial' modifier before a constructor name,
-                        // as in 'partial partial C()'.
-                        if (isCurrentTokenPartialModifierBeforeConstructorName())
+                        // With partial constructors enabled, the current token is a second 'partial'
+                        // modifier before the constructor name in 'partial partial C()'. In earlier
+                        // versions, it is instead the member's return type.
+                        if (isPartialConstructorName(peekIndex: 1))
                             return true;
 
                         // Process longer modifier chains one token at a time rather than recursively
@@ -1739,33 +1740,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 if (this.CurrentToken.Kind is SyntaxKind.ImplicitKeyword or SyntaxKind.ExplicitKeyword)
                     return true;
 
-                // The current token is the constructor name after the initial 'partial' modifier,
-                // as in 'partial C()'.
-                if (isCurrentTokenPartialConstructorName())
+                // With partial constructors enabled, the current token is the constructor name after
+                // the initial modifier in 'partial C()'. In earlier versions, 'partial' is the return
+                // type and the current identifier is the member name.
+                if (isPartialConstructorName(peekIndex: 0))
                     return true;
 
                 // Otherwise, require a return type followed by a member name, as in 'partial int M()'.
                 return this.IsTypeFollowedByMemberName();
             }
 
-            bool isCurrentTokenPartialModifierBeforeConstructorName()
+            bool isPartialConstructorName(int peekIndex)
             {
-                Debug.Assert(this.CurrentToken.ContextualKind == SyntaxKind.PartialKeyword);
-
-                // With partial constructors enabled, the current 'partial' is another modifier before
-                // the constructor name. In earlier versions, it is instead the member's return type.
                 return IsFeatureEnabled(MessageID.IDS_FeaturePartialEventsAndConstructors) &&
-                    this.PeekToken(1).Kind == SyntaxKind.IdentifierToken &&
-                    this.PeekToken(2).Kind == SyntaxKind.OpenParenToken;
-            }
-
-            bool isCurrentTokenPartialConstructorName()
-            {
-                // Before partial constructors, the initial 'partial' is the return type and the current
-                // identifier is the member name.
-                return IsFeatureEnabled(MessageID.IDS_FeaturePartialEventsAndConstructors) &&
-                    this.CurrentToken.Kind == SyntaxKind.IdentifierToken &&
-                    this.PeekToken(1).Kind == SyntaxKind.OpenParenToken;
+                    this.PeekToken(peekIndex).Kind == SyntaxKind.IdentifierToken &&
+                    this.PeekToken(peekIndex + 1).Kind == SyntaxKind.OpenParenToken;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1697,37 +1697,37 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
                     if (modifier == DeclarationModifiers.None)
                     {
-                        // Case 1: No modifier-like token remains, so the current token must start the
-                        // member itself.
+                        // No modifier-like token remains, so the current token must start the member itself.
 
-                        // 'event' cannot begin another member form, so parse 'partial event' as an event
-                        // in every language version. Binding reports the feature diagnostic when necessary.
+                        // Case 1: 'event' cannot begin another member form, so parse 'partial event'
+                        // as an event in every language version. Binding reports the feature diagnostic
+                        // when necessary.
                         if (this.CurrentToken.Kind == SyntaxKind.EventKeyword)
                             return true;
 
-                        // 'implicit' and 'explicit' can only start conversion operators, so 'partial'
-                        // is a modifier even when the operator declaration is incomplete.
+                        // Case 2: 'implicit' and 'explicit' can only start conversion operators, so
+                        // 'partial' is a modifier even when the operator declaration is incomplete.
                         if (this.CurrentToken.Kind is SyntaxKind.ImplicitKeyword or SyntaxKind.ExplicitKeyword)
                             return true;
 
-                        // Otherwise, require a return type followed by a member name, as in
+                        // Case 3: Otherwise, require a return type followed by a member name, as in
                         // 'partial int M()'.
                         return this.IsTypeFollowedByMemberName();
                     }
 
-                    // Case 2: Before a non-contextual modifier, as in 'partial static', the initial
+                    // Case 4: Before a non-contextual modifier, as in 'partial static', the initial
                     // 'partial' is unambiguously a modifier.
                     if (this.CurrentToken.Kind != SyntaxKind.IdentifierToken)
                         return true;
 
-                    // Case 3: A contextual modifier followed by 'Identifier(' either starts a method
+                    // Case 5: A contextual modifier followed by 'Identifier(' either starts a method
                     // return type, as in 'partial async C()', or is another modifier on a partial
                     // constructor, as in 'partial partial C()'. Either way, the initial 'partial'
                     // is a modifier.
                     if (isIdentifierFollowedByOpenParen(peekIndex: 1))
                         return true;
 
-                    // Case 4: A contextual modifier may otherwise be the member's return type, such as
+                    // Case 6: A contextual modifier may otherwise be the member's return type, such as
                     // the second 'partial' in 'partial partial P { get; }'.
                     if (this.IsTypeFollowedByMemberName())
                         return true;

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1658,7 +1658,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 return false;
 
             return isPartialModifierInTypeOrNamespaceDeclaration() ||
-                isPartialModifierInMemberDeclaration();
+                   isPartialModifierInMemberDeclaration();
 
             bool isPartialModifierInTypeOrNamespaceDeclaration()
             {
@@ -1669,9 +1669,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 // Type and namespace declarations are straightforward: skip the modifier list and
                 // require a well-known declaration keyword such as 'class', 'struct', or 'namespace'.
                 while (GetModifierExcludingScoped(this.CurrentToken) != DeclarationModifiers.None)
-                {
                     this.EatToken();
-                }
 
                 return this.IsTypeOrNamespaceDeclarationStart();
             }
@@ -1688,8 +1686,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 // Consume the 'partial' being classified before scanning the declaration head.
                 // Otherwise, scanning that same token as a possible type would recurse through IsTrueIdentifier.
                 this.EatToken(); // partial
-
-                var partialConstructorsEnabled = IsFeatureEnabled(MessageID.IDS_FeaturePartialEventsAndConstructors);
 
                 while (true)
                 {
@@ -1729,36 +1725,36 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
                     this.EatToken();
                 }
+            }
 
-                bool isMemberDeclarationStart()
-                {
-                    // 'event' cannot begin another member form, so parse 'partial event' as an event in every
-                    // language version. Binding reports the feature diagnostic when necessary.
-                    if (this.CurrentToken.Kind == SyntaxKind.EventKeyword)
-                        return true;
+            bool isMemberDeclarationStart()
+            {
+                // 'event' cannot begin another member form, so parse 'partial event' as an event in every
+                // language version. Binding reports the feature diagnostic when necessary.
+                if (this.CurrentToken.Kind == SyntaxKind.EventKeyword)
+                    return true;
 
-                    // 'implicit' and 'explicit' can only start conversion operators, so 'partial' is a modifier
-                    // even when the operator declaration is incomplete.
-                    if (this.CurrentToken.Kind is SyntaxKind.ImplicitKeyword or SyntaxKind.ExplicitKeyword)
-                        return true;
+                // 'implicit' and 'explicit' can only start conversion operators, so 'partial' is a modifier
+                // even when the operator declaration is incomplete.
+                if (this.CurrentToken.Kind is SyntaxKind.ImplicitKeyword or SyntaxKind.ExplicitKeyword)
+                    return true;
 
-                    // Before partial constructors, 'partial C()' is a method returning 'partial'. Only prefer
-                    // the constructor interpretation when the feature is enabled.
-                    if (canStartPartialConstructor(peekIndex: 0))
-                        return true;
+                // Before partial constructors, 'partial C()' is a method returning 'partial'. Only prefer
+                // the constructor interpretation when the feature is enabled.
+                if (canStartPartialConstructor(peekIndex: 0))
+                    return true;
 
-                    // Otherwise, require a return type followed by a member name, as in 'partial int M()'.
-                    return this.IsTypeFollowedByMemberName();
-                }
+                // Otherwise, require a return type followed by a member name, as in 'partial int M()'.
+                return this.IsTypeFollowedByMemberName();
+            }
 
-                // The surrounding checks establish the preceding 'partial' modifier. This returns true only
-                // when partial constructors are enabled and the following tokens can start the constructor.
-                bool canStartPartialConstructor(int peekIndex)
-                {
-                    return partialConstructorsEnabled &&
-                        this.PeekToken(peekIndex).Kind == SyntaxKind.IdentifierToken &&
-                        this.PeekToken(peekIndex + 1).Kind == SyntaxKind.OpenParenToken;
-                }
+            // The surrounding checks establish the preceding 'partial' modifier. This returns true only
+            // when partial constructors are enabled and the following tokens can start the constructor.
+            bool canStartPartialConstructor(int peekIndex)
+            {
+                return IsFeatureEnabled(MessageID.IDS_FeaturePartialEventsAndConstructors) &&
+                    this.PeekToken(peekIndex).Kind == SyntaxKind.IdentifierToken &&
+                    this.PeekToken(peekIndex + 1).Kind == SyntaxKind.OpenParenToken;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1723,7 +1723,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                     // Case 5: A contextual modifier followed by 'Identifier(' either starts a method
                     // return type, as in 'partial async C()', or is another modifier on a partial
                     // constructor, as in 'partial partial C()'. Either way, the initial 'partial'
-                    // is a modifier.
+                    // is a modifier. This does not fall through to Case 6 for the latter form in
+                    // C# 14: scanning the second 'partial' as a type reenters this helper and classifies
+                    // it as a modifier, so IsTypeFollowedByMemberName() returns false.
                     if (isIdentifierFollowedByOpenParen(peekIndex: 1))
                         return true;
 

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1700,8 +1700,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                     if (this.CurrentToken.Kind != SyntaxKind.IdentifierToken)
                         return true;
 
-                    // Case 3: A contextual modifier may instead be the member's return type, such as 'async'
-                    // in 'partial async M()'.
+                    // Case 3: A contextual modifier may instead be the member's return type, such as
+                    // the second 'partial' in 'partial partial P { get; }', or 'async' in
+                    // 'partial async M()'.
                     if (isMemberDeclarationStart())
                         return true;
 

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1662,10 +1662,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             if (isPartialModifierInTypeOrNamespaceDeclaration())
                 return true;
 
-            if (onlyForTypeDeclarations)
-                return false;
-
-            beforePartialResetPoint.Reset();
             return isPartialModifierInMemberDeclaration();
 
             bool isPartialModifierInTypeOrNamespaceDeclaration()
@@ -1686,6 +1682,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
             bool isPartialModifierInMemberDeclaration()
             {
+                if (onlyForTypeDeclarations)
+                    return false;
+
+                beforePartialResetPoint.Reset();
+
                 Debug.Assert(this.CurrentToken.ContextualKind == SyntaxKind.PartialKeyword);
 
                 // Consume the 'partial' being classified before scanning the declaration head.

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1657,98 +1657,111 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             if (this.IsUnambiguousAnonymousFunctionModifierListFollowedByOpenParen())
                 return false;
 
-            using var resetPoint = this.GetDisposableResetPoint(resetOnDispose: true);
+            using var beforePartialResetPoint = this.GetDisposableResetPoint(resetOnDispose: true);
 
-            // Consume the 'partial' being classified before scanning the declaration head.
-            // Otherwise, scanning that same token as a possible type would recurse through IsTrueIdentifier.
-            this.EatToken(); // partial
-
-            // Type and namespace declarations are straightforward: skip the modifier list and
-            // require a well-known declaration keyword such as 'class', 'struct', or 'namespace'.
-            while (GetModifierExcludingScoped(this.CurrentToken) != DeclarationModifiers.None)
-            {
-                this.EatToken();
-            }
-
-            if (this.IsTypeOrNamespaceDeclarationStart())
+            if (isPartialModifierInTypeOrNamespaceDeclaration())
                 return true;
 
             if (onlyForTypeDeclarations)
                 return false;
 
-            // Start over for members, where a contextual modifier may instead be the return type.
-            resetPoint.Reset();
-            this.EatToken(); // partial
+            beforePartialResetPoint.Reset();
+            return isPartialModifierInMemberDeclaration();
 
-            var partialConstructorsEnabled = IsFeatureEnabled(MessageID.IDS_FeaturePartialEventsAndConstructors);
-
-            while (true)
+            bool isPartialModifierInTypeOrNamespaceDeclaration()
             {
-                var modifier = GetModifierExcludingScoped(this.CurrentToken);
+                Debug.Assert(this.CurrentToken.ContextualKind == SyntaxKind.PartialKeyword);
 
-                if (modifier != DeclarationModifiers.None)
+                this.EatToken(); // partial
+
+                // Type and namespace declarations are straightforward: skip the modifier list and
+                // require a well-known declaration keyword such as 'class', 'struct', or 'namespace'.
+                while (GetModifierExcludingScoped(this.CurrentToken) != DeclarationModifiers.None)
                 {
-                    // A non-contextual modifier token cannot be the name of a member returning
-                    // 'partial', so its presence proves that the initial 'partial' is a modifier.
-                    if (this.CurrentToken.Kind != SyntaxKind.IdentifierToken)
-                        return true;
-
-                    if (this.CurrentToken.ContextualKind == SyntaxKind.PartialKeyword)
-                    {
-                        // In C# 14, prefer the duplicate-modifier constructor interpretation of
-                        // 'partial partial C()' over treating the second 'partial' as a return type.
-                        if (canStartPartialConstructor(peekIndex: 1))
-                            return true;
-
-                        // Process longer modifier chains one token at a time rather than recursively
-                        // scanning each 'partial' as a possible type.
-                        if (this.PeekToken(1).ContextualKind == SyntaxKind.PartialKeyword)
-                        {
-                            this.EatToken();
-                            continue;
-                        }
-                    }
+                    this.EatToken();
                 }
 
-                // A contextual modifier may instead start the member's return type, such as
-                // 'async' in 'partial async M()'.
-                if (isMemberDeclarationStart())
-                    return true;
-
-                if (modifier == DeclarationModifiers.None)
-                    return false;
-
-                this.EatToken();
+                return this.IsTypeOrNamespaceDeclarationStart();
             }
 
-            bool isMemberDeclarationStart()
+            bool isPartialModifierInMemberDeclaration()
             {
-                // 'event' cannot begin another member form, so parse 'partial event' as an event in every
-                // language version. Binding reports the feature diagnostic when necessary.
-                if (this.CurrentToken.Kind == SyntaxKind.EventKeyword)
-                    return true;
+                Debug.Assert(this.CurrentToken.ContextualKind == SyntaxKind.PartialKeyword);
 
-                // 'implicit' and 'explicit' can only start conversion operators, so 'partial' is a modifier
-                // even when the operator declaration is incomplete.
-                if (this.CurrentToken.Kind is SyntaxKind.ImplicitKeyword or SyntaxKind.ExplicitKeyword)
-                    return true;
+                // Consume the 'partial' being classified before scanning the declaration head.
+                // Otherwise, scanning that same token as a possible type would recurse through IsTrueIdentifier.
+                this.EatToken(); // partial
 
-                // Before partial constructors, 'partial C()' is a method returning 'partial'. Only prefer
-                // the constructor interpretation when the feature is enabled.
-                if (canStartPartialConstructor(peekIndex: 0))
-                    return true;
+                var partialConstructorsEnabled = IsFeatureEnabled(MessageID.IDS_FeaturePartialEventsAndConstructors);
 
-                // Otherwise, require a return type followed by a member name, as in 'partial int M()'.
-                return this.IsTypeFollowedByMemberName();
-            }
+                while (true)
+                {
+                    var modifier = GetModifierExcludingScoped(this.CurrentToken);
 
-            // The surrounding checks establish the preceding 'partial' modifier. This returns true only
-            // when partial constructors are enabled and the following tokens can start the constructor.
-            bool canStartPartialConstructor(int peekIndex)
-            {
-                return partialConstructorsEnabled &&
-                    this.PeekToken(peekIndex).Kind == SyntaxKind.IdentifierToken &&
-                    this.PeekToken(peekIndex + 1).Kind == SyntaxKind.OpenParenToken;
+                    if (modifier != DeclarationModifiers.None)
+                    {
+                        // A non-contextual modifier token cannot be the name of a member returning
+                        // 'partial', so its presence proves that the initial 'partial' is a modifier.
+                        if (this.CurrentToken.Kind != SyntaxKind.IdentifierToken)
+                            return true;
+
+                        if (this.CurrentToken.ContextualKind == SyntaxKind.PartialKeyword)
+                        {
+                            // In C# 14, prefer the duplicate-modifier constructor interpretation of
+                            // 'partial partial C()' over treating the second 'partial' as a return type.
+                            if (canStartPartialConstructor(peekIndex: 1))
+                                return true;
+
+                            // Process longer modifier chains one token at a time rather than recursively
+                            // scanning each 'partial' as a possible type.
+                            if (this.PeekToken(1).ContextualKind == SyntaxKind.PartialKeyword)
+                            {
+                                this.EatToken();
+                                continue;
+                            }
+                        }
+                    }
+
+                    // A contextual modifier may instead start the member's return type, such as
+                    // 'async' in 'partial async M()'.
+                    if (isMemberDeclarationStart())
+                        return true;
+
+                    if (modifier == DeclarationModifiers.None)
+                        return false;
+
+                    this.EatToken();
+                }
+
+                bool isMemberDeclarationStart()
+                {
+                    // 'event' cannot begin another member form, so parse 'partial event' as an event in every
+                    // language version. Binding reports the feature diagnostic when necessary.
+                    if (this.CurrentToken.Kind == SyntaxKind.EventKeyword)
+                        return true;
+
+                    // 'implicit' and 'explicit' can only start conversion operators, so 'partial' is a modifier
+                    // even when the operator declaration is incomplete.
+                    if (this.CurrentToken.Kind is SyntaxKind.ImplicitKeyword or SyntaxKind.ExplicitKeyword)
+                        return true;
+
+                    // Before partial constructors, 'partial C()' is a method returning 'partial'. Only prefer
+                    // the constructor interpretation when the feature is enabled.
+                    if (canStartPartialConstructor(peekIndex: 0))
+                        return true;
+
+                    // Otherwise, require a return type followed by a member name, as in 'partial int M()'.
+                    return this.IsTypeFollowedByMemberName();
+                }
+
+                // The surrounding checks establish the preceding 'partial' modifier. This returns true only
+                // when partial constructors are enabled and the following tokens can start the constructor.
+                bool canStartPartialConstructor(int peekIndex)
+                {
+                    return partialConstructorsEnabled &&
+                        this.PeekToken(peekIndex).Kind == SyntaxKind.IdentifierToken &&
+                        this.PeekToken(peekIndex + 1).Kind == SyntaxKind.OpenParenToken;
+                }
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1683,9 +1683,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
                 Debug.Assert(this.CurrentToken.ContextualKind == SyntaxKind.PartialKeyword);
 
-                // Consume the 'partial' being classified before scanning the declaration head.
-                // Otherwise, scanning that same token as a possible type would recurse through IsTrueIdentifier.
-                this.EatToken(); // partial
+                // Consume the 'partial' and determine if what follows is definitively a member.
+                this.EatToken();
 
                 // With partial constructors enabled, 'partial Identifier(' starts a constructor.
                 // In earlier versions, 'partial' is the return type and the identifier is the member name.

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1400,16 +1400,33 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                         }
 
                     case DeclarationModifiers.File:
-                        if (!parseAsModifier(MessageID.IDS_FeatureFileTypes, out modTok))
-                            return;
-
-                        break;
-
                     case DeclarationModifiers.Closed:
-                        if (!parseAsModifier(MessageID.IDS_FeatureClosedClasses, out modTok))
-                            return;
+                    case DeclarationModifiers.Required:
+                    case DeclarationModifiers.Safe:
+                        {
+                            var requiredFeature = newMod switch
+                            {
+                                DeclarationModifiers.File => MessageID.IDS_FeatureFileTypes,
+                                DeclarationModifiers.Closed => MessageID.IDS_FeatureClosedClasses,
+                                DeclarationModifiers.Required => MessageID.IDS_FeatureRequiredMembers,
+                                DeclarationModifiers.Safe => MessageID.IDS_FeatureUnsafeEvolution,
+                                _ => throw ExceptionUtilities.UnexpectedValue(newMod),
+                            };
 
-                        break;
+                            // When the feature is enabled, the associated contextual keyword is always a keyword
+                            // if not escaped. Otherwise, conservatively determine whether it is intended as a
+                            // modifier so binding can report the language-version diagnostic. Top-level statements
+                            // must always be disambiguated because the keyword may instead be a local name.
+                            if ((!IsFeatureEnabled(requiredFeature) || forTopLevelStatements) &&
+                                !ShouldContextualKeywordBeTreatedAsModifier(parsingStatementNotDeclaration: false))
+                            {
+                                return;
+                            }
+
+                            // LangVersion errors for contextual modifiers are given during binding.
+                            modTok = ConvertToKeyword(EatToken());
+                            break;
+                        }
 
                     case DeclarationModifiers.Async:
                         if (!ShouldContextualKeywordBeTreatedAsModifier(parsingStatementNotDeclaration: false))
@@ -1418,18 +1435,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                         }
 
                         modTok = ConvertToKeyword(this.EatToken());
-                        break;
-
-                    case DeclarationModifiers.Required:
-                        if (!parseAsModifier(MessageID.IDS_FeatureRequiredMembers, out modTok))
-                            return;
-
-                        break;
-
-                    case DeclarationModifiers.Safe:
-                        if (!parseAsModifier(MessageID.IDS_FeatureUnsafeEvolution, out modTok))
-                            return;
-
                         break;
 
                     default:
@@ -1476,23 +1481,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 return this.CurrentToken.ContextualKind is
                     SyntaxKind.RecordKeyword or SyntaxKind.UnionKeyword or SyntaxKind.ExtensionKeyword ||
                     this.IsTypeDeclarationStart();
-            }
-
-            bool parseAsModifier(MessageID requiredFeature, [NotNullWhen(true)] out SyntaxToken? modTok)
-            {
-                // When 'requiredFeature' is enabled, the associated contextual keyword is always a keyword if not escaped. Otherwise, we reuse the async detection
-                // machinery to make a conservative guess as to whether the user meant it to be a keyword, so that they get a good langver
-                // diagnostic and all the machinery to upgrade their project kicks in. The only exception to this rule is top level statements,
-                // where the user could conceivably have a local with the same name as the modifier. For these locations, we need to disambiguate as well.
-                if ((!IsFeatureEnabled(requiredFeature) || forTopLevelStatements) && !ShouldContextualKeywordBeTreatedAsModifier(parsingStatementNotDeclaration: false))
-                {
-                    modTok = null;
-                    return false;
-                }
-
-                // LangVersion errors for contextual modifiers are given during binding.
-                modTok = ConvertToKeyword(EatToken());
-                return true;
             }
         }
 
@@ -1691,10 +1679,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 if (isIdentifierFollowedByOpenParen(peekIndex: 0))
                     return IsFeatureEnabled(MessageID.IDS_FeaturePartialEventsAndConstructors);
 
-                while (true)
+                while (GetModifierExcludingScoped(this.CurrentToken) is var modifier)
                 {
-                    var modifier = GetModifierExcludingScoped(this.CurrentToken);
-
                     if (modifier == DeclarationModifiers.None)
                     {
                         // No modifier-like token remains, so the current token must start the member itself.
@@ -1736,6 +1722,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
                     this.EatToken();
                 }
+
+                throw ExceptionUtilities.Unreachable();
             }
 
             bool isIdentifierFollowedByOpenParen(int peekIndex)

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1671,6 +1671,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
                 if (modifier == DeclarationModifiers.None)
                 {
+                    // Handle type and namespace declaration heads here. Member declaration heads are
+                    // handled by the shared check below, which also disambiguates contextual modifiers.
                     if (this.IsTypeOrNamespaceDeclarationStart())
                         return true;
                 }
@@ -1706,8 +1708,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                     }
                 }
 
-                // The current token is either the final declaration head or a contextual modifier
-                // that may instead start a member return type, such as 'async' in 'partial async M()'.
+                // With no modifier, this checks the final declaration head. With a contextual modifier,
+                // it checks whether that token instead starts a member return type, such as 'async' in
+                // 'partial async M()'.
                 if (includingForMembers && isMemberDeclarationStart())
                     return true;
 

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1605,16 +1605,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                     return true;
                 }
 
-                // "TOKEN TypeName class". In this case, we just have an incomplete member before
-                // an existing type declaration.  Treat this 'TOKEN' as a keyword.
-                if (IsTypeDeclarationStart())
-                {
-                    return true;
-                }
-
-                // "TOKEN TypeName namespace". In this case, we just have an incomplete member before
-                // an existing namespace declaration.  Treat this 'TOKEN' as a keyword.
-                if (currentTokenKind == SyntaxKind.NamespaceKeyword)
+                // "TOKEN TypeName class" or "TOKEN TypeName namespace". In this case, we just have
+                // an incomplete member before an existing declaration. Treat this 'TOKEN' as a keyword.
+                if (this.IsTypeOrNamespaceDeclarationStart())
                 {
                     return true;
                 }
@@ -1627,6 +1620,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
             return false;
         }
+
+        private bool IsTypeOrNamespaceDeclarationStart()
+            => this.IsTypeDeclarationStart() || this.CurrentToken.Kind == SyntaxKind.NamespaceKeyword;
 
         private static bool IsNonContextualModifier(SyntaxToken nextToken)
         {
@@ -1669,59 +1665,60 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
             var partialConstructorsEnabled = IsFeatureEnabled(MessageID.IDS_FeaturePartialEventsAndConstructors);
 
-            // Look through following modifiers for the declaration head. A contextual modifier may
-            // instead begin the member itself, such as 'ref' in 'partial ref int M()'.
-            while (GetModifierExcludingScoped(this.CurrentToken) != DeclarationModifiers.None)
+            while (true)
             {
-                // For example, 'async' starts the return type in 'partial async M()'.
-                if (shouldStopSkippingModifiers())
+                var modifier = GetModifierExcludingScoped(this.CurrentToken);
+
+                if (modifier == DeclarationModifiers.None)
+                {
+                    if (this.IsTypeOrNamespaceDeclarationStart())
+                        return true;
+                }
+                else
+                {
+                    // Namespace lookahead must skip all modifiers and require a type or namespace
+                    // declaration head. It must not accept a member such as 'partial int M()'.
+                    if (!includingForMembers)
+                    {
+                        this.EatToken();
+                        continue;
+                    }
+
+                    // A non-contextual modifier token cannot be the name of a member returning
+                    // 'partial', so its presence proves that the initial 'partial' is a modifier.
+                    if (this.CurrentToken.Kind != SyntaxKind.IdentifierToken)
+                        return true;
+
+                    if (this.CurrentToken.ContextualKind == SyntaxKind.PartialKeyword)
+                    {
+                        // In C# 14, prefer the duplicate-modifier constructor interpretation of
+                        // 'partial partial C()' over treating the second 'partial' as a return type.
+                        if (canStartPartialConstructor(peekIndex: 1))
+                            return true;
+
+                        // Process longer modifier chains one token at a time rather than recursively
+                        // scanning each 'partial' as a possible type.
+                        if (this.PeekToken(1).ContextualKind == SyntaxKind.PartialKeyword)
+                        {
+                            this.EatToken();
+                            continue;
+                        }
+                    }
+                }
+
+                // The current token is either the final declaration head or a contextual modifier
+                // that may instead start a member return type, such as 'async' in 'partial async M()'.
+                if (includingForMembers && isMemberDeclarationStart())
                     return true;
+
+                if (modifier == DeclarationModifiers.None)
+                    return false;
 
                 this.EatToken();
             }
 
-            // 'partial public class C' reaches 'class' here.
-            if (this.IsTypeDeclarationStart())
-                return true;
-
-            // Parse 'partial public namespace N' as a namespace so binding can report the misplaced
-            // modifier instead of producing cascading parser errors.
-            if (this.CurrentToken.Kind == SyntaxKind.NamespaceKeyword)
-                return true;
-
-            return isMemberDeclarationStart();
-
-            bool shouldStopSkippingModifiers()
-            {
-                if (!includingForMembers)
-                    return false;
-
-                // A non-contextual modifier proves that the initial 'partial' belongs to a member.
-                if (this.CurrentToken.Kind != SyntaxKind.IdentifierToken)
-                    return true;
-
-                // A different contextual modifier may instead start the member's return type,
-                // such as 'async' in 'partial async M()'.
-                if (this.CurrentToken.ContextualKind != SyntaxKind.PartialKeyword)
-                    return isMemberDeclarationStart();
-
-                // In C# 14, prefer the duplicate-modifier constructor interpretation of
-                // 'partial partial C()' over treating the second 'partial' as a return type.
-                if (canStartPartialConstructor(peekIndex: 1))
-                    return true;
-
-                // Process longer modifier chains one token at a time rather than recursively
-                // scanning each 'partial' as a possible type.
-                return this.PeekToken(1).ContextualKind != SyntaxKind.PartialKeyword &&
-                    isMemberDeclarationStart();
-            }
-
             bool isMemberDeclarationStart()
             {
-                // Namespace lookahead must not accept member-only forms such as 'partial int M()'.
-                if (!includingForMembers)
-                    return false;
-
                 // 'event' cannot begin another member form, so parse 'partial event' as an event in every
                 // language version. Binding reports the feature diagnostic when necessary.
                 if (this.CurrentToken.Kind == SyntaxKind.EventKeyword)

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1657,13 +1657,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             if (this.IsUnambiguousAnonymousFunctionModifierListFollowedByOpenParen())
                 return false;
 
-            using var beforePartialResetPoint = this.GetDisposableResetPoint(resetOnDispose: true);
-
             return isPartialModifierInTypeOrNamespaceDeclaration() ||
                 isPartialModifierInMemberDeclaration();
 
             bool isPartialModifierInTypeOrNamespaceDeclaration()
             {
+                using var _ = this.GetDisposableResetPoint(resetOnDispose: true);
+
                 Debug.Assert(this.CurrentToken.ContextualKind == SyntaxKind.PartialKeyword);
 
                 this.EatToken(); // partial
@@ -1683,7 +1683,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 if (onlyForTypeDeclarations)
                     return false;
 
-                beforePartialResetPoint.Reset();
+                using var _ = this.GetDisposableResetPoint(resetOnDispose: true);
 
                 Debug.Assert(this.CurrentToken.ContextualKind == SyntaxKind.PartialKeyword);
 

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1710,8 +1710,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                         if (isPartialConstructorName(peekIndex: 1))
                             return true;
 
-                        // Process longer modifier chains one token at a time rather than recursively
-                        // scanning each 'partial' as a possible type.
+                        // Do not call isMemberDeclarationStart() for consecutive 'partial' tokens. It
+                        // reaches IsTypeFollowedByMemberName(), which scans the current 'partial' as a
+                        // possible type and reenters IsCurrentTokenDefinitelyPartialModifier(). Consume
+                        // one token here so long modifier chains are processed iteratively.
                         if (this.PeekToken(1).ContextualKind == SyntaxKind.PartialKeyword)
                         {
                             this.EatToken();

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ModifierParserRecoveryTests.Partial.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ModifierParserRecoveryTests.Partial.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -408,21 +407,6 @@ public sealed partial class ModifierParserRecoveryTests(ITestOutputHelper output
             N(SyntaxKind.EndOfFileToken);
         }
         EOF();
-    }
-
-    [Theory]
-    [InlineData(LanguageVersion.CSharp13)]
-    [InlineData(LanguageVersion.Preview)]
-    public void ManyPartialModifiers_MakesProgress(LanguageVersion languageVersion)
-    {
-        var modifiers = string.Concat(Enumerable.Repeat("partial ", 10_000));
-        var source = $"class C {{ {modifiers}int M(); }}";
-
-        var root = SyntaxFactory.ParseSyntaxTree(
-            source,
-            options: TestOptions.Regular.WithLanguageVersion(languageVersion)).GetRoot();
-
-        Assert.Equal(source, root.ToFullString());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- rename the partial modifier lookahead helper to describe its result
- inline the redundant partial member-or-type wrapper
- clarify whether member declarations are included in lookahead

## Test plan

- `Microsoft.CodeAnalysis.CSharp.Syntax.UnitTests`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85183)