### PR TITLE
Preserve VB Iterator in SyntaxGenerator modifier updates

### DIFF
--- a/src/Workspaces/Core/Portable/Editing/DeclarationModifiers.cs
+++ b/src/Workspaces/Core/Portable/Editing/DeclarationModifiers.cs
@@ -139,6 +139,8 @@ public readonly record struct DeclarationModifiers
 
     internal bool IsFixed => (Modifiers & Modifiers.Fixed) != 0;
 
+    internal bool IsIterator => (Modifiers & Modifiers.Iterator) != 0;
+
     public bool IsClosed => (Modifiers & Modifiers.Closed) != 0;
 
     public DeclarationModifiers WithIsStatic(bool isStatic)
@@ -224,6 +226,8 @@ public readonly record struct DeclarationModifiers
     public static DeclarationModifiers File => new(Modifiers.File);
 
     internal static DeclarationModifiers Fixed => new(Modifiers.Fixed);
+
+    internal static DeclarationModifiers Iterator => new(Modifiers.Iterator);
 
     public static DeclarationModifiers Closed => new(Modifiers.Closed);
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Editing/Modifiers.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Editing/Modifiers.cs
@@ -33,5 +33,6 @@ internal enum Modifiers
     File        = 1 << 17,
     Fixed       = 1 << 18,
     Closed      = 1 << 19,
+    Iterator    = 1 << 20,
 #pragma warning restore format
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicAccessibilityFacts.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/VisualBasic/Services/SyntaxFacts/VisualBasicAccessibilityFacts.vb
@@ -220,6 +220,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.LanguageService
                         modifiers = modifiers Or Modifiers.Static
                     Case SyntaxKind.AsyncKeyword
                         modifiers = modifiers Or Modifiers.Async
+                    Case SyntaxKind.IteratorKeyword
+                        modifiers = modifiers Or Modifiers.Iterator
                     Case SyntaxKind.ConstKeyword
                         modifiers = modifiers Or Modifiers.Const
                     Case SyntaxKind.ReadOnlyKeyword

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/LanguageServices/VisualBasicSyntaxGeneratorInternal.vb
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/VisualBasic/LanguageServices/VisualBasicSyntaxGeneratorInternal.vb
@@ -22,10 +22,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
         Public Shared ReadOnly Instance As New VisualBasicSyntaxGeneratorInternal()
 
         Public Shared ReadOnly s_fieldModifiers As DeclarationModifiers = DeclarationModifiers.Const Or DeclarationModifiers.[New] Or DeclarationModifiers.ReadOnly Or DeclarationModifiers.Static Or DeclarationModifiers.WithEvents
-        Public Shared ReadOnly s_methodModifiers As DeclarationModifiers = DeclarationModifiers.Abstract Or DeclarationModifiers.Async Or DeclarationModifiers.[New] Or DeclarationModifiers.Override Or DeclarationModifiers.Partial Or DeclarationModifiers.Sealed Or DeclarationModifiers.Static Or DeclarationModifiers.Virtual
+        Public Shared ReadOnly s_methodModifiers As DeclarationModifiers = DeclarationModifiers.Abstract Or DeclarationModifiers.Async Or DeclarationModifiers.Iterator Or DeclarationModifiers.[New] Or DeclarationModifiers.Override Or DeclarationModifiers.Partial Or DeclarationModifiers.Sealed Or DeclarationModifiers.Static Or DeclarationModifiers.Virtual
         Public Shared ReadOnly s_constructorModifiers As DeclarationModifiers = DeclarationModifiers.Static
-        Public Shared ReadOnly s_propertyModifiers As DeclarationModifiers = DeclarationModifiers.Abstract Or DeclarationModifiers.[New] Or DeclarationModifiers.Override Or DeclarationModifiers.ReadOnly Or DeclarationModifiers.WriteOnly Or DeclarationModifiers.Sealed Or DeclarationModifiers.Static Or DeclarationModifiers.Virtual
-        Public Shared ReadOnly s_indexerModifiers As DeclarationModifiers = DeclarationModifiers.Abstract Or DeclarationModifiers.[New] Or DeclarationModifiers.Override Or DeclarationModifiers.ReadOnly Or DeclarationModifiers.WriteOnly Or DeclarationModifiers.Sealed Or DeclarationModifiers.Static Or DeclarationModifiers.Virtual
+        Public Shared ReadOnly s_propertyModifiers As DeclarationModifiers = DeclarationModifiers.Abstract Or DeclarationModifiers.Iterator Or DeclarationModifiers.[New] Or DeclarationModifiers.Override Or DeclarationModifiers.ReadOnly Or DeclarationModifiers.WriteOnly Or DeclarationModifiers.Sealed Or DeclarationModifiers.Static Or DeclarationModifiers.Virtual
+        Public Shared ReadOnly s_indexerModifiers As DeclarationModifiers = DeclarationModifiers.Abstract Or DeclarationModifiers.Iterator Or DeclarationModifiers.[New] Or DeclarationModifiers.Override Or DeclarationModifiers.ReadOnly Or DeclarationModifiers.WriteOnly Or DeclarationModifiers.Sealed Or DeclarationModifiers.Static Or DeclarationModifiers.Virtual
         Public Shared ReadOnly s_classModifiers As DeclarationModifiers = DeclarationModifiers.Abstract Or DeclarationModifiers.[New] Or DeclarationModifiers.Partial Or DeclarationModifiers.Sealed Or DeclarationModifiers.Static
         Public Shared ReadOnly s_structModifiers As DeclarationModifiers = DeclarationModifiers.[New] Or DeclarationModifiers.Partial
         Public Shared ReadOnly s_interfaceModifiers As DeclarationModifiers = DeclarationModifiers.[New] Or DeclarationModifiers.Partial
