### PR TITLE
Reduce source file metadata I/O

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/FileUtilitiesTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/FileUtilitiesTests.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
@@ -107,6 +108,38 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal(@"C:\x/y\./goo", PathUtilities.CombineAbsoluteAndRelativePaths(@"C:\x/y", @"./goo"));
             Assert.Equal(@"C:\x/y\..\goo", PathUtilities.CombineAbsoluteAndRelativePaths(@"C:\x/y", @"..\goo"));
             Assert.Equal(@"C:\x/y\../goo", PathUtilities.CombineAbsoluteAndRelativePaths(@"C:\x/y", @"../goo"));
+        }
+
+        [ConditionalFact(typeof(WindowsOnly))]
+        public void GetFileLengthAndTimeStampFromOpenFile()
+        {
+            using var root = new TempRoot();
+            var file = root.CreateFile().WriteAllText("hello");
+            using var stream = new FileStream(file.Path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+
+            FileUtilities.GetFileLengthAndTimeStamp(stream.SafeFileHandle, out var fileLength, out var timeStamp);
+
+            Assert.Equal(stream.Length, fileLength);
+            Assert.Equal(File.GetLastWriteTimeUtc(file.Path), timeStamp);
+        }
+
+        [ConditionalFact(typeof(WindowsOnly))]
+        public void GetFileLengthAndTimeStampFromOpenFileUsesHandle()
+        {
+            using var root = new TempRoot();
+            var file = root.CreateFile().WriteAllText("original");
+            var originalTimeStamp = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            File.SetLastWriteTimeUtc(file.Path, originalTimeStamp);
+
+            using var stream = new FileStream(file.Path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+            File.Move(file.Path, file.Path + ".moved");
+            File.WriteAllText(file.Path, "replacement");
+            File.SetLastWriteTimeUtc(file.Path, originalTimeStamp.AddDays(1));
+
+            FileUtilities.GetFileLengthAndTimeStamp(stream.SafeFileHandle, out var fileLength, out var timeStamp);
+
+            Assert.Equal("original".Length, fileLength);
+            Assert.Equal(originalTimeStamp, timeStamp);
         }
 
         [ConditionalFact(typeof(WindowsOnly))]

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/ShadowCopyAnalyzerPathResolver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/ShadowCopyAnalyzerPathResolver.cs
@@ -507,7 +507,7 @@ namespace Microsoft.CodeAnalysis
         }
 
         /// <summary>Get number of hard links to a file.</summary>
-        private static ByHandleFileInformation? TryGetWindowsFileInformation(string path)
+        private static FileUtilities.WindowsFileInformation? TryGetWindowsFileInformation(string path)
         {
             // https://learn.microsoft.com/en-us/windows/win32/fileio/file-access-rights-constants
             const uint FILE_READ_ATTRIBUTES = 0x0080;
@@ -527,7 +527,7 @@ namespace Microsoft.CodeAnalysis
                 dwFlagsAndAttributes: 0,
                 hTemplateFile: IntPtr.Zero);
 
-            if (!GetFileInformationByHandle(handle, out var fileInformation))
+            if (!FileUtilities.TryGetFileInformationByHandle(handle, out var fileInformation))
                 return null;
 
             return fileInformation;
@@ -543,24 +543,6 @@ namespace Microsoft.CodeAnalysis
                 uint dwFlagsAndAttributes,
                 IntPtr hTemplateFile);
 
-            // https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getfileinformationbyhandle
-            [DllImport("Kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-            static extern bool GetFileInformationByHandle(SafeFileHandle handle, out ByHandleFileInformation fileInformation);
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        private struct ByHandleFileInformation
-        {
-            public uint FileAttributes;
-            public System.Runtime.InteropServices.ComTypes.FILETIME CreationTime;
-            public System.Runtime.InteropServices.ComTypes.FILETIME LastAccessTime;
-            public System.Runtime.InteropServices.ComTypes.FILETIME LastWriteTime;
-            public uint VolumeSerialNumber;
-            public uint FileSizeHigh;
-            public uint FileSizeLow;
-            public uint NumberOfLinks;
-            public uint FileIndexHigh;
-            public uint FileIndexLow;
         }
     }
 }

