### PR TITLE
Include NuGet.config in Helix test payloads

### DIFF
--- a/src/Tools/RunTests/HelixTestRunner.cs
+++ b/src/Tools/RunTests/HelixTestRunner.cs
@@ -324,6 +324,9 @@ internal sealed class HelixTestRunner
             File.CreateSymbolicLink(
                 path: Path.Combine(workItemPayloadDir, "global.json"),
                 pathToTarget: Path.Combine(artifactsDir, "..", "global.json"));
+            File.CreateSymbolicLink(
+                path: Path.Combine(workItemPayloadDir, "NuGet.config"),
+                pathToTarget: Path.Combine(artifactsDir, "..", "NuGet.config"));
 
             var (commandFileName, commandContent) = GetHelixCommandContent(assemblyRelativeFilePaths, rspFileName, testOS);
             File.WriteAllText(Path.Combine(workItemPayloadDir, commandFileName), commandContent);


### PR DESCRIPTION
Fixes a hermeticity gap in Roslyn Helix test work items.

`PrepareTests` preserves the repository `NuGet.config`, but `HelixTestRunner` only included `eng` and `global.json` in each generated work-item payload. As a result, runtime NuGet clients such as `Microsoft.CodeAnalysis.Testing.ReferenceAssemblies` loaded the Helix machine defaults and attempted to resolve packages from nuget.org.

This change includes `NuGet.config` at every work-item root. The config clears inherited package sources and uses the approved feeds, including `dotnet-public`.

This addresses the `Microsoft.NETCore.App.Ref.10.0.1` failures observed in [build 1587731](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1587731) for #85107.

Validation:
- Built `src/Tools/RunTests/RunTests.csproj`
- Generated 27 local Helix work-item payloads and verified each contained `NuGet.config`
- Ran the exact failing `SkippedNamespace_MoreDerivedNamespace` test with fresh NuGet and temporary package caches; it resolved `Microsoft.NETCore.App.Ref.10.0.1` successfully
- Ran all `Microsoft.CodeAnalysis.PublicApiAnalyzers.UnitTests`: 317 passed
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85210)