### PR TITLE
Classify parameter discards earlier, syntactically instead of semantically, resolving classification conflict

### DIFF
--- a/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
@@ -3330,9 +3330,7 @@ public sealed partial class SemanticClassifierTests : AbstractCSharpClassifierTe
             """,
             testHost,
             Namespace("System"),
-            Delegate("Func"),
-            Keyword("_"),
-            Keyword("_"));
+            Delegate("Func"));
 
     [Theory, CombinatorialData]
     public Task DiscardsInLambdaWithInferredType(TestHost testHost)
@@ -3347,9 +3345,7 @@ public sealed partial class SemanticClassifierTests : AbstractCSharpClassifierTe
             """,
             testHost,
             Namespace("System"),
-            Delegate("Func"),
-            Keyword("_"),
-            Keyword("_"));
+            Delegate("Func"));
 
     [Theory, CombinatorialData]
     public Task NativeInteger(TestHost testHost)

--- a/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
@@ -3287,67 +3287,6 @@ public sealed partial class SemanticClassifierTests : AbstractCSharpClassifierTe
             Keyword("_"));
 
     [Theory, CombinatorialData]
-    public Task UnusedUnderscoreParameterInLambda(TestHost testHost)
-        => TestAsync("""
-            class X
-            {
-                void N()
-                {
-                    System.Func<int, int> a = (int _) => 0;
-                }
-            }
-            """,
-            testHost,
-            Namespace("System"),
-            Delegate("Func"));
-
-    [Theory, CombinatorialData]
-    public Task UsedUnderscoreParameterInLambda(TestHost testHost)
-        => TestAsync("""
-            class X
-            {
-                void N()
-                {
-                    System.Func<int, int> a = (int _) => _;
-                }
-            }
-            """,
-            testHost,
-            Namespace("System"),
-            Delegate("Func"),
-            Parameter("_"));
-
-    [Theory, CombinatorialData]
-    public Task DiscardsInLambda(TestHost testHost)
-        => TestAsync("""
-            class X
-            {
-                void N()
-                {
-                    System.Func<int, int, int> a = (int _, int _) => 0;
-                }
-            }
-            """,
-            testHost,
-            Namespace("System"),
-            Delegate("Func"));
-
-    [Theory, CombinatorialData]
-    public Task DiscardsInLambdaWithInferredType(TestHost testHost)
-        => TestAsync("""
-            class X
-            {
-                void N()
-                {
-                    System.Func<int, int, int> a = (_, _) => 0;
-                }
-            }
-            """,
-            testHost,
-            Namespace("System"),
-            Delegate("Func"));
-
-    [Theory, CombinatorialData]
     public Task NativeInteger(TestHost testHost)
         => TestInMethodAsync(
             @"nint i = 0; nuint i2 = 0;",

--- a/src/EditorFeatures/CSharpTest/Classification/SyntacticClassifierTests_Preprocessor.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SyntacticClassifierTests_Preprocessor.cs
@@ -1102,7 +1102,7 @@ expected: Classifications(Identifier("x"), Operators.Equals, Punctuation.OpenPar
         => TestInMethodAsync(
             code: @"x = (_, _) => 1;",
             testHost: testHost,
-expected: Classifications(Identifier("x"), Operators.Equals, Punctuation.OpenParen, Parameter("_"), Punctuation.Comma, Parameter("_"), Punctuation.CloseParen,
+expected: Classifications(Identifier("x"), Operators.Equals, Punctuation.OpenParen, Keyword("_"), Punctuation.Comma, Keyword("_"), Punctuation.CloseParen,
                 Operators.EqualsGreaterThan, Number("1"), Punctuation.Semicolon));
 
     [Theory, CombinatorialData]

--- a/src/EditorFeatures/CSharpTest/Classification/TotalClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/TotalClassifierTests.cs
@@ -2942,6 +2942,45 @@ Punctuation.CloseCurly);
         ], actualFormatted);
     }
 
