### PR TITLE
Fix compiler server logging

### DIFF
--- a/src/Compilers/Server/VBCSCompiler/VBCSCompiler.cs
+++ b/src/Compilers/Server/VBCSCompiler/VBCSCompiler.cs
@@ -19,7 +19,9 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 return CommonCompiler.Failed;
             }
 
-            using var logger = new CompilerServerLogger($"VBCSCompiler {Process.GetCurrentProcess().Id}", options.LogFilePath);
+            using var logger = options.LogFilePath is null
+                ? new CompilerServerLogger($"VBCSCompiler {Process.GetCurrentProcess().Id}", StandardBuildEnvironment.Instance)
+                : new CompilerServerLogger($"VBCSCompiler {Process.GetCurrentProcess().Id}", options.LogFilePath);
 
 #if BOOTSTRAP
             ExitingTraceListener.Install(logger);

--- a/src/Compilers/Server/VBCSCompiler/VBCSCompiler.cs
+++ b/src/Compilers/Server/VBCSCompiler/VBCSCompiler.cs
@@ -19,9 +19,10 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 return CommonCompiler.Failed;
             }
 
+            var identifier = $"VBCSCompiler {Process.GetCurrentProcess().Id}";
             using var logger = options.LogFilePath is null
-                ? new CompilerServerLogger($"VBCSCompiler {Process.GetCurrentProcess().Id}", StandardBuildEnvironment.Instance)
-                : new CompilerServerLogger($"VBCSCompiler {Process.GetCurrentProcess().Id}", options.LogFilePath);
+                ? new CompilerServerLogger(identifier, StandardBuildEnvironment.Instance)
+                : new CompilerServerLogger(identifier, options.LogFilePath);
 
 #if BOOTSTRAP
             ExitingTraceListener.Install(logger);

--- a/src/Compilers/Server/VBCSCompilerTests/VBCSCompilerServerTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/VBCSCompilerServerTests.cs
@@ -34,6 +34,65 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
 
         public class StartupTests : VBCSCompilerServerTests
         {
+            [Theory]
+            [InlineData(false)]
+            [InlineData(true)]
+            public void LoggingFromEnvironment(bool logToDirectory)
+            {
+                var directory = TempRoot.CreateDirectory();
+                var logPath = logToDirectory ? directory.Path : Path.Combine(directory.Path, "server.log");
+
+                RunServerWithLogging(logPath);
+
+                var logFile = Assert.Single(Directory.GetFiles(directory.Path));
+                if (logToDirectory)
+                {
+                    Assert.StartsWith("server.", Path.GetFileName(logFile));
+                    Assert.EndsWith(".log", logFile);
+                }
+                else
+                {
+                    Assert.Equal(logPath, logFile);
+                }
+
+                var log = File.ReadAllText(logFile);
+                Assert.Contains("ID=VBCSCompiler ", log);
+                Assert.Contains("Keep alive timeout is: 1000 milliseconds.", log);
+            }
+
+            [Fact]
+            public void ExplicitLogFileOverridesEnvironment()
+            {
+                var directory = TempRoot.CreateDirectory();
+                var environmentLogPath = Path.Combine(directory.Path, "environment.log");
+                var explicitLogPath = Path.Combine(directory.Path, "explicit.log");
+
+                RunServerWithLogging(environmentLogPath, $@" -log:""{explicitLogPath}""");
+
+                Assert.False(File.Exists(environmentLogPath));
+                var log = File.ReadAllText(explicitLogPath);
+                Assert.Contains("ID=VBCSCompiler ", log);
+                Assert.Contains("Keep alive timeout is: 1000 milliseconds.", log);
+            }
+
+            private static void RunServerWithLogging(string environmentLogPath, string additionalArguments = "")
+            {
+                var filePath = typeof(VBCSCompiler).Assembly.Location;
+                var arguments = $"-pipename:{ServerUtil.GetPipeName()} -timeout:1{additionalArguments}";
+                if (BuildServerConnection.IsBuiltinToolRunningOnCoreClr)
+                {
+                    arguments = RuntimeHostInfo.GetDotNetExecCommandLine(filePath, arguments);
+                    filePath = RuntimeHostInfo.GetDotNetHostPath(StandardBuildEnvironment.Instance);
+                }
+
+                var result = ProcessUtilities.Run(filePath, arguments, additionalEnvironmentVars:
+                    new Dictionary<string, string>
+                    {
+                        [CompilerServerLogger.EnvironmentVariableName] = environmentLogPath,
+                    });
+                Assert.True(result.ExitCode == CommonCompiler.Succeeded, result.ToString());
+            }
+
             [ConditionalFact(typeof(WindowsOnly))]
             [WorkItem(217709, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/217709")]
             public async Task ShadowCopyAnalyzerAssemblyLoaderMissingDirectory()


### PR DESCRIPTION
Fixes a regression from https://github.com/dotnet/roslyn/pull/84701 - automatic compiler server logging to the file/directory specified by the env var `RoslynCommandLineLogFile` stopped working.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85193)