### PR TITLE
Remove instructions causing unecessary updates to instructions files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -92,7 +92,6 @@ When starting any task or answering any question about this repo:
 ### Doc Update Obligation
 
 Every task that changes code must end with a doc pass:
-- Added or moved files? → Update `.github/memory/FILE_MAP.md` (top-level) and the matching `.github/instructions/<area>.instructions.md` (directory detail).
 - Changed a public interface, diagnostic ID, or API? → Update the relevant `.github/instructions/<area>.instructions.md` and `PublicAPI.Unshipped.txt`.
 - Hit something surprising or undocumented? → Ask the user how they want it documented.
 - Established a new pattern? → Repo-wide → `.github/memory/CONVENTIONS.md`; layer-specific → the matching `.github/instructions/<area>.instructions.md`.

--- a/.github/skills/update-agent-docs/SKILL.md
+++ b/.github/skills/update-agent-docs/SKILL.md
@@ -12,13 +12,11 @@ Run at the end of every task that changes code. This is not optional.
 
 ## Checklist
 
-**Files added or moved?** → Update `.github/memory/FILE_MAP.md` (top-level area) and the matching `.github/instructions/<area>.instructions.md` (directory detail).
-
 **Memory file added, removed, renamed, or had its purpose change?** → Update `.github/memory/INDEX.md` and any memory files that reference it.
 
-**Public API changed?** → Update the matching `.github/instructions/<area>.instructions.md` (Compiler/IDE) and the owning project's `PublicAPI.Unshipped.txt` (RS0016 enforces this). `API_MAP.md` covers only repo-wide entry points.
+**Public API changed?** → Update the owning project's `PublicAPI.Unshipped.txt` (RS0016 enforces this). `API_MAP.md` covers only repo-wide entry points.
 
-**New compiler error code, IDE diagnostic ID, or resource string added?** → Reflect it in the matching `.github/instructions/<area>.instructions.md`; ensure `ErrorCode.cs` / `IDEDiagnosticIds.cs` / `.resx` (+ `/t:UpdateXlf`) are consistent.
+**New compiler error code, IDE diagnostic ID, or resource string added?** → Ensure `ErrorCode.cs` / `IDEDiagnosticIds.cs` / `.resx` (+ `/t:UpdateXlf`) are consistent.
 
 **New pattern established?** → If repo-wide, add to `.github/memory/CONVENTIONS.md`; if layer-specific, add to the matching `.github/instructions/<area>.instructions.md`.
 


### PR DESCRIPTION
The instructions to update FILE_MAP on any file add/remove was making that quite noisy -- we don't need to record the addition of a single utilities class, for example. Also remove instructions to update area instructions on routine edits that are already tracked in other files.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85214)