+    [WpfTheory]
+    [InlineData("System.Action<int, int> lambda = (_, p) => { };", false)]
+    [InlineData("System.Action<int, int> lambda = (int _, int p) => { };", false)]
+    [InlineData("System.Action<int, int, int> lambda = (_, _, p) => { };", true)]
+    [InlineData("System.Action<int, int, int> lambda = (int _, int _, int p) => { };", true)]
+    public async Task TestTotalClassifier_LambdaDiscards(string declaration, bool isDiscard)
+    {
+        using var workspace = EditorTestWorkspace.CreateCSharp($$"""
+            class C
+            {
+                void M()
+                {
+                    {{declaration}}
+                }
+            }
+            """);
+        var document = workspace.Documents.First();
+        var provider = new TotalClassificationTaggerProvider(
+            workspace.GetService<TaggerHost>(),
+            workspace.GetService<ClassificationTypeMap>());
+
+        var buffer = document.GetTextBuffer();
+        using var tagger = provider.CreateTagger(document.GetTextView(), buffer);
+
+        var listenerProvider = workspace.ExportProvider.GetExportedValue<IAsynchronousOperationListenerProvider>();
+        await listenerProvider.GetWaiter(FeatureAttribute.Classification).ExpeditedWaitAsync();
+
+        var tags = tagger!.GetTags(new NormalizedSnapshotSpanCollection(buffer.CurrentSnapshot.GetFullSpan()));
+        var actual = tags.OrderBy(tag => tag.Span.Start.Position)
+            .Where(tag => tag.Span.GetText() is "_" or "p")
+            .Select(tag => new FormattedClassification(tag.Span.GetText(), tag.Tag.ClassificationType.Classification));
+
+        AssertEx.Equal<FormattedClassification>(
+            isDiscard
+                ? [Keyword("_"), Keyword("_"), Parameter("p")]
+                : [Parameter("_"), Parameter("p")],
+            actual);
+    }
+
     [WpfFact]
     public void TestCopyPasteClassifier()
     {

--- a/src/Workspaces/CSharp/Portable/Classification/ClassificationHelpers.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/ClassificationHelpers.cs
@@ -256,6 +256,17 @@ internal static class ClassificationHelpers
         }
         else if (token.Parent is ParameterSyntax parameterSyntax && parameterSyntax.Identifier == token)
         {
+            if (token.Text == "_" && parameterSyntax.Parent is ParameterListSyntax { Parent: AnonymousFunctionExpressionSyntax } parameterList)
+            {
+                foreach (var otherParameter in parameterList.Parameters)
+                {
+                    if (otherParameter != parameterSyntax && otherParameter.Identifier.Text == "_")
+                    {
+                        return ClassificationTypeNames.Keyword;
+                    }
+                }
+            }
+
             return ClassificationTypeNames.ParameterName;
         }
         else if (token.Parent is ForEachStatementSyntax forEachStatementSyntax && forEachStatementSyntax.Identifier == token)

--- a/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/DiscardSyntaxClassifier.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/DiscardSyntaxClassifier.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification.Classifiers;
 
 internal sealed class DiscardSyntaxClassifier : AbstractSyntaxClassifier
 {
-    public override ImmutableArray<Type> SyntaxNodeTypes { get; } = [typeof(DiscardDesignationSyntax), typeof(DiscardPatternSyntax), typeof(ParameterSyntax), typeof(IdentifierNameSyntax)];
+    public override ImmutableArray<Type> SyntaxNodeTypes { get; } = [typeof(DiscardDesignationSyntax), typeof(DiscardPatternSyntax), typeof(IdentifierNameSyntax)];
 
     public override void AddClassifications(
        SyntaxNode syntax,
@@ -33,16 +33,6 @@ internal sealed class DiscardSyntaxClassifier : AbstractSyntaxClassifier
 
         switch (syntax)
         {
-            case ParameterSyntax parameter when parameter.Identifier.Text == "_":
-                var symbol = semanticModel.GetDeclaredSymbol(parameter, cancellationToken);
-
-                if (symbol?.IsDiscard == true)
-                {
-                    result.Add(new ClassifiedSpan(parameter.Identifier.Span, ClassificationTypeNames.Keyword));
-                }
-
-                break;
-
             case IdentifierNameSyntax identifierName when identifierName.Identifier.Text == "_":
                 var symbolInfo = semanticModel.GetSymbolInfo(identifierName, cancellationToken);
 


### PR DESCRIPTION
Fixes #51553.

Roslyn classifies discards as keywords for syntax highlighting which shows whether or not `_` is referring to a symbol.

<img width="329" height="230" alt="image" src="https://github.com/user-attachments/assets/3364de33-039c-451a-94e5-25cc2f091731" />

However, it's not working for lambda parameter discards:
<img width="394" height="49" alt="image" src="https://github.com/user-attachments/assets/60c81709-2e7d-45ce-9821-f3830cea834a" />

There was an attempt to implement it in https://github.com/dotnet/roslyn/pull/40396 for lambda parameter discards:
https://github.com/dotnet/roslyn/blob/6de0973c513f7d3940cc0b52ff7cd7d55b869982/src/Workspaces/CSharp/Portable/Classification/SyntaxClassification/DiscardSyntaxClassifier.cs#L36-L44

But this was insufficient because it was implemented in the semantic classifier. The syntactic classifier already classified it as ParameterName, and the two are merged with ordering rules which cause ParameterName to win over Keyword.
https://github.com/dotnet/roslyn/blob/6de0973c513f7d3940cc0b52ff7cd7d55b869982/src/EditorFeatures/Core/Classification/ClassificationTypeFormatDefinitions.cs#L520-L523

This PR fixes the issue by implementing the proper classification in the syntactic classifier instead of the semantic classifier. This is preferable because the semantic classifier may run after more of a delay, so this is less visual flicker in the IDE.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85225)