### PR TITLE
Fix simplifier's inconsistent removal of a type parameter cast

### DIFF
--- a/src/EditorFeatures/Test2/Simplification/CastSimplificationTests.vb
+++ b/src/EditorFeatures/Test2/Simplification/CastSimplificationTests.vb
@@ -1109,6 +1109,59 @@ class Program
             Await TestAsync(input, expected)
         End Function
 
+        <Theory>
+        <InlineData("ISomeInterface", "((T)value)")>
+        <InlineData("struct, ISomeInterface", "((T)value)")>
+        <InlineData("class, ISomeInterface", "(value)")>
+        <InlineData("BaseClass, ISomeInterface", "(value)")>
+        Public Async Function TestCSharp_IdentityCastToTypeParameter(constraint As String, expectedReceiver As String) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+interface ISomeInterface
+{
+    void Mutate();
+}
+
+class BaseClass
+{
+}
+
+class C
+{
+    void M&lt;T&gt;(T value) where T : <%= constraint %>
+    {
+        ({|Simplify:(T)value|}).Mutate();
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code>
+interface ISomeInterface
+{
+    void Mutate();
+}
+
+class BaseClass
+{
+}
+
+class C
+{
+    void M&lt;T&gt;(T value) where T : <%= constraint %>
+    {
+        <%= expectedReceiver %>.Mutate();
+    }
+}
+</code>
+
+            Await TestAsync(input, expected)
+        End Function
+
         <Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529914")>
         Public Async Function TestCSharp_Remove_TypeParameterToEffectiveBaseType() As Task
             Dim input =

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Simplification/Simplifiers/CastSimplifier.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Simplification/Simplifiers/CastSimplifier.cs
@@ -736,8 +736,8 @@ internal static class CastSimplifier
         if (castType.IsSpecialType())
             return false;
 
-        // if it's not a struct, then we're not making a copy and can safely remove the cast.
-        if (!castType.IsStructType())
+        // if it's a reference type, then we're not making a copy and can safely remove the cast.
+        if (castType.IsReferenceType)
             return false;
 
         // if the struct is readonly, then we can safely remove the cast as it's not mutable.

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Simplification/Simplifiers/CastSimplifier.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Simplification/Simplifiers/CastSimplifier.cs
@@ -442,9 +442,9 @@ internal static class CastSimplifier
         if (IsIdentityFloatingPointCastThatMustBePreserved(castNode, castedExpressionNode, originalSemanticModel, cancellationToken))
             return false;
 
-        // Identity struct casts will make a copy.  This copy may need to be kept to preserve semantics that only
-        // the copy is being manipulated and not the original struct.
-        if (IsIdentityStructCastThatMustBePreserved(castNode, castedExpressionNode, originalSemanticModel, cancellationToken))
+        // Identity casts will make a copy if the type is a mutable struct or is a type parameter that may be a struct.
+        // This copy may need to be kept to preserve semantics that only the copy is being manipulated and not the original struct.
+        if (IsIdentityCastThatCreatesACopy(castNode, castedExpressionNode, originalSemanticModel, cancellationToken))
             return false;
 
         #endregion blocked cases
@@ -710,17 +710,17 @@ internal static class CastSimplifier
         return true;
     }
 
-    private static bool IsIdentityStructCastThatMustBePreserved(
+    private static bool IsIdentityCastThatCreatesACopy(
         ExpressionSyntax castNode, ExpressionSyntax castedExpressionNode, SemanticModel semanticModel, CancellationToken cancellationToken)
     {
-        // Identity struct casts will make a copy.  This copy may need to be kept to preserve semantics that only
-        // the copy is being manipulated and not the original struct.
+        // Identity casts will make a copy if the type is a mutable struct or is a type parameter that may be a struct.
+        // This copy may need to be kept to preserve semantics that only the copy is being manipulated and not the original struct.
         //
-        // Note: this is an innacurate heuristic.  Generally speaking, practically any member accessed off of a
-        // struct might mutate it (like accessing .Length on an ImmutableArray).  But practically speaking that is
-        // highly unlikely to actually mutate.  To avoid many false negatives from allowing us to simplify pointless
-        // struct casts, we only look for a very narrow case that just rises up to be potentially problematic.
-        // Specifically, the invocation of a non-known method on a non-known struct type where neitehr the struct
+        // Note: this is an inaccurate heuristic.  Generally speaking, practically any member accessed off of a
+        // struct might mutate it (like accessing .Length on an ImmutableArray before the type was marked readonly).
+        // But practically speaking that is highly unlikely to actually mutate.  To avoid many false negatives from allowing us to
+        // simplify pointless struct casts, we only look for a very narrow case that just rises up to be potentially problematic.
+        // Specifically, the invocation of a non-known method on a non-known type that may be a struct where neither the type
         // nor method are readonly.
 
         var conversion = semanticModel.GetConversion(castedExpressionNode, cancellationToken);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Simplification/Simplifiers/CastSimplifier.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Simplification/Simplifiers/CastSimplifier.cs
@@ -442,7 +442,7 @@ internal static class CastSimplifier
         if (IsIdentityFloatingPointCastThatMustBePreserved(castNode, castedExpressionNode, originalSemanticModel, cancellationToken))
             return false;
 
-        // Identity casts will make a copy if the type is a mutable struct or is a type parameter that may be a struct.
+        // Identity casts will make a copy if the type is a struct or is a type parameter that may be a struct.
         // This copy may need to be kept to preserve semantics that only the copy is being manipulated and not the original struct.
         if (IsIdentityCastThatCreatesACopy(castNode, castedExpressionNode, originalSemanticModel, cancellationToken))
             return false;
@@ -713,7 +713,7 @@ internal static class CastSimplifier
     private static bool IsIdentityCastThatCreatesACopy(
         ExpressionSyntax castNode, ExpressionSyntax castedExpressionNode, SemanticModel semanticModel, CancellationToken cancellationToken)
     {
-        // Identity casts will make a copy if the type is a mutable struct or is a type parameter that may be a struct.
+        // Identity casts will make a copy if the type is a struct or is a type parameter that may be a struct.
         // This copy may need to be kept to preserve semantics that only the copy is being manipulated and not the original struct.
         //
         // Note: this is an inaccurate heuristic.  Generally speaking, practically any member accessed off of a


### PR DESCRIPTION
 Fixes https://github.com/dotnet/roslyn/issues/61922 when the struct in question is a type parameter. Followup to https://github.com/dotnet/roslyn/pull/66607.

The simplifier has been written so that it does not remove this cast (nor call it unnecessary in the IDE). The cast causes a copy to be made so that `f` is not mutated. Because `f` is not mutated, the cast can have observable effects on program behavior:
```cs
class C
{
    S f;
    void M() => ((S)f).Mutate();
}
struct S { public void Mutate() { } }
```

However, it messes up on type parameters:
```cs
class C<T> where T : I
{
    T f;
    void M() => ((T)f).Mutate();
}
interface I { void Mutate() { } }
```

All the same factors apply, but Roslyn simplifies the code to `((f)).Mutate()` which produces a materially different program when `T` is a struct type. This produces an incorrect nag in the IDE calling the cast unnecessary, which it very well may not be, and it forces code fixes to do special handling when generating explicit casts from `ITypeSymbol` in case the cast is simply removed by the simplifier when the fix is applied.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85201)