### PR TITLE
Consolidate roslyn options to build with analyzers

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -540,7 +540,7 @@ stages:
     steps:
       - template: eng/pipelines/checkout-unix-task.yml
 
-      - script: ./eng/build.sh --solution Roslyn.slnx --restore --build --configuration Debug --prepareMachine --ci --binaryLog --runanalyzers --warnaserror /p:RoslynEnforceCodeStyle=true
+      - script: ./eng/build.sh --solution Roslyn.slnx --restore --build --configuration Debug --prepareMachine --ci --binaryLog --runanalyzers --warnaserror
         displayName: Build with analyzers
 
       - template: eng/pipelines/publish-logs.yml

--- a/eng/make-bootstrap.ps1
+++ b/eng/make-bootstrap.ps1
@@ -57,7 +57,7 @@ try {
   # MSBuildAdditionalCommandLineArgs=
   $args = "/p:TreatWarningsAsErrors=true /warnaserror /nologo /nodeReuse:false /p:Configuration=$configuration /v:m";
   $args += " /p:RunAnalyzersDuringBuild=false /bl:$binaryLogFilePath"
-  $args += " /t:Pack /p:RoslynEnforceCodeStyle=false /p:DotNetUseShippingVersions=true /p:InitialDefineConstants=BOOTSTRAP"
+  $args += " /t:Pack /p:DotNetUseShippingVersions=true /p:InitialDefineConstants=BOOTSTRAP"
   $args += " /p:PackageOutputPath=$output /p:NgenOptimization=false /p:PublishWindowsPdb=false"
 
   if ($ci) {

--- a/eng/targets/Imports.targets
+++ b/eng/targets/Imports.targets
@@ -17,6 +17,17 @@
     </ItemGroup>
   </Target>
 
+  <!-- Keep builds fast by default, unless explicitly running the "Run Code Analysis" command. -->
+  <PropertyGroup Condition="'$(RunAnalyzersDuringBuild)' == ''">
+    <RunAnalyzersDuringBuild Condition="'$(RunCodeAnalysis)' == 'true'">true</RunAnalyzersDuringBuild>
+    <RunAnalyzersDuringBuild Condition="'$(RunAnalyzersDuringBuild)' == ''">false</RunAnalyzersDuringBuild>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(RunAnalyzersDuringBuild)' != 'true'">
+    <!-- Don't treat FormattingAnalyzer as an error unless build analysis is enabled. -->
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);IDE0055</WarningsNotAsErrors>
+  </PropertyGroup>
+
   <PropertyGroup>
     <FileAlignment>512</FileAlignment>
 
@@ -46,21 +57,9 @@
       impact the correctness of the output, so we avoid the performance overhead where it's easy to do so.
     -->
     <RoslynCheckCodeStyle Condition="'$(RoslynCheckCodeStyle)' == '' AND '$(DisableNullableWarnings)' == 'true'">false</RoslynCheckCodeStyle>
-    <RoslynCheckCodeStyle Condition="'$(RoslynCheckCodeStyle)' == '' AND ('$(ContinuousIntegrationBuild)' != 'true' OR '$(RoslynEnforceCodeStyle)' == 'true')">true</RoslynCheckCodeStyle>
+    <RoslynCheckCodeStyle Condition="'$(RoslynCheckCodeStyle)' == '' AND ('$(ContinuousIntegrationBuild)' != 'true' OR '$(RunAnalyzersDuringBuild)' == 'true')">true</RoslynCheckCodeStyle>
 
     <EnforceCodeStyleInBuild Condition="'$(EnforceCodeStyleInBuild)' == '' AND '$(RoslynCheckCodeStyle)' == 'true'">true</EnforceCodeStyleInBuild>
-  </PropertyGroup>
-
-  <!--
-    PERF: Set default value for 'RunAnalyzersDuringBuild' to determine if analyzers should be executed.
-          Default to 'false' in all non-CI builds to improve local build time (i.e. csc/vbc invocations both inside Visual Studio and from command line prompt), except if:
-            1. We are enforcing code style, i.e. '$(RoslynEnforceCodeStyle)' == 'true' OR
-            2. We are explicitly running code analysis via "Run Code Analysis" command, i.e. '$(RunCodeAnalysis)' == 'true'.
-          Otherwise, default to 'true'.
-  -->
-  <PropertyGroup Condition="'$(RunAnalyzersDuringBuild)' == ''">
-    <RunAnalyzersDuringBuild Condition="'$(RoslynEnforceCodeStyle)' != 'true' AND '$(RunCodeAnalysis)' != 'true'">false</RunAnalyzersDuringBuild>
-    <RunAnalyzersDuringBuild Condition="'$(RunAnalyzersDuringBuild)' == ''">true</RunAnalyzersDuringBuild>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(DisableNullableWarnings)' == 'true'">

--- a/eng/targets/Settings.props
+++ b/eng/targets/Settings.props
@@ -176,11 +176,6 @@
     <GeneratePerformanceSensitiveAttribute>false</GeneratePerformanceSensitiveAttribute>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(RoslynEnforceCodeStyle)' != 'true'">
-    <!-- Don't treat FormattingAnalyzer as an error, even when TreatWarningsAsErrors is specified. -->
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);IDE0055</WarningsNotAsErrors>
-  </PropertyGroup>
-
   <!--
     Language specific settings
   -->

