### PR TITLE
Reduce IntelliSense cancellation exception overhead

### DIFF
--- a/src/EditorFeatures/Core/IntelliSense/ModelComputation.cs
+++ b/src/EditorFeatures/Core/IntelliSense/ModelComputation.cs
@@ -124,12 +124,13 @@ internal sealed class ModelComputation<TModel> where TModel : class
             [_notifyControllerTask, nextTask],
             async tasks =>
             {
-                await ThreadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(alwaysYield: true, _stopCancellationToken);
+                await ThreadingContext.JoinableTaskFactory.SwitchToMainThreadAsync(alwaysYield: true, _stopCancellationToken).NoThrowAwaitable();
+
+                if (_stopCancellationToken.IsCancellationRequested)
+                    return;
 
                 if (tasks.All(t => t.Status == TaskStatus.RanToCompletion))
                 {
-                    _stopCancellationToken.ThrowIfCancellationRequested();
-
                     // Check if we're still the last task.  If so then we should update the
                     // controller. Otherwise there's a pending task that should run.  We
                     // don't need to update the controller (and the presenters) until our


### PR DESCRIPTION
Stopping an IntelliSense model computation can cancel its notification continuation after it has started switching to the UI thread. The cancellable await throws an expected `OperationCanceledException` even though the continuation only needs to skip a stale controller notification.

Use the no-throw await and explicitly return when stop cancellation wins. Transform faults and notification ordering remain unchanged.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85242)