### PR TITLE
Make the ProjectData.Tasks package packable and include the targets file

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -42,6 +42,7 @@
     "Microsoft.Net.Compilers.Toolset": "arcade",
     "Microsoft.Net.Compilers.Toolset.Arm64": "arcade",
     "Microsoft.Net.Compilers.Toolset.Framework": "arcade",
+    "Microsoft.NET.ProjectData.Tasks": "arcade",
     "Microsoft.CodeAnalysis.BuildClient": "arcade",
     "Microsoft.CodeAnalysis.Contracts": "arcade",
     "Microsoft.CodeAnalysis.Debugging": "arcade",

--- a/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Tasks/Microsoft.NET.ProjectData.Tasks.csproj
+++ b/src/LanguageServer/ProjectData/Microsoft.NET.ProjectData.Tasks/Microsoft.NET.ProjectData.Tasks.csproj
@@ -6,8 +6,8 @@
     <EnableAotAnalyzer>false</EnableAotAnalyzer>
     <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
     <RootNamespace>Microsoft.NET.ProjectData.Tasks</RootNamespace>
-    <!-- Task assemblies are not shipped as NuGet packages from this repo. -->
-    <IsPackable>false</IsPackable>
+    <!-- The SDK extracts this package and arranges its deployment layout; it is not intended for PackageReference consumption. -->
+    <IsPackable>true</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <!-- These members are used by source files that are intentionally not linked into this
          netstandard2.0 task assembly, so Roslyn's partial view reports them as unused. -->
@@ -32,9 +32,9 @@
   <ItemGroup>
     <!-- The targets file ships next to this assembly so MSBuild can resolve the DLL via
          $(MSBuildThisFileDirectory). Copying it to the build output keeps both files together. -->
-    <None Include="build\Microsoft.NET.ProjectData.targets" Link="Microsoft.NET.ProjectData.targets" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="build\Microsoft.NET.ProjectData.targets" Link="Microsoft.NET.ProjectData.targets" CopyToOutputDirectory="PreserveNewest" Pack="true" PackagePath="lib\$(TargetFramework)\" />
     <!-- Generated property allow-list imported by the .targets; must travel with it. -->
-    <None Include="build\Microsoft.NET.ProjectData.Schema.props" Link="Microsoft.NET.ProjectData.Schema.props" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="build\Microsoft.NET.ProjectData.Schema.props" Link="Microsoft.NET.ProjectData.Schema.props" CopyToOutputDirectory="PreserveNewest" Pack="true" PackagePath="lib\$(TargetFramework)\" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This is to enable consumption in the SDK repo.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85232)