### PR TITLE
Fix type hierarchy request test compilation

### DIFF
--- a/src/LanguageServer/ProtocolUnitTests/TypeHierarchy/TypeHierarchyTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/TypeHierarchy/TypeHierarchyTests.cs
@@ -418,8 +418,6 @@ public sealed class TypeHierarchyTests(ITestOutputHelper testOutputHelper) : Abs
             LSP.Methods.TypeHierarchySupertypesName,
             new LSP.TypeHierarchySupertypesParams
             {
-                TextDocument = CreateTextDocumentIdentifier(item.Uri),
-                Position = item.SelectionRange.Start,
                 Item = item,
             },
             CancellationToken.None) ?? [];
@@ -429,8 +427,6 @@ public sealed class TypeHierarchyTests(ITestOutputHelper testOutputHelper) : Abs
             LSP.Methods.TypeHierarchySubtypesName,
             new LSP.TypeHierarchySubtypesParams
             {
-                TextDocument = CreateTextDocumentIdentifier(item.Uri),
-                Position = item.SelectionRange.Start,
                 Item = item,
             },
             CancellationToken.None) ?? [];

--- a/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostTypeHierarchyEndpointTest.cs
+++ b/src/Razor/src/Razor/test/Microsoft.CodeAnalysis.Razor.CohostingShared.UnitTests/Endpoints/CohostTypeHierarchyEndpointTest.cs
@@ -262,8 +262,6 @@ public class CohostTypeHierarchyEndpointTest(ITestOutputHelper testOutputHelper)
         var request = new TypeHierarchySupertypesParams
         {
             Item = roundTrippedItem,
-            Position = roundTrippedItem.SelectionRange.Start,
-            TextDocument = new TextDocumentIdentifier { DocumentUri = roundTrippedItem.Uri },
         };
 
         return await endpoint.GetTestAccessor().HandleRequestAsync(request, document, DisposalToken) ?? [];
@@ -277,8 +275,6 @@ public class CohostTypeHierarchyEndpointTest(ITestOutputHelper testOutputHelper)
         var request = new TypeHierarchySubtypesParams
         {
             Item = roundTrippedItem,
-            Position = roundTrippedItem.SelectionRange.Start,
-            TextDocument = new TextDocumentIdentifier { DocumentUri = roundTrippedItem.Uri },
         };
 
         return await endpoint.GetTestAccessor().HandleRequestAsync(request, document, DisposalToken) ?? [];


### PR DESCRIPTION
Fixes the test compilation failures introduced by #82294.

`TypeHierarchySupertypesParams` and `TypeHierarchySubtypesParams` no longer inherit `TextDocumentPositionParams` under the LSP 3.18 model. Remove the stale `TextDocument` and `Position` assignments from the Language Server and Razor test requests; the handlers resolve the document from `Item.Data`.

Validation:
- `dotnet test src/LanguageServer/ProtocolUnitTests/Microsoft.CodeAnalysis.LanguageServer.Protocol.UnitTests.csproj -f net10.0 --filter 'FullyQualifiedName~TypeHierarchyTests' -p:RunAnalyzersDuringBuild=true --no-restore`
- `dotnet test src/Razor/src/Razor/test/Microsoft.VisualStudioCode.RazorExtension.UnitTests/Microsoft.VisualStudioCode.RazorExtension.UnitTests.csproj --filter 'FullyQualifiedName~CohostTypeHierarchyEndpointTest' -p:RunAnalyzersDuringBuild=true --no-restore`

The `net472` build could not be run locally on macOS because the .NET Framework 4.7.2 targeting pack is unavailable; CI covers that target.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85253)