@@ -446,6 +446,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
 
             If modifiers.IsAsync Then
                 _list = _list.Add(SyntaxFactory.Token(SyntaxKind.AsyncKeyword))
+            End If
+
+            If modifiers.IsIterator Then
+                _list = _list.Add(SyntaxFactory.Token(SyntaxKind.IteratorKeyword))
             End If
 
             If modifiers.IsConst Then

--- a/src/Workspaces/VisualBasicTest/CodeGeneration/SyntaxGeneratorTests.vb
+++ b/src/Workspaces/VisualBasicTest/CodeGeneration/SyntaxGeneratorTests.vb
@@ -2753,6 +2753,25 @@ End Class
             Assert.Equal(DeclarationModifiers.None, Generator.GetModifiers(Generator.WithModifiers(SyntaxFactory.TypeParameter("tp"), DeclarationModifiers.Abstract)))
         End Sub
 
+        <Fact, WorkItem("https://github.com/dotnet/roslyn-analyzers/pull/7434")>
+        Public Sub TestWithModifiers_Iterator()
+            Dim declaration = SyntaxFactory.ParseCompilationUnit("Public Iterator Function Method1() As IEnumerable(Of Integer)
+    Yield 1
+End Function").Members.Single()
+
+            Dim modifiers = Generator.GetModifiers(declaration).WithIsStatic(True)
+            VerifySyntax(Of MethodBlockSyntax)(Generator.WithModifiers(declaration, modifiers), "Public Shared Iterator Function Method1() As IEnumerable(Of Integer)
+    Yield 1
+End Function")
+
+            Dim statement = DirectCast(declaration, MethodBlockSyntax).SubOrFunctionStatement
+            VerifySyntax(Of MethodStatementSyntax)(Generator.WithModifiers(statement, modifiers),
+                "Public Shared Iterator Function Method1() As IEnumerable(Of Integer)")
+            VerifySyntax(Of MethodBlockSyntax)(Generator.WithAccessibility(declaration, Accessibility.Private), "Private Iterator Function Method1() As IEnumerable(Of Integer)
+    Yield 1
+End Function")
+        End Sub
+
         <Fact>
         Public Sub TestWithModifiers_Sealed_Class()
             Dim classBlock = DirectCast(Generator.ClassDeclaration("C"), ClassBlockSyntax)


### PR DESCRIPTION
## Summary

Preserve the Visual Basic `Iterator` modifier when `SyntaxGenerator` updates a declaration's modifiers or accessibility.

This addresses the underlying Roslyn bug reported in https://github.com/dotnet/roslyn-analyzers/issues/7433 and follows up on the regression originally proposed in https://github.com/dotnet/roslyn-analyzers/pull/7434. Related API discussion: https://github.com/dotnet/roslyn/issues/75388.

For example, adding `Shared` through `WithModifiers(method, GetModifiers(method).WithIsStatic(true))` currently changes:

```vb
Public Iterator Function Method1() As IEnumerable(Of Integer)
    Yield 1
End Function
```
into a non-iterator function with a `Yield` statement.
```vb
Public Shared Function Method1() As IEnumerable(Of Integer)
    Yield 1
End Function
```

## Implementation

- Add an internal iterator modifier flag and internal `DeclarationModifiers` accessors. No public API is added.
- Recognize `Iterator` when reading VB modifiers, include it in the allowed method/property/indexer modifiers, and emit it when rebuilding modifier tokens.
- Add a Roslyn syntax-generator regression test covering method blocks, method statements, and accessibility changes.

## Alternative considered

A smaller alternative is to copy the existing `Iterator` token from the original declaration when rebuilding its modifiers, without representing it in `DeclarationModifiers`.

That would fix the original mark-member-as-static scenario, but the behavior differs:

| Operation | Internal flag used here | Preserve existing token only |
| --- | --- | --- |
| Add `Shared` using the existing modifiers | Retains `Iterator` | Retains `Iterator` |
| Copy modifiers from an iterator method to another method | Copies `Iterator` | Does not copy `Iterator` unless the target already has it |
| Replace modifiers with only `DeclarationModifiers.Static` | Removes `Iterator` | Retains `Iterator` |

The internal flag keeps `GetModifiers`/`WithModifiers` round trips consistent and lets an explicit replacement remove the modifier. Preserving every existing token indiscriminately would also prevent callers from intentionally removing modifiers.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85237)