--- a/src/Compilers/Core/Portable/FileSystem/FileUtilities.cs
+++ b/src/Compilers/Core/Portable/FileSystem/FileUtilities.cs
@@ -454,5 +454,50 @@ namespace Roslyn.Utilities
                 throw new IOException(e.Message, e);
             }
         }
+
+        /// <exception cref="IOException"/>
+        internal static void GetFileLengthAndTimeStamp(SafeFileHandle handle, out long fileLength, out DateTime timeStamp)
+        {
+            Debug.Assert(PlatformInformation.IsWindows);
+            try
+            {
+                if (!TryGetFileInformationByHandle(handle, out var fileInformation))
+                    Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
+
+                fileLength = ((long)fileInformation.FileSizeHigh << 32) | fileInformation.FileSizeLow;
+                var lastWriteTime = ((long)(uint)fileInformation.LastWriteTime.dwHighDateTime << 32) |
+                    (uint)fileInformation.LastWriteTime.dwLowDateTime;
+                timeStamp = DateTime.FromFileTimeUtc(lastWriteTime);
+            }
+            catch (IOException)
+            {
+                throw;
+            }
+            catch (Exception e)
+            {
+                throw new IOException(e.Message, e);
+            }
+        }
+
+        internal static bool TryGetFileInformationByHandle(SafeFileHandle handle, out WindowsFileInformation fileInformation)
+            => GetFileInformationByHandle(handle, out fileInformation);
+
+        [DllImport("Kernel32.dll", SetLastError = true)]
+        private static extern bool GetFileInformationByHandle(SafeFileHandle handle, out WindowsFileInformation fileInformation);
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct WindowsFileInformation
+        {
+            public uint FileAttributes;
+            public System.Runtime.InteropServices.ComTypes.FILETIME CreationTime;
+            public System.Runtime.InteropServices.ComTypes.FILETIME LastAccessTime;
+            public System.Runtime.InteropServices.ComTypes.FILETIME LastWriteTime;
+            public uint VolumeSerialNumber;
+            public uint FileSizeHigh;
+            public uint FileSizeLow;
+            public uint NumberOfLinks;
+            public uint FileIndexHigh;
+            public uint FileIndexLow;
+        }
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/FileTextLoader.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/FileTextLoader.cs
@@ -93,6 +93,38 @@ public class FileTextLoader : TextLoader
     private FileStream OpenFile(int bufferSize, bool useAsync)
         => new(this.FilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete, bufferSize, useAsync);
 
+    private FileStream OpenFileAndGetLengthAndTimeStamp(
+        int bufferSize,
+        bool useAsync,
+        out long fileLength,
+        out DateTime lastWriteTime)
+    {
+        if (!PlatformInformation.IsWindows)
+        {
+            FileUtilities.GetFileLengthAndTimeStamp(Path, out fileLength, out lastWriteTime);
+            ValidateFileLength(Path, fileLength);
+            return FileUtilities.RethrowExceptionsAsIOException(
+                static t => t.self.OpenFile(t.bufferSize, t.useAsync),
+                (self: this, bufferSize, useAsync));
+        }
+
+        var stream = FileUtilities.RethrowExceptionsAsIOException(
+            static t => t.self.OpenFile(t.bufferSize, t.useAsync),
+            (self: this, bufferSize, useAsync));
+
+        try
+        {
+            FileUtilities.GetFileLengthAndTimeStamp(stream.SafeFileHandle, out fileLength, out lastWriteTime);
+            ValidateFileLength(Path, fileLength);
+            return stream;
+        }
+        catch
+        {
+            stream.Dispose();
+            throw;
+        }
+    }
+
     /// <summary>
     /// Load a text and a version of the document in the workspace.
     /// </summary>