--- a/eng/test-build-correctness.ps1
+++ b/eng/test-build-correctness.ps1
@@ -58,7 +58,7 @@ try {
   }
 
   Write-Host "Building Roslyn"
-  & eng/build.ps1 -restore -build -bootstrapDir:$bootstrapDir -ci:$ci -prepareMachine:$prepareMachine -runAnalyzers:$true -configuration:$configuration -pack -binaryLog -useGlobalNuGetCache:$false -warnAsError:$true -properties:"/p:RoslynEnforceCodeStyle=true"
+  & eng/build.ps1 -restore -build -bootstrapDir:$bootstrapDir -ci:$ci -prepareMachine:$prepareMachine -runAnalyzers:$true -configuration:$configuration -pack -binaryLog -useGlobalNuGetCache:$false -warnAsError:$true
   Test-LastExitCode
 
   Subst-TempDir

--- a/eng/validate-roslyn-sdk-samples.ps1
+++ b/eng/validate-roslyn-sdk-samples.ps1
@@ -62,7 +62,7 @@ $buildArgs = @(
   "-c", $configuration
   "--no-incremental"
   "--warnaserror"
-  "/p:RoslynEnforceCodeStyle=true"
+  "/p:RunAnalyzersDuringBuild=true"
 )
 
 if ($ci) {

--- a/eng/validate-rules-missing-documentation.ps1
+++ b/eng/validate-rules-missing-documentation.ps1
@@ -13,7 +13,7 @@ try {
   $prepareMachine = $ci
 
   $projectFilePath = Join-Path $RepoRoot "src\Features\Core\Portable\Microsoft.CodeAnalysis.Features.csproj"
-  Exec-DotNet "build $projectFilePath -t:GenerateRulesMissingDocumentation -p:RoslynEnforceCodeStyle=false -p:RunAnalyzersDuringBuild=false -p:ContinuousIntegrationBuild=$ci -c Release"
+  Exec-DotNet "build $projectFilePath -t:GenerateRulesMissingDocumentation -p:RunAnalyzersDuringBuild=false -p:ContinuousIntegrationBuild=$ci -c Release"
 }
 catch {
   Write-Host $_


### PR DESCRIPTION
Allows passing just `/p:RunAnalyzersDuringBuild=true` to run a build with analyzers instead of `/p:RoslynEnforceCodeStyle=true /p:RunAnalyzersDuringBuild=true`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85227)