### PR TITLE
Avoid cache misses due to cancellation in deprioritized analyzer cache

### DIFF
--- a/docs/ide/api-designs/Diagnostic Analysis.md
+++ b/docs/ide/api-designs/Diagnostic Analysis.md
@@ -356,9 +356,13 @@ To enhance lightbulb performance, expensive analyzers are deprioritized from `Co
 
 ```csharp
 // Cached per analyzer - assumed stable across compilations
-ConditionalWeakTable<DiagnosticAnalyzer, ImmutableHashSet<string>?> 
+ConditionalWeakTable<DiagnosticAnalyzer, AsyncLazy<ImmutableHashSet<string>?>>
     s_analyzerToDeprioritizedDiagnosticIds;
 ```
+
+Each lazy wraps a single non-cancelable computation task. Individual requests can cancel their waits without
+canceling or restarting the shared analyzer initialization. Successful results remain cached; if initialization
+faults, the matching cache entry is removed so a later request can retry with a fresh task.
 
 **Deprioritized analyzers:**
 - Register `SymbolStartAnalysisContext`/`SymbolEndAnalysisContext` actions

--- a/src/EditorFeatures/Test/CodeFixes/CodeFixServiceTests.cs
+++ b/src/EditorFeatures/Test/CodeFixes/CodeFixServiceTests.cs
@@ -956,6 +956,49 @@ public sealed class CodeFixServiceTests
     }
 #pragma warning restore RS0034 // Exported parts should be marked with 'ImportingConstructorAttribute'
 
+    [Fact, WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/3058983")]
+    public async Task TestDeprioritizationComputationCompletesAfterRequestCancellationAsync()
+    {
+        const string code = "class C { }";
+        var analyzer = new BlockingDeprioritizationAnalyzer();
+        var analyzerReference = new MockAnalyzerReference(fixer: null, [analyzer]);
+
+        using var workspace = ServiceSetup(new MockFixer(), code: code).workspace;
+        var sourceDocument = workspace.CurrentSolution.Projects.Single()
+            .AddAnalyzerReference(analyzerReference)
+            .Documents.Single();
+        var analyzerService = (DiagnosticAnalyzerService)workspace.Services.GetRequiredService<IDiagnosticAnalyzerService>();
+
+        using var cancellationTokenSource = new CancellationTokenSource();
+        try
+        {
+            var firstRequest = analyzerService.IsAnyDeprioritizedDiagnosticIdInProcessAsync(
+                sourceDocument.Project, [BlockingDeprioritizationAnalyzer.Descriptor.Id], cancellationTokenSource.Token);
+
+            var compilationStartEntered = analyzer.CompilationStartEntered;
+            Assert.Same(compilationStartEntered, await Task.WhenAny(compilationStartEntered, firstRequest));
+            cancellationTokenSource.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            {
+                await firstRequest;
+            });
+
+            var updatedDocument = sourceDocument.WithText(SourceText.From(code + Environment.NewLine));
+            analyzer.ReleaseCompilationStart();
+
+            var isDeprioritized = await analyzerService.IsAnyDeprioritizedDiagnosticIdInProcessAsync(
+                updatedDocument.Project, [BlockingDeprioritizationAnalyzer.Descriptor.Id], CancellationToken.None);
+
+            Assert.True(isDeprioritized);
+            Assert.Equal(1, analyzer.CompilationStartCount);
+        }
+        finally
+        {
+            analyzer.ReleaseCompilationStart();
+        }
+    }
+
     [Theory, CombinatorialData]
     public async Task TestGetFixesWithDeprioritizedAnalyzerAsync(
         DeprioritizedAnalyzer.ActionKind actionKind,
@@ -1135,6 +1178,36 @@ public sealed class CodeFixServiceTests
                 Assert.Equal(testSpan, diagnostic.DataLocation.UnmappedFileSpan.GetClampedTextSpan(text));
             }
         }
+    }
+
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    private sealed class BlockingDeprioritizationAnalyzer : DiagnosticAnalyzer
+    {
+        public static readonly DiagnosticDescriptor Descriptor = new(
+            "ID0002", "Title", "Message", "Category", DiagnosticSeverity.Warning, isEnabledByDefault: true);
+
+        private readonly TaskCompletionSource<bool> _compilationStartEntered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly ManualResetEventSlim _continueCompilationStart = new();
+        private int _compilationStartCount;
+
+        public Task CompilationStartEntered => _compilationStartEntered.Task;
+        public int CompilationStartCount => Volatile.Read(ref _compilationStartCount);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Descriptor];
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.RegisterCompilationStartAction(context =>
+            {
+                Interlocked.Increment(ref _compilationStartCount);
+                _compilationStartEntered.TrySetResult(true);
+                _continueCompilationStart.Wait(context.CancellationToken);
+                context.RegisterSemanticModelAction(_ => { });
+            });
+        }
+
+        public void ReleaseCompilationStart()
+            => _continueCompilationStart.Set();
     }
 
     [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/src/Features/Core/Portable/Diagnostics/Service/DiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/Service/DiagnosticAnalyzerService.cs
@@ -149,7 +149,7 @@ internal sealed partial class DiagnosticAnalyzerService
 
             foreach (var analyzer in service.GetProjectAnalyzers_OnlyCallInProcess(project))
             {
-                var set = GetCachedDeprioritizedDiagnosticIds(analyzer);
+                var set = await GetCachedDeprioritizedDiagnosticIdsAsync(analyzer, CancellationToken.None).ConfigureAwait(false);
                 if (set != null)
                     builder.UnionWith(set);
             }

--- a/src/Features/Core/Portable/Diagnostics/Service/DiagnosticAnalyzerService.cs
+++ b/src/Features/Core/Portable/Diagnostics/Service/DiagnosticAnalyzerService.cs
@@ -149,7 +149,7 @@ internal sealed partial class DiagnosticAnalyzerService
 
             foreach (var analyzer in service.GetProjectAnalyzers_OnlyCallInProcess(project))
             {
-                Contract.ThrowIfFalse(DiagnosticAnalyzerService.s_analyzerToDeprioritizedDiagnosticIds.TryGetValue(analyzer, out var set));
+                var set = GetCachedDeprioritizedDiagnosticIds(analyzer);
                 if (set != null)
                     builder.UnionWith(set);
             }

--- a/src/Features/Core/Portable/Diagnostics/Service/DiagnosticAnalyzerService_DeprioritizationCandidates.cs
+++ b/src/Features/Core/Portable/Diagnostics/Service/DiagnosticAnalyzerService_DeprioritizationCandidates.cs
@@ -65,20 +65,23 @@ internal sealed partial class DiagnosticAnalyzerService
                     // Follow the pattern in SolutionCompilationState.GeneratorDriverInitializationCache: AsyncLazy
                     // cancels its computation when all requesters cancel, so keep one non-cancelable requester alive
                     // to prevent repeated edits from repeatedly starting and canceling this initialization.
-                    var keepAliveTask = Task.Run(() => createdLazy.GetValueAsync(CancellationToken.None));
-                    _ = keepAliveTask.ReportNonFatalErrorAsync();
-                    _ = keepAliveTask.ContinueWith(
-                        _ =>
+                    _ = Task.Run(async () =>
+                    {
+                        try
                         {
+                            await createdLazy.GetValueAsync(CancellationToken.None).ConfigureAwait(false);
+                        }
+                        catch (Exception ex) when (FatalError.ReportAndCatch(ex))
+                        {
+                            // Removing the failed lazy allows a later lookup to retry. Callers that already requested
+                            // its value will still observe this exception.
                             if (s_analyzerToDeprioritizedDiagnosticIds.TryGetValue(analyzer, out var currentLazy) &&
                                 ReferenceEquals(currentLazy, createdLazy))
                             {
                                 s_analyzerToDeprioritizedDiagnosticIds.Remove(analyzer);
                             }
-                        },
-                        CancellationToken.None,
-                        TaskContinuationOptions.NotOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously,
-                        TaskScheduler.Default);
+                        }
+                    }, CancellationToken.None);
                 }
             }
 

--- a/src/Features/Core/Portable/Diagnostics/Service/DiagnosticAnalyzerService_DeprioritizationCandidates.cs
+++ b/src/Features/Core/Portable/Diagnostics/Service/DiagnosticAnalyzerService_DeprioritizationCandidates.cs
@@ -24,6 +24,8 @@ internal sealed partial class DiagnosticAnalyzerService
     /// like appearing in a different language's compilation, or a compilation with different references, etc.
     /// We accept that this cache may be inaccurate in such scenarios as they are likely rare, and this only
     /// serves as a simple heuristic to order analyzer execution.  If wrong, it's not a major deal.
+    /// Each AsyncLazy wraps a single non-cancelable computation task, so request cancellation only cancels that
+    /// request's wait and cannot restart the analyzer initialization.
     /// </summary>
     private static readonly ConditionalWeakTable<DiagnosticAnalyzer, AsyncLazy<ImmutableHashSet<string>?>> s_analyzerToDeprioritizedDiagnosticIds = new();
 
@@ -56,32 +58,30 @@ internal sealed partial class DiagnosticAnalyzerService
                         project, analyzers, GetOrCreateHostAnalyzerInfo_OnlyCallInProcess(project), this.CrashOnAnalyzerException, cancellationToken).ConfigureAwait(false);
                 }
 
-                var createdLazy = AsyncLazy.Create(
-                    cancellationToken => ComputeDeprioritizedDiagnosticIdsAsync(analyzer, cancellationToken));
+                // Concurrent cache misses can create multiple candidate lazies. Defer Task.Run so candidates that
+                // lose the ConditionalWeakTable race do not start duplicate analyzer work.
+                var computationTaskGate = new object();
+                Task<ImmutableHashSet<string>?>? computationTask = null;
+                var createdLazy = AsyncLazy.Create(_ =>
+                {
+                    lock (computationTaskGate)
+                    {
+                        // AsyncLazy can invoke its delegate again after all of its requesters cancel, even if the
+                        // previous computation ignored cancellation and is still running. Always return the same
+                        // one-shot task so cancellation cannot start duplicate analyzer work.
+                        return computationTask ??= Task.Run(
+                            () => ComputeDeprioritizedDiagnosticIdsAsync(analyzer, CancellationToken.None),
+                            CancellationToken.None);
+                    }
+                });
                 lazyDeprioritizedIds = s_analyzerToDeprioritizedDiagnosticIds.GetValue(analyzer, _ => createdLazy);
 
                 if (ReferenceEquals(lazyDeprioritizedIds, createdLazy))
                 {
-                    // Follow the pattern in SolutionCompilationState.GeneratorDriverInitializationCache: AsyncLazy
-                    // cancels its computation when all requesters cancel, so keep one non-cancelable requester alive
-                    // to prevent repeated edits from repeatedly starting and canceling this initialization.
-                    _ = Task.Run(async () =>
-                    {
-                        try
-                        {
-                            await createdLazy.GetValueAsync(CancellationToken.None).ConfigureAwait(false);
-                        }
-                        catch (Exception ex) when (FatalError.ReportAndCatch(ex))
-                        {
-                            // Removing the failed lazy allows a later lookup to retry. Callers that already requested
-                            // its value will still observe this exception.
-                            if (s_analyzerToDeprioritizedDiagnosticIds.TryGetValue(analyzer, out var currentLazy) &&
-                                ReferenceEquals(currentLazy, createdLazy))
-                            {
-                                s_analyzerToDeprioritizedDiagnosticIds.Remove(analyzer);
-                            }
-                        }
-                    }, CancellationToken.None);
+                    // AsyncLazy gives each caller an independently cancelable wait. The shared task itself is
+                    // non-cancelable, so all callers can cancel without discarding and restarting its work.
+                    var keepAliveTask = createdLazy.GetValueAsync(CancellationToken.None);
+                    _ = ObserveKeepAliveTaskAsync(analyzer, createdLazy, keepAliveTask);
                 }
             }
 
@@ -122,14 +122,35 @@ internal sealed partial class DiagnosticAnalyzerService
         }
     }
 
+    private static async Task ObserveKeepAliveTaskAsync(
+        DiagnosticAnalyzer analyzer,
+        AsyncLazy<ImmutableHashSet<string>?> createdLazy,
+        Task<ImmutableHashSet<string>?> keepAliveTask)
+    {
+        try
+        {
+            await keepAliveTask.ConfigureAwait(false);
+        }
+        catch (Exception ex) when (FatalError.ReportAndCatch(ex))
+        {
+            // Every request through createdLazy resolves to this same one-shot task. Existing callers still observe
+            // this exception, but a stale reference cannot start a retry. Removing the matching cache entry allows
+            // a later lookup to create a fresh task instead.
+            if (s_analyzerToDeprioritizedDiagnosticIds.TryGetValue(analyzer, out var currentLazy) &&
+                ReferenceEquals(currentLazy, createdLazy))
+            {
+                s_analyzerToDeprioritizedDiagnosticIds.Remove(analyzer);
+            }
+        }
+    }
+
     private static async Task<ImmutableHashSet<string>?> GetCachedDeprioritizedDiagnosticIdsAsync(
         DiagnosticAnalyzer analyzer, CancellationToken cancellationToken)
     {
         Contract.ThrowIfFalse(s_analyzerToDeprioritizedDiagnosticIds.TryGetValue(analyzer, out var lazy));
 
-        // A caller that joins before this computation faults will observe the same exception. AsyncLazy does not
-        // cache failures, so a caller arriving after the fault but before the cache entry is removed can retry
-        // the computation through this same lazy.
+        // AsyncLazy only coordinates each caller's cancellation. Its delegate returns the same one-shot task even
+        // after a fault, so this await cannot start another computation through a stale cache entry.
         return await lazy.GetValueAsync(cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Features/Core/Portable/Diagnostics/Service/DiagnosticAnalyzerService_DeprioritizationCandidates.cs
+++ b/src/Features/Core/Portable/Diagnostics/Service/DiagnosticAnalyzerService_DeprioritizationCandidates.cs
@@ -8,7 +8,9 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Diagnostics;
 
@@ -23,17 +25,14 @@ internal sealed partial class DiagnosticAnalyzerService
     /// We accept that this cache may be inaccurate in such scenarios as they are likely rare, and this only
     /// serves as a simple heuristic to order analyzer execution.  If wrong, it's not a major deal.
     /// </summary>
-    private static readonly ConditionalWeakTable<DiagnosticAnalyzer, ImmutableHashSet<string>?> s_analyzerToDeprioritizedDiagnosticIds = new();
+    private static readonly ConditionalWeakTable<DiagnosticAnalyzer, AsyncLazy<ImmutableHashSet<string>?>> s_analyzerToDeprioritizedDiagnosticIds = new();
 
     private async Task<bool> IsDeprioritizedAnalyzerAsync(
         Project project, DiagnosticAnalyzer analyzer, CancellationToken cancellationToken)
     {
         await PopulateDeprioritizedDiagnosticIdMapAsync(project, cancellationToken).ConfigureAwait(false);
 
-        // this can't fail as the above call populates the CWT entries for all analyzers within that project if missing.
-        Contract.ThrowIfFalse(s_analyzerToDeprioritizedDiagnosticIds.TryGetValue(analyzer, out var set));
-
-        return set != null;
+        return GetCachedDeprioritizedDiagnosticIds(analyzer) != null;
     }
 
     private async ValueTask PopulateDeprioritizedDiagnosticIdMapAsync(Project project, CancellationToken cancellationToken)
@@ -49,7 +48,7 @@ internal sealed partial class DiagnosticAnalyzerService
         var analyzers = GetProjectAnalyzers_OnlyCallInProcess(project);
         foreach (var analyzer in analyzers)
         {
-            if (!s_analyzerToDeprioritizedDiagnosticIds.TryGetValue(analyzer, out var deprioritizedIds))
+            if (!s_analyzerToDeprioritizedDiagnosticIds.TryGetValue(analyzer, out var lazyDeprioritizedIds))
             {
                 if (compilationWithAnalyzers is null)
                 {
@@ -57,20 +56,33 @@ internal sealed partial class DiagnosticAnalyzerService
                         project, analyzers, GetOrCreateHostAnalyzerInfo_OnlyCallInProcess(project), this.CrashOnAnalyzerException, cancellationToken).ConfigureAwait(false);
                 }
 
-                deprioritizedIds = await ComputeDeprioritizedDiagnosticIdsAsync(analyzer).ConfigureAwait(false);
+                var createdLazy = AsyncLazy.Create(
+                    cancellationToken => ComputeDeprioritizedDiagnosticIdsAsync(analyzer, cancellationToken));
+                lazyDeprioritizedIds = s_analyzerToDeprioritizedDiagnosticIds.GetValue(analyzer, _ => createdLazy);
 
-#if NET
-                s_analyzerToDeprioritizedDiagnosticIds.TryAdd(analyzer, deprioritizedIds);
-#else
-                lock (s_analyzerToDeprioritizedDiagnosticIds)
+                if (ReferenceEquals(lazyDeprioritizedIds, createdLazy))
                 {
-                    if (!s_analyzerToDeprioritizedDiagnosticIds.TryGetValue(analyzer, out var existing))
-                        s_analyzerToDeprioritizedDiagnosticIds.Add(analyzer, deprioritizedIds);
+                    // Follow the pattern in SolutionCompilationState.GeneratorDriverInitializationCache: AsyncLazy
+                    // cancels its computation when all requesters cancel, so keep one non-cancelable requester alive
+                    // to prevent repeated edits from repeatedly starting and canceling this initialization.
+                    var keepAliveTask = Task.Run(() => createdLazy.GetValueAsync(CancellationToken.None));
+                    _ = keepAliveTask.ReportNonFatalErrorAsync();
+                    _ = keepAliveTask.ContinueWith(
+                        _ =>
+                        {
+                            if (s_analyzerToDeprioritizedDiagnosticIds.TryGetValue(analyzer, out var currentLazy) &&
+                                ReferenceEquals(currentLazy, createdLazy))
+                            {
+                                s_analyzerToDeprioritizedDiagnosticIds.Remove(analyzer);
+                            }
+                        },
+                        CancellationToken.None,
+                        TaskContinuationOptions.NotOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously,
+                        TaskScheduler.Default);
                 }
-#endif
-
             }
 
+            var deprioritizedIds = await lazyDeprioritizedIds.GetValueAsync(cancellationToken).ConfigureAwait(false);
             if (deprioritizedIds != null)
             {
                 foreach (var id in diagnosticIds)
@@ -83,7 +95,8 @@ internal sealed partial class DiagnosticAnalyzerService
 
         return false;
 
-        async ValueTask<ImmutableHashSet<string>?> ComputeDeprioritizedDiagnosticIdsAsync(DiagnosticAnalyzer analyzer)
+        async Task<ImmutableHashSet<string>?> ComputeDeprioritizedDiagnosticIdsAsync(
+            DiagnosticAnalyzer analyzer, CancellationToken cancellationToken)
         {
             // We deprioritize SymbolStart/End and SemanticModel analyzers from 'Normal' to 'Low' priority bucket,
             // as these are computationally more expensive.
@@ -104,5 +117,12 @@ internal sealed partial class DiagnosticAnalyzerService
 
             return [.. analyzer.SupportedDiagnostics.Select(d => d.Id)];
         }
+    }
+
+    private static ImmutableHashSet<string>? GetCachedDeprioritizedDiagnosticIds(DiagnosticAnalyzer analyzer)
+    {
+        Contract.ThrowIfFalse(s_analyzerToDeprioritizedDiagnosticIds.TryGetValue(analyzer, out var lazy));
+        Contract.ThrowIfFalse(lazy.TryGetValue(out var deprioritizedIds));
+        return deprioritizedIds;
     }
 }

--- a/src/Features/Core/Portable/Diagnostics/Service/DiagnosticAnalyzerService_DeprioritizationCandidates.cs
+++ b/src/Features/Core/Portable/Diagnostics/Service/DiagnosticAnalyzerService_DeprioritizationCandidates.cs
@@ -32,7 +32,7 @@ internal sealed partial class DiagnosticAnalyzerService
     {
         await PopulateDeprioritizedDiagnosticIdMapAsync(project, cancellationToken).ConfigureAwait(false);
 
-        return GetCachedDeprioritizedDiagnosticIds(analyzer) != null;
+        return await GetCachedDeprioritizedDiagnosticIdsAsync(analyzer, cancellationToken).ConfigureAwait(false) != null;
     }
 
     private async ValueTask PopulateDeprioritizedDiagnosticIdMapAsync(Project project, CancellationToken cancellationToken)
@@ -122,10 +122,14 @@ internal sealed partial class DiagnosticAnalyzerService
         }
     }
 
-    private static ImmutableHashSet<string>? GetCachedDeprioritizedDiagnosticIds(DiagnosticAnalyzer analyzer)
+    private static async Task<ImmutableHashSet<string>?> GetCachedDeprioritizedDiagnosticIdsAsync(
+        DiagnosticAnalyzer analyzer, CancellationToken cancellationToken)
     {
         Contract.ThrowIfFalse(s_analyzerToDeprioritizedDiagnosticIds.TryGetValue(analyzer, out var lazy));
-        Contract.ThrowIfFalse(lazy.TryGetValue(out var deprioritizedIds));
-        return deprioritizedIds;
+
+        // A caller that joins before this computation faults will observe the same exception. AsyncLazy does not
+        // cache failures, so a caller arriving after the fault but before the cache entry is removed can retry
+        // the computation through this same lazy.
+        return await lazy.GetValueAsync(cancellationToken).ConfigureAwait(false);
     }
 }


### PR DESCRIPTION
Attempt at a fix for https://devdiv.visualstudio.com/DevDiv/_workitems/edit/3058983/?view=edit

Repeated cancellation (ie, edits) would cause work to kick off repeatedly, as the cache would only store Ids once they were computed. This steals the approach in the generator driver to cache an async lazy so that in progress work is still cached, meaning repeated edits aren't a problem.

The test failed initially (2 compilation start actions were kicked off) so the fix definitely works, but only RPS (and probably only against .NET 11) will prove if the regression is fixed.

FYI @marcpopMSFT 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85222)