@@ -100,10 +132,6 @@ public class FileTextLoader : TextLoader
     /// <exception cref="InvalidDataException"></exception>
     public override async Task<TextAndVersion> LoadTextAndVersionAsync(LoadTextOptions options, CancellationToken cancellationToken)
     {
-        FileUtilities.GetFileLengthAndTimeStamp(Path, out var fileLength, out var prevLastWriteTime);
-
-        ValidateFileLength(Path, fileLength);
-
         // In many .NET Framework versions (specifically the 4.5.* series, but probably much earlier
         // and also later) there is this particularly interesting bit in FileStream.BeginReadAsync:
         //
@@ -171,18 +199,23 @@ public class FileTextLoader : TextLoader
         // corefx. We also open the file for reading with FileShare mode read/write/delete so that
         // we do not lock this file.
 
+        using var stream = OpenFileAndGetLengthAndTimeStamp(
+            bufferSize: 1,
+            useAsync: true,
+            out _,
+            out var prevLastWriteTime);
+
         var textAndVersion = await FileUtilities.RethrowExceptionsAsIOExceptionAsync(
             async static t =>
             {
-                using var stream = t.self.OpenFile(bufferSize: 1, useAsync: true);
                 var version = VersionStamp.Create(t.prevLastWriteTime);
 
                 // we do this so that we asynchronously read from file. and this should allocate less for IDE case. 
                 // but probably not for command line case where it doesn't use more sophisticated services.
-                using var readStream = await SerializableBytes.CreateReadableStreamAsync(stream, cancellationToken: t.cancellationToken).ConfigureAwait(false);
+                using var readStream = await SerializableBytes.CreateReadableStreamAsync(t.stream, cancellationToken: t.cancellationToken).ConfigureAwait(false);
                 var text = t.self.CreateText(readStream, t.options, t.cancellationToken);
                 return TextAndVersion.Create(text, version, t.self.Path);
-            }, (self: this, prevLastWriteTime, options, cancellationToken)).ConfigureAwait(false);
+            }, (self: this, stream, prevLastWriteTime, options, cancellationToken)).ConfigureAwait(false);
 
         return CheckForConcurrentFileWrites(prevLastWriteTime, textAndVersion);
     }
@@ -194,19 +227,19 @@ public class FileTextLoader : TextLoader
     /// <exception cref="InvalidDataException"></exception>
     internal override TextAndVersion LoadTextAndVersionSynchronously(LoadTextOptions options, CancellationToken cancellationToken)
     {
-        FileUtilities.GetFileLengthAndTimeStamp(Path, out var fileLength, out var prevLastWriteTime);
-
-        ValidateFileLength(Path, fileLength);
+        using var stream = OpenFileAndGetLengthAndTimeStamp(
+            bufferSize: 4096,
+            useAsync: false,
+            out _,
+            out var prevLastWriteTime);
 
         var textAndVersion = FileUtilities.RethrowExceptionsAsIOException(
             static t =>
             {
-                // Open file for reading with FileShare mode read/write/delete so that we do not lock this file.
-                using var stream = t.self.OpenFile(bufferSize: 4096, useAsync: false);
                 var version = VersionStamp.Create(t.prevLastWriteTime);
-                var text = t.self.CreateText(stream, t.options, t.cancellationToken);
+                var text = t.self.CreateText(t.stream, t.options, t.cancellationToken);
                 return TextAndVersion.Create(text, version, t.self.Path);
-            }, (self: this, prevLastWriteTime, options, cancellationToken));
+            }, (self: this, stream, prevLastWriteTime, options, cancellationToken));
 
         return CheckForConcurrentFileWrites(prevLastWriteTime, textAndVersion);
     }


### PR DESCRIPTION
Loading source files on Windows currently queries path metadata before opening each file, then queries the path again after reading to detect concurrent writes. The first lookup showed up in scenario-scoped Speedometer CPU and file I/O traces, even though almost all reads were served from cache.

This change takes the initial length and timestamp from the opened handle, retains the post-read path check, and preserves the existing non-Windows ordering. It also consolidates the handle interop already used by analyzer shadow copying.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85226)