### PR TITLE
Prevent completion filtering cleanup races

### DIFF
--- a/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/ItemManager.CompletionListUpdater.cs
+++ b/src/EditorFeatures/Core/IntelliSense/AsyncCompletion/ItemManager.CompletionListUpdater.cs
@@ -135,7 +135,9 @@ internal partial class ItemManager
             // since the completion list could be long with import completion enabled.
             var itemsToBeIncluded = s_listOfMatchResultPool.Allocate();
             var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            var cancellationTokenForHighlightAndFilter = cancellationTokenSource.Token;
             var threadLocalPatternMatchHelper = new ThreadLocal<PatternMatchHelper>(() => new PatternMatchHelper(_filterText), trackAllValues: true);
+            Task<(CompletionList<CompletionItemWithHighlight>, ImmutableArray<CompletionFilterWithState>)>? highlightAndFilterTask = null;
 
             try
             {
@@ -151,9 +153,9 @@ internal partial class ItemManager
                 // Sort items based on pattern matching result
                 itemsToBeIncluded.Sort(MatchResult.SortingComparer);
 
-                var highlightAndFilterTask = Task.Run(
-                    () => GetHighlightedListAndUpdatedFilters(session, itemsToBeIncluded, threadLocalPatternMatchHelper, cancellationTokenSource.Token),
-                    cancellationTokenSource.Token);
+                highlightAndFilterTask = Task.Run(
+                    () => GetHighlightedListAndUpdatedFilters(session, itemsToBeIncluded, threadLocalPatternMatchHelper, cancellationTokenForHighlightAndFilter),
+                    cancellationTokenForHighlightAndFilter);
 
                 // Decide the item to be selected for this completion session.
                 // The selection is mostly based on how well the item matches with the filter text, but we also need to
@@ -184,17 +186,30 @@ internal partial class ItemManager
             finally
             {
                 cancellationTokenSource.Cancel();
-                cancellationTokenSource.Dispose();
+                try
+                {
+                    if (highlightAndFilterTask is not null)
+                        await highlightAndFilterTask.ConfigureAwait(false);
+                }
+                catch (OperationCanceledException ex) when (
+                    ex.CancellationToken == cancellationTokenForHighlightAndFilter
+                    && cancellationTokenForHighlightAndFilter.IsCancellationRequested)
+                {
+                }
+                finally
+                {
+                    cancellationTokenSource.Dispose();
 
-                // Don't call ClearAndFree, which resets the capacity to a default value.
-                itemsToBeIncluded.Clear();
-                s_listOfMatchResultPool.Free(itemsToBeIncluded);
+                    // Don't call ClearAndFree, which resets the capacity to a default value.
+                    itemsToBeIncluded.Clear();
+                    s_listOfMatchResultPool.Free(itemsToBeIncluded);
 
-                // Dispose PatternMatchers
-                foreach (var helper in threadLocalPatternMatchHelper.Values)
-                    helper.Dispose();
+                    // Dispose PatternMatchers
+                    foreach (var helper in threadLocalPatternMatchHelper.Values)
+                        helper.Dispose();
 
-                threadLocalPatternMatchHelper.Dispose();
+                    threadLocalPatternMatchHelper.Dispose();
+                }
             }
 
             (CompletionList<CompletionItemWithHighlight>, ImmutableArray<CompletionFilterWithState>) GetHighlightedListAndUpdatedFilters(

--- a/src/EditorFeatures/Test2/IntelliSense/CompletionListUpdaterDisposalRaceTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CompletionListUpdaterDisposalRaceTests.vb
@@ -1,0 +1,65 @@
+' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports System.Runtime.ExceptionServices
+Imports System.Text
+Imports System.Threading
+Imports Microsoft.CodeAnalysis.Completion
+
+Namespace Microsoft.CodeAnalysis.Editor.UnitTests.IntelliSense
+    <UseExportProvider>
+    <Trait(Traits.Feature, Traits.Features.Completion)>
+    Public NotInheritable Class CompletionListUpdaterDisposalRaceTests
+        <WpfFact>
+        Public Async Function EarlyReturnFromDeletionTriggerDoesNotRaceCompletionListUpdaterDisposal() As Task
+            Const ItemCount = 400
+            Const IterationCount = 20
+
+            Dim documentContent As New StringBuilder()
+            documentContent.AppendLine("class C")
+            documentContent.AppendLine("{")
+            documentContent.AppendLine("    void M()")
+            documentContent.AppendLine("    {")
+            For i = 0 To ItemCount - 1
+                documentContent.AppendLine($"        int raceItem{i} = 0;")
+            Next
+            documentContent.AppendLine("        raceItem0$$;")
+            documentContent.AppendLine("    }")
+            documentContent.AppendLine("}")
+
+            Using state = TestStateFactory.CreateCSharpTestState(<Document><%= documentContent.ToString() %></Document>)
+                state.Workspace.GlobalOptions.SetGlobalOption(CompletionOptionsStorage.TriggerOnDeletion, LanguageNames.CSharp, True)
+
+                Dim objectDisposedExceptionCount = 0
+                Dim firstChanceHandler As EventHandler(Of FirstChanceExceptionEventArgs) =
+                    Sub(sender, e)
+                        If TypeOf e.Exception Is ObjectDisposedException AndAlso
+                           e.Exception.StackTrace?.Contains("CompletionListUpdater") = True Then
+                            Interlocked.Increment(objectDisposedExceptionCount)
+                        End If
+                    End Sub
+
+                AddHandler AppDomain.CurrentDomain.FirstChanceException, firstChanceHandler
+                Try
+                    For iteration = 1 To IterationCount
+                        state.SendBackspace()
+                        Await state.AssertCompletionSession()
+
+                        state.SendTypeChars("Z")
+
+                        state.AssertNoCompletionSessionWithNoBlock()
+                        Await Task.Delay(50)
+
+                        state.SendBackspace()
+                        state.SendTypeChars("0")
+                    Next
+                Finally
+                    RemoveHandler AppDomain.CurrentDomain.FirstChanceException, firstChanceHandler
+                End Try
+
+                Assert.Equal(0, Volatile.Read(objectDisposedExceptionCount))
+            End Using
+        End Function
+    End Class
+End Namespace


### PR DESCRIPTION
Completion filtering can return early while its background highlighting task is still running. Cleanup then disposes the linked cancellation source and returns pooled matching state that the worker still reads, producing `ObjectDisposedException` events and risking cross-request state corruption.

Cancel and join the worker before releasing its resources, while preserving unexpected worker fault propagation. Regression coverage repeatedly exercises the deletion-trigger early-return path.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85241)