### PR TITLE
Add semantic test attribute discovery option

### DIFF
--- a/src/Features/CSharpTest/Testing/CSharpTestMethodFinderTests.cs
+++ b/src/Features/CSharpTest/Testing/CSharpTestMethodFinderTests.cs
@@ -112,6 +112,68 @@ public sealed class CSharpTestMethodFinderTests
             """);
 
     [Fact]
+    public Task TestSemanticDiscoveryFindsXUnitAliasedFactMethod()
+        => TestXunitSemanticAsync("""
+            using Xunit;
+            using test = Xunit.FactAttribute;
+            public class TestClass
+            {
+                [test]
+                public void Test$$Method1() { }
+            }
+            """, "TestMethod1");
+
+    [Fact]
+    public Task TestSyntaxDiscoveryDoesNotFindDerivedXUnitFactMethod()
+        => TestXunitAsync("""
+            using Xunit;
+            public sealed class ConditionalFactAttribute : FactAttribute { }
+
+            public class TestClass
+            {
+                [ConditionalFact]
+                public void Test$$Method1() { }
+            }
+            """);
+
+    [Fact]
+    public Task TestSemanticDiscoveryFindsDerivedXUnitFactMethod()
+        => TestXunitSemanticAsync("""
+            using Xunit;
+            public class ConditionalFactAttribute : FactAttribute { }
+            public sealed class WindowsOnlyFactAttribute : ConditionalFactAttribute { }
+
+            public class TestClass
+            {
+                [WindowsOnlyFact]
+                public void Test$$Method1() { }
+            }
+            """, "TestMethod1");
+
+    [Fact]
+    public Task TestSemanticDiscoveryDoesNotFindUnrelatedFactAttribute()
+        => TestAsync("""
+            using System;
+            namespace Other
+            {
+                public sealed class FactAttribute : Attribute { }
+            }
+
+            public class TestClass
+            {
+                [Other.Fact]
+                public void Test$$Method1() { }
+            }
+            """, """
+            using System;
+            namespace Xunit
+            {
+                public class FactAttribute : Attribute { }
+                public class TheoryAttribute : FactAttribute { }
+            }
+            """, useSemanticDiscovery: true);
+
+    [Fact]
     public Task TestFindsXUnitFactOnlySelectedMethod()
         => TestXunitAsync("""
             using Xunit;
@@ -292,6 +354,19 @@ public sealed class CSharpTestMethodFinderTests
             }
             """, "TestMethod1", "TestMethod2", "TestMethod3", "TestMethod4");
 
+    [Fact]
+    public Task TestSemanticDiscoveryFindsDerivedNUnitTestMethod()
+        => TestNUnitSemanticAsync("""
+            using NUnit.Framework;
+            public sealed class CustomTestAttribute : TestAttribute { }
+
+            public class TestClass
+            {
+                [CustomTest]
+                public void Test$$Method1() { }
+            }
+            """, "TestMethod1");
+
     #endregion
 
     #region MSTest
@@ -335,6 +410,19 @@ public sealed class CSharpTestMethodFinderTests
                 public void NotTestMethod() { }
             }
             """, "TestMethod1", "TestMethod2");
+
+    [Fact]
+    public Task TestSemanticDiscoveryFindsDerivedMSTestMethod()
+        => TestMSTestSemanticAsync("""
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+            public sealed class CustomTestMethodAttribute : TestMethodAttribute { }
+
+            public class TestClass
+            {
+                [CustomTestMethod]
+                public void Test$$Method1() { }
+            }
+            """, "TestMethod1");
 
     #endregion
 
@@ -404,7 +492,22 @@ public sealed class CSharpTestMethodFinderTests
                 [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
                 public class TheoryAttribute : FactAttribute { }
             }
-            """, expectedTestNames);
+            """, false, expectedTestNames);
+    }
+
+    private static Task TestXunitSemanticAsync(string code, params string[] expectedTestNames)
+    {
+        return TestAsync(code, """
+            using System;
+            namespace Xunit
+            {
+                [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+                public class FactAttribute : Attribute { }
+
+                [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+                public class TheoryAttribute : FactAttribute { }
+            }
+            """, true, expectedTestNames);
     }
 
     private static Task TestXunitMatchAsync(string code, params string[] expectedQualifiedTestNames)
@@ -443,7 +546,7 @@ public sealed class CSharpTestMethodFinderTests
                     public TestCaseSourceAttribute(string sourceName) { }
                 }
             }
-            """, expectedTestNames);
+            """, false, expectedTestNames);
     }
 
     private static Task TestMSTestAsync(string code, params string[] expectedTestNames)
@@ -455,10 +558,39 @@ public sealed class CSharpTestMethodFinderTests
                 [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
                 public class TestMethodAttribute : Attribute { }
             }
-            """, expectedTestNames);
+            """, false, expectedTestNames);
     }
 
-    private static async Task TestAsync(string code, string testAttributeDefinitionsCode, params string[] expectedTestNames)
+    private static Task TestNUnitSemanticAsync(string code, params string[] expectedTestNames)
+    {
+        return TestAsync(code, """
+            using System;
+            namespace NUnit.Framework
+            {
+                public class TestAttribute : Attribute { }
+                public class TheoryAttribute : Attribute { }
+                public class TestCaseAttribute : Attribute { }
+                public class TestCaseSourceAttribute : Attribute { }
+            }
+            """, true, expectedTestNames);
+    }
+
+    private static Task TestMSTestSemanticAsync(string code, params string[] expectedTestNames)
+    {
+        return TestAsync(code, """
+            using System;
+            namespace Microsoft.VisualStudio.TestTools.UnitTesting
+            {
+                public class TestMethodAttribute : Attribute { }
+            }
+            """, true, expectedTestNames);
+    }
+
+    private static async Task TestAsync(
+        string code,
+        string testAttributeDefinitionsCode,
+        bool useSemanticDiscovery,
+        params string[] expectedTestNames)
     {
         var workspace = TestWorkspace.CreateCSharp([code, testAttributeDefinitionsCode]);
 
@@ -466,7 +598,8 @@ public sealed class CSharpTestMethodFinderTests
         var span = testDocument.CursorPosition != null ? new TextSpan(testDocument.CursorPosition.Value, 0) : testDocument.SelectedSpans.Single();
 
         var testMethodFinder = workspace.CurrentSolution.Projects.Single().GetRequiredLanguageService<ITestMethodFinder>();
-        var testMethods = await testMethodFinder.GetPotentialTestMethodsAsync(workspace.CurrentSolution.GetRequiredDocument(testDocument.Id), span, CancellationToken.None);
+        var testMethods = await testMethodFinder.GetPotentialTestMethodsAsync(
+            workspace.CurrentSolution.GetRequiredDocument(testDocument.Id), span, useSemanticDiscovery, CancellationToken.None);
         var testMethodNames = testMethods.Cast<MethodDeclarationSyntax>().Select(m => m.Identifier.Text).ToArray();
 
         AssertEx.Equal(expectedTestNames, testMethodNames);
@@ -480,7 +613,8 @@ public sealed class CSharpTestMethodFinderTests
         var span = testDocument.CursorPosition != null ? new TextSpan(testDocument.CursorPosition.Value, 0) : testDocument.SelectedSpans.Single();
 
         var testMethodFinder = workspace.CurrentSolution.Projects.Single().GetRequiredLanguageService<ITestMethodFinder>();
-        var testMethods = await testMethodFinder.GetPotentialTestMethodsAsync(workspace.CurrentSolution.GetRequiredDocument(testDocument.Id), span, CancellationToken.None);
+        var testMethods = await testMethodFinder.GetPotentialTestMethodsAsync(
+            workspace.CurrentSolution.GetRequiredDocument(testDocument.Id), span, false, CancellationToken.None);
         var semanticModel = await workspace.CurrentSolution.GetRequiredDocument(testDocument.Id).GetRequiredSemanticModelAsync(CancellationToken.None);
 
         List<string> unmatchedTestNames = [];

--- a/src/Features/CSharpTest/Testing/CSharpTestMethodFinderTests.cs
+++ b/src/Features/CSharpTest/Testing/CSharpTestMethodFinderTests.cs
@@ -355,14 +355,13 @@ public sealed class CSharpTestMethodFinderTests
             """, "TestMethod1", "TestMethod2", "TestMethod3", "TestMethod4");
 
     [Fact]
-    public Task TestSemanticDiscoveryFindsDerivedNUnitTestMethod()
+    public Task TestSemanticDiscoveryFindsNUnitTestMethod()
         => TestNUnitSemanticAsync("""
             using NUnit.Framework;
-            public sealed class CustomTestAttribute : TestAttribute { }
 
             public class TestClass
             {
-                [CustomTest]
+                [Test]
                 public void Test$$Method1() { }
             }
             """, "TestMethod1");
@@ -567,10 +566,10 @@ public sealed class CSharpTestMethodFinderTests
             using System;
             namespace NUnit.Framework
             {
-                public class TestAttribute : Attribute { }
-                public class TheoryAttribute : Attribute { }
-                public class TestCaseAttribute : Attribute { }
-                public class TestCaseSourceAttribute : Attribute { }
+                public sealed class TestAttribute : Attribute { }
+                public sealed class TheoryAttribute : Attribute { }
+                public sealed class TestCaseAttribute : Attribute { }
+                public sealed class TestCaseSourceAttribute : Attribute { }
             }
             """, true, expectedTestNames);
     }

--- a/src/Features/Core/Portable/Testing/AbstractTestMethodFinder.cs
+++ b/src/Features/Core/Portable/Testing/AbstractTestMethodFinder.cs
@@ -83,11 +83,13 @@ internal abstract class AbstractTestMethodFinder<TMethodDeclaration>(IEnumerable
         var semanticModel = useSemanticDiscovery
             ? await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false)
             : null;
-        var testAttributeTypes = semanticModel is null ? [] : GetTestAttributeTypes(semanticModel.Compilation);
+        var (testAttributeTypes, inheritableTestAttributeTypes) = semanticModel is null
+            ? ([], [])
+            : GetTestAttributeTypes(semanticModel.Compilation);
 
         return nodes.WhereAsArray(node =>
             node is TMethodDeclaration method &&
-            IsTestMethod(method, semanticModel, testAttributeTypes, cancellationToken));
+            IsTestMethod(method, semanticModel, testAttributeTypes, inheritableTestAttributeTypes, cancellationToken));
     }
 
     private async Task<ImmutableArray<SyntaxNode>> GetPotentialTestNodesAsync(
@@ -98,12 +100,14 @@ internal abstract class AbstractTestMethodFinder<TMethodDeclaration>(IEnumerable
         var semanticModel = useSemanticDiscovery
             ? await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false)
             : null;
-        var testAttributeTypes = semanticModel is null ? [] : GetTestAttributeTypes(semanticModel.Compilation);
+        var (testAttributeTypes, inheritableTestAttributeTypes) = semanticModel is null
+            ? ([], [])
+            : GetTestAttributeTypes(semanticModel.Compilation);
 
         using var _ = ArrayBuilder<SyntaxNode>.GetInstance(out var testMethods);
         foreach (var method in methodsInRange)
         {
-            if (IsTestMethod(method, semanticModel, testAttributeTypes, cancellationToken))
+            if (IsTestMethod(method, semanticModel, testAttributeTypes, inheritableTestAttributeTypes, cancellationToken))
             {
                 testMethods.Add(method);
             }
@@ -127,6 +131,7 @@ internal abstract class AbstractTestMethodFinder<TMethodDeclaration>(IEnumerable
         TMethodDeclaration method,
         SemanticModel? semanticModel,
         ImmutableArray<INamedTypeSymbol> testAttributeTypes,
+        ImmutableArray<INamedTypeSymbol> inheritableTestAttributeTypes,
         CancellationToken cancellationToken)
     {
         if (semanticModel is null)
@@ -142,9 +147,19 @@ internal abstract class AbstractTestMethodFinder<TMethodDeclaration>(IEnumerable
 
         foreach (var attribute in methodSymbol.GetAttributes())
         {
-            for (var attributeType = attribute.AttributeClass; attributeType is not null; attributeType = attributeType.BaseType)
+            if (attribute.AttributeClass is not { } attributeClass)
             {
-                if (testAttributeTypes.Contains(attributeType, SymbolEqualityComparer.Default))
+                continue;
+            }
+
+            if (testAttributeTypes.Contains(attributeClass, SymbolEqualityComparer.Default))
+            {
+                return true;
+            }
+
+            for (var baseType = attributeClass.BaseType; baseType is not null; baseType = baseType.BaseType)
+            {
+                if (inheritableTestAttributeTypes.Contains(baseType, SymbolEqualityComparer.Default))
                 {
                     return true;
                 }
@@ -154,9 +169,11 @@ internal abstract class AbstractTestMethodFinder<TMethodDeclaration>(IEnumerable
         return false;
     }
 
-    private ImmutableArray<INamedTypeSymbol> GetTestAttributeTypes(Compilation compilation)
+    private (ImmutableArray<INamedTypeSymbol> testAttributeTypes, ImmutableArray<INamedTypeSymbol> inheritableTestAttributeTypes) GetTestAttributeTypes(
+        Compilation compilation)
     {
-        using var _ = ArrayBuilder<INamedTypeSymbol>.GetInstance(out var builder);
+        using var _1 = ArrayBuilder<INamedTypeSymbol>.GetInstance(out var testAttributeTypes);
+        using var _2 = ArrayBuilder<INamedTypeSymbol>.GetInstance(out var inheritableTestAttributeTypes);
 
         foreach (var metadata in TestFrameworkMetadata)
         {
@@ -165,11 +182,15 @@ internal abstract class AbstractTestMethodFinder<TMethodDeclaration>(IEnumerable
                 var attributeType = compilation.GetTypeByMetadataName(metadataName);
                 if (attributeType is not null)
                 {
-                    builder.Add(attributeType);
+                    testAttributeTypes.Add(attributeType);
+                    if (metadata.SupportsDerivedTestAttributes)
+                    {
+                        inheritableTestAttributeTypes.Add(attributeType);
+                    }
                 }
             }
         }
 
-        return builder.ToImmutableAndClear();
+        return (testAttributeTypes.ToImmutableAndClear(), inheritableTestAttributeTypes.ToImmutableAndClear());
     }
 }

--- a/src/Features/Core/Portable/Testing/AbstractTestMethodFinder.cs
+++ b/src/Features/Core/Portable/Testing/AbstractTestMethodFinder.cs
@@ -77,15 +77,14 @@ internal abstract class AbstractTestMethodFinder<TMethodDeclaration>(IEnumerable
         return fullyQualifiedMethodName == fullyQualifiedTestName;
     }
 
-    public async Task<ImmutableArray<SyntaxNode>> GetTestMethodsAsync(
-        Document document, ImmutableArray<SyntaxNode> nodes, bool useSemanticDiscovery, CancellationToken cancellationToken)
+    public bool IsTestMethod(SyntaxNode node)
+        => node is TMethodDeclaration method && IsTestMethod(method);
+
+    public async Task<ImmutableArray<SyntaxNode>> GetSemanticTestMethodsAsync(
+        Document document, ImmutableArray<SyntaxNode> nodes, CancellationToken cancellationToken)
     {
-        var semanticModel = useSemanticDiscovery
-            ? await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false)
-            : null;
-        var (testAttributeTypes, inheritableTestAttributeTypes) = semanticModel is null
-            ? ([], [])
-            : GetTestAttributeTypes(semanticModel.Compilation);
+        var semanticModel = await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        var (testAttributeTypes, inheritableTestAttributeTypes) = GetTestAttributeTypes(semanticModel.Compilation);
 
         return nodes.WhereAsArray(node =>
             node is TMethodDeclaration method &&

--- a/src/Features/Core/Portable/Testing/AbstractTestMethodFinder.cs
+++ b/src/Features/Core/Portable/Testing/AbstractTestMethodFinder.cs
@@ -30,11 +30,10 @@ internal abstract class AbstractTestMethodFinder<TMethodDeclaration>(IEnumerable
 
     protected abstract bool DescendIntoChildren(SyntaxNode node);
 
-    public async Task<ImmutableArray<SyntaxNode>> GetPotentialTestMethodsAsync(Document document, TextSpan textSpan, CancellationToken cancellationToken)
+    public async Task<ImmutableArray<SyntaxNode>> GetPotentialTestMethodsAsync(
+        Document document, TextSpan textSpan, bool useSemanticDiscovery, CancellationToken cancellationToken)
     {
-        var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-
-        var testNodes = await GetPotentialTestNodesAsync(document, textSpan, cancellationToken).ConfigureAwait(false);
+        var testNodes = await GetPotentialTestNodesAsync(document, textSpan, useSemanticDiscovery, cancellationToken).ConfigureAwait(false);
 
         // Find any test methods that intersect with the requested span.
         var intersectingNodes = testNodes.WhereAsArray(node => node.Span.IntersectsWith(textSpan));
@@ -78,20 +77,33 @@ internal abstract class AbstractTestMethodFinder<TMethodDeclaration>(IEnumerable
         return fullyQualifiedMethodName == fullyQualifiedTestName;
     }
 
-    public bool IsTestMethod(SyntaxNode node)
+    public async Task<ImmutableArray<SyntaxNode>> GetTestMethodsAsync(
+        Document document, ImmutableArray<SyntaxNode> nodes, bool useSemanticDiscovery, CancellationToken cancellationToken)
     {
-        return node is TMethodDeclaration method && IsTestMethod(method);
+        var semanticModel = useSemanticDiscovery
+            ? await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false)
+            : null;
+        var testAttributeTypes = semanticModel is null ? [] : GetTestAttributeTypes(semanticModel.Compilation);
+
+        return nodes.WhereAsArray(node =>
+            node is TMethodDeclaration method &&
+            IsTestMethod(method, semanticModel, testAttributeTypes, cancellationToken));
     }
 
-    private async Task<ImmutableArray<SyntaxNode>> GetPotentialTestNodesAsync(Document document, TextSpan textSpan, CancellationToken cancellationToken)
+    private async Task<ImmutableArray<SyntaxNode>> GetPotentialTestNodesAsync(
+        Document document, TextSpan textSpan, bool useSemanticDiscovery, CancellationToken cancellationToken)
     {
         var root = await document.GetRequiredSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
         var methodsInRange = root.DescendantNodesAndSelf(descendIntoChildren: ShouldDescend, descendIntoTrivia: false).OfType<TMethodDeclaration>();
+        var semanticModel = useSemanticDiscovery
+            ? await document.GetRequiredSemanticModelAsync(cancellationToken).ConfigureAwait(false)
+            : null;
+        var testAttributeTypes = semanticModel is null ? [] : GetTestAttributeTypes(semanticModel.Compilation);
 
         using var _ = ArrayBuilder<SyntaxNode>.GetInstance(out var testMethods);
         foreach (var method in methodsInRange)
         {
-            if (IsTestMethod(method))
+            if (IsTestMethod(method, semanticModel, testAttributeTypes, cancellationToken))
             {
                 testMethods.Add(method);
             }
@@ -109,5 +121,55 @@ internal abstract class AbstractTestMethodFinder<TMethodDeclaration>(IEnumerable
             // If the text span doesn't intersect with the node at all we don't need to explore it.
             return node.Span.IntersectsWith(textSpan) && DescendIntoChildren(node);
         }
+    }
+
+    private bool IsTestMethod(
+        TMethodDeclaration method,
+        SemanticModel? semanticModel,
+        ImmutableArray<INamedTypeSymbol> testAttributeTypes,
+        CancellationToken cancellationToken)
+    {
+        if (semanticModel is null)
+        {
+            return IsTestMethod(method);
+        }
+
+        var methodSymbol = semanticModel.GetDeclaredSymbol(method, cancellationToken);
+        if (methodSymbol is null)
+        {
+            return false;
+        }
+
+        foreach (var attribute in methodSymbol.GetAttributes())
+        {
+            for (var attributeType = attribute.AttributeClass; attributeType is not null; attributeType = attributeType.BaseType)
+            {
+                if (testAttributeTypes.Contains(attributeType, SymbolEqualityComparer.Default))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private ImmutableArray<INamedTypeSymbol> GetTestAttributeTypes(Compilation compilation)
+    {
+        using var _ = ArrayBuilder<INamedTypeSymbol>.GetInstance(out var builder);
+
+        foreach (var metadata in TestFrameworkMetadata)
+        {
+            foreach (var metadataName in metadata.TestAttributeMetadataNames)
+            {
+                var attributeType = compilation.GetTypeByMetadataName(metadataName);
+                if (attributeType is not null)
+                {
+                    builder.Add(attributeType);
+                }
+            }
+        }
+
+        return builder.ToImmutableAndClear();
     }
 }

--- a/src/Features/Core/Portable/Testing/ITestMethodFinder.cs
+++ b/src/Features/Core/Portable/Testing/ITestMethodFinder.cs
@@ -19,10 +19,15 @@ internal interface ITestMethodFinder : ILanguageService
     Task<ImmutableArray<SyntaxNode>> GetPotentialTestMethodsAsync(Document document, TextSpan textSpan, bool useSemanticDiscovery, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Finds potential test methods in <paramref name="nodes"/>.
+    /// Determines if the given method node is a potential test method using syntax-only checks.
     /// </summary>
-    Task<ImmutableArray<SyntaxNode>> GetTestMethodsAsync(
-        Document document, ImmutableArray<SyntaxNode> nodes, bool useSemanticDiscovery, CancellationToken cancellationToken);
+    bool IsTestMethod(SyntaxNode node);
+
+    /// <summary>
+    /// Finds potential test methods in <paramref name="nodes"/> using semantic checks.
+    /// </summary>
+    Task<ImmutableArray<SyntaxNode>> GetSemanticTestMethodsAsync(
+        Document document, ImmutableArray<SyntaxNode> nodes, CancellationToken cancellationToken);
 
     /// <summary>
     /// Determines if a node is a likely match for the fully qualified test name.

--- a/src/Features/Core/Portable/Testing/ITestMethodFinder.cs
+++ b/src/Features/Core/Portable/Testing/ITestMethodFinder.cs
@@ -14,15 +14,15 @@ internal interface ITestMethodFinder : ILanguageService
 {
     /// <summary>
     /// Finds potential test methods in the range.  This is not intended to be 100% accurate, but good enough without exploding complexity.
-    /// For example, this does not consider inheritance.
+    /// Semantic discovery recognizes derived test attribute types when enabled.
     /// </summary>
-    Task<ImmutableArray<SyntaxNode>> GetPotentialTestMethodsAsync(Document document, TextSpan textSpan, CancellationToken cancellationToken);
+    Task<ImmutableArray<SyntaxNode>> GetPotentialTestMethodsAsync(Document document, TextSpan textSpan, bool useSemanticDiscovery, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Determines if the given method node is a potential test method.
-    /// This is used in code lens computation, so it generally does syntax-only checks.
+    /// Finds potential test methods in <paramref name="nodes"/>.
     /// </summary>
-    bool IsTestMethod(SyntaxNode node);
+    Task<ImmutableArray<SyntaxNode>> GetTestMethodsAsync(
+        Document document, ImmutableArray<SyntaxNode> nodes, bool useSemanticDiscovery, CancellationToken cancellationToken);
 
     /// <summary>
     /// Determines if a node is a likely match for the fully qualified test name.

--- a/src/Features/Core/Portable/Testing/TestFrameworks/ITestFrameworkMetadata.cs
+++ b/src/Features/Core/Portable/Testing/TestFrameworks/ITestFrameworkMetadata.cs
@@ -2,10 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Immutable;
+
 namespace Microsoft.CodeAnalysis.Features.Testing;
 
 internal interface ITestFrameworkMetadata
 {
+    /// <summary>
+    /// Fully qualified metadata names for test attributes supported by the framework.
+    /// </summary>
+    ImmutableArray<string> TestAttributeMetadataNames { get; }
+
     /// <summary>
     /// Determines if the input attribute token name matches known test method attribute names.
     /// </summary>

--- a/src/Features/Core/Portable/Testing/TestFrameworks/ITestFrameworkMetadata.cs
+++ b/src/Features/Core/Portable/Testing/TestFrameworks/ITestFrameworkMetadata.cs
@@ -14,6 +14,11 @@ internal interface ITestFrameworkMetadata
     ImmutableArray<string> TestAttributeMetadataNames { get; }
 
     /// <summary>
+    /// Whether attributes derived from the framework's test attributes are supported by its test runner.
+    /// </summary>
+    bool SupportsDerivedTestAttributes { get; }
+
+    /// <summary>
     /// Determines if the input attribute token name matches known test method attribute names.
     /// </summary>
     bool MatchesAttributeSyntacticName(string attributeSyntacticName);

--- a/src/Features/Core/Portable/Testing/TestFrameworks/MSTestTestFrameworkMetadata.cs
+++ b/src/Features/Core/Portable/Testing/TestFrameworks/MSTestTestFrameworkMetadata.cs
@@ -15,6 +15,8 @@ internal sealed class MSTestTestFrameworkMetadata : ITestFrameworkMetadata
     public ImmutableArray<string> TestAttributeMetadataNames { get; } =
         ["Microsoft.VisualStudio.TestTools.UnitTesting.TestMethodAttribute"];
 
+    public bool SupportsDerivedTestAttributes => true;
+
     [ImportingConstructor]
     [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
     public MSTestTestFrameworkMetadata()

--- a/src/Features/Core/Portable/Testing/TestFrameworks/MSTestTestFrameworkMetadata.cs
+++ b/src/Features/Core/Portable/Testing/TestFrameworks/MSTestTestFrameworkMetadata.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Immutable;
 using System.Composition;
 using Microsoft.CodeAnalysis.Host.Mef;
 
@@ -11,6 +12,9 @@ namespace Microsoft.CodeAnalysis.Features.Testing;
 [Export(typeof(ITestFrameworkMetadata)), Shared]
 internal sealed class MSTestTestFrameworkMetadata : ITestFrameworkMetadata
 {
+    public ImmutableArray<string> TestAttributeMetadataNames { get; } =
+        ["Microsoft.VisualStudio.TestTools.UnitTesting.TestMethodAttribute"];
+
     [ImportingConstructor]
     [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
     public MSTestTestFrameworkMetadata()

--- a/src/Features/Core/Portable/Testing/TestFrameworks/NUnitTestFrameworkMetadata.cs
+++ b/src/Features/Core/Portable/Testing/TestFrameworks/NUnitTestFrameworkMetadata.cs
@@ -15,6 +15,8 @@ internal sealed class NUnitTestFrameworkMetadata : ITestFrameworkMetadata
     public ImmutableArray<string> TestAttributeMetadataNames { get; } =
         ["NUnit.Framework.TestAttribute", "NUnit.Framework.TheoryAttribute", "NUnit.Framework.TestCaseAttribute", "NUnit.Framework.TestCaseSourceAttribute"];
 
+    public bool SupportsDerivedTestAttributes => false;
+
     [ImportingConstructor]
     [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
     public NUnitTestFrameworkMetadata()

--- a/src/Features/Core/Portable/Testing/TestFrameworks/NUnitTestFrameworkMetadata.cs
+++ b/src/Features/Core/Portable/Testing/TestFrameworks/NUnitTestFrameworkMetadata.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Immutable;
 using System.Composition;
 using Microsoft.CodeAnalysis.Host.Mef;
 
@@ -11,6 +12,9 @@ namespace Microsoft.CodeAnalysis.Features.Testing;
 [Export(typeof(ITestFrameworkMetadata)), Shared]
 internal sealed class NUnitTestFrameworkMetadata : ITestFrameworkMetadata
 {
+    public ImmutableArray<string> TestAttributeMetadataNames { get; } =
+        ["NUnit.Framework.TestAttribute", "NUnit.Framework.TheoryAttribute", "NUnit.Framework.TestCaseAttribute", "NUnit.Framework.TestCaseSourceAttribute"];
+
     [ImportingConstructor]
     [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
     public NUnitTestFrameworkMetadata()

--- a/src/Features/Core/Portable/Testing/TestFrameworks/XUnitTestFrameworkMetadata.cs
+++ b/src/Features/Core/Portable/Testing/TestFrameworks/XUnitTestFrameworkMetadata.cs
@@ -15,6 +15,8 @@ internal sealed class XUnitTestFrameworkMetadata : ITestFrameworkMetadata
     public ImmutableArray<string> TestAttributeMetadataNames { get; } =
         ["Xunit.FactAttribute", "Xunit.TheoryAttribute"];
 
+    public bool SupportsDerivedTestAttributes => true;
+
     [ImportingConstructor]
     [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
     public XUnitTestFrameworkMetadata()

--- a/src/Features/Core/Portable/Testing/TestFrameworks/XUnitTestFrameworkMetadata.cs
+++ b/src/Features/Core/Portable/Testing/TestFrameworks/XUnitTestFrameworkMetadata.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Immutable;
 using System.Composition;
 using Microsoft.CodeAnalysis.Host.Mef;
 
@@ -11,6 +12,9 @@ namespace Microsoft.CodeAnalysis.Features.Testing;
 [Export(typeof(ITestFrameworkMetadata)), Shared]
 internal sealed class XUnitTestFrameworkMetadata : ITestFrameworkMetadata
 {
+    public ImmutableArray<string> TestAttributeMetadataNames { get; } =
+        ["Xunit.FactAttribute", "Xunit.TheoryAttribute"];
+
     [ImportingConstructor]
     [Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
     public XUnitTestFrameworkMetadata()

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Testing/RunTestsHandler.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Testing/RunTestsHandler.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageServer.Handler;
 using Microsoft.CodeAnalysis.LanguageServer.Handler.Testing;
 using Microsoft.CodeAnalysis.LanguageServer.Logging;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.Extensions.Logging;
 using Microsoft.TestPlatform.VsTestConsole.TranslationLayer;
 using LSP = Roslyn.LanguageServer.Protocol;
@@ -17,7 +18,7 @@ namespace Microsoft.CodeAnalysis.LanguageServer.Testing;
 [ExportCSharpVisualBasicLspServiceFactory(typeof(RunTestsHandler)), Shared]
 [method: ImportingConstructor]
 [method: Obsolete(MefConstruction.ImportingConstructorMessage, error: true)]
-internal sealed class RunTestsHandlerFactory(ServerConfiguration serverConfiguration) : ILspServiceFactory
+internal sealed class RunTestsHandlerFactory(ServerConfiguration serverConfiguration, IGlobalOptionService globalOptionService) : ILspServiceFactory
 {
     public ILspService CreateILspService(LspServices lspServices, WellKnownLspServerKinds serverKind)
     {
@@ -25,12 +26,17 @@ internal sealed class RunTestsHandlerFactory(ServerConfiguration serverConfigura
         return new RunTestsHandler(
             new TestDiscoverer(loggerFactory),
             new TestRunner(loggerFactory),
-            serverConfiguration);
+            serverConfiguration,
+            globalOptionService);
     }
 }
 
 [Method(RunTestsMethodName)]
-internal sealed class RunTestsHandler(TestDiscoverer testDiscoverer, TestRunner testRunner, ServerConfiguration serverConfiguration)
+internal sealed class RunTestsHandler(
+    TestDiscoverer testDiscoverer,
+    TestRunner testRunner,
+    ServerConfiguration serverConfiguration,
+    IGlobalOptionService globalOptionService)
     : ILspServiceDocumentRequestHandler<RunTestsParams, RunTestsPartialResult[]>
 {
     private const string RunTestsMethodName = "textDocument/runTests";
@@ -80,7 +86,9 @@ internal sealed class RunTestsHandler(TestDiscoverer testDiscoverer, TestRunner 
 
         var runSettingsPath = request.RunSettingsPath;
         var runSettings = await GetRunSettingsAsync(runSettingsPath, progress, context, cancellationToken);
-        var testCases = await testDiscoverer.DiscoverTestsAsync(request.Range, document, projectOutputPath, runSettings, progress, vsTestConsoleWrapper, cancellationToken);
+        var useSemanticTestDiscovery = globalOptionService.GetOption(LspOptionsStorage.LspUseSemanticTestDiscovery, document.Project.Language);
+        var testCases = await testDiscoverer.DiscoverTestsAsync(
+            request.Range, document, projectOutputPath, runSettings, progress, vsTestConsoleWrapper, useSemanticTestDiscovery, cancellationToken);
         if (!testCases.IsEmpty)
         {
             var clientLanguageServerManager = context.GetRequiredLspService<IClientLanguageServerManager>();

--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Testing/TestDiscoverer.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Testing/TestDiscoverer.cs
@@ -32,6 +32,7 @@ internal sealed partial class TestDiscoverer(ILoggerFactory loggerFactory)
         string? runSettings,
         BufferedProgress<RunTestsPartialResult> progress,
         VsTestConsoleWrapper vsTestConsoleWrapper,
+        bool useSemanticTestDiscovery,
         CancellationToken cancellationToken)
     {
         var partialResult = new RunTestsPartialResult(LanguageServerResources.Discovering_tests, $"{Environment.NewLine}{LanguageServerResources.Starting_test_discovery}", Progress: null);
@@ -40,7 +41,7 @@ internal sealed partial class TestDiscoverer(ILoggerFactory loggerFactory)
         var testMethodFinder = document.GetRequiredLanguageService<ITestMethodFinder>();
 
         // Find any potential test methods (based on attributes) that exist in the input range.
-        var potentialTestMethods = await GetPotentialTestMethodsAsync(range, document, testMethodFinder, cancellationToken);
+        var potentialTestMethods = await GetPotentialTestMethodsAsync(range, document, testMethodFinder, useSemanticTestDiscovery, cancellationToken);
         if (potentialTestMethods.IsEmpty)
         {
             progress.Report(partialResult with { Message = LanguageServerResources.No_test_methods_found_in_requested_range });
@@ -71,11 +72,17 @@ internal sealed partial class TestDiscoverer(ILoggerFactory loggerFactory)
 
         return matchedTests;
 
-        async Task<ImmutableArray<SyntaxNode>> GetPotentialTestMethodsAsync(LSP.Range range, Document document, ITestMethodFinder testMethodFinder, CancellationToken cancellationToken)
+        async Task<ImmutableArray<SyntaxNode>> GetPotentialTestMethodsAsync(
+            LSP.Range range,
+            Document document,
+            ITestMethodFinder testMethodFinder,
+            bool useSemanticTestDiscovery,
+            CancellationToken cancellationToken)
         {
             var text = await document.GetTextAsync(cancellationToken);
             var textSpan = ProtocolConversions.RangeToTextSpan(range, text);
-            var potentialTestMethods = await testMethodFinder.GetPotentialTestMethodsAsync(document, textSpan, cancellationToken);
+            var potentialTestMethods = await testMethodFinder.GetPotentialTestMethodsAsync(
+                document, textSpan, useSemanticTestDiscovery, cancellationToken);
             _logger.LogDebug(message: $"Potential test methods in range: {string.Join(Environment.NewLine, potentialTestMethods)}");
             return potentialTestMethods;
         }

--- a/src/LanguageServer/Protocol/Handler/CodeLens/CodeLensHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/CodeLens/CodeLensHandler.cs
@@ -75,7 +75,8 @@ internal sealed class CodeLensHandler : ILspServiceDocumentRequestHandler<LSP.Co
         if (!globalOptionService.GetOption(LspOptionsStorage.LspUsingDevkitFeatures) && testsCodeLensEnabled)
         {
             // Only return test codelenses if we're not using devkit.
-            AddTestCodeLens(codeLenses, members, document, text, textDocumentIdentifier);
+            var useSemanticTestDiscovery = globalOptionService.GetOption(LspOptionsStorage.LspUseSemanticTestDiscovery, document.Project.Language);
+            await AddTestCodeLensAsync(codeLenses, members, document, text, textDocumentIdentifier, useSemanticTestDiscovery, cancellationToken).ConfigureAwait(false);
         }
 
         return codeLenses.ToArray();
@@ -107,12 +108,14 @@ internal sealed class CodeLensHandler : ILspServiceDocumentRequestHandler<LSP.Co
         }
     }
 
-    private static void AddTestCodeLens(
+    private static async Task AddTestCodeLensAsync(
         ArrayBuilder<LSP.CodeLens> codeLenses,
         ImmutableArray<CodeLensMember> members,
         Document document,
         SourceText text,
-        LSP.TextDocumentIdentifier textDocumentIdentifier)
+        LSP.TextDocumentIdentifier textDocumentIdentifier,
+        bool useSemanticTestDiscovery,
+        CancellationToken cancellationToken)
     {
         var testMethodFinder = document.GetLanguageService<ITestMethodFinder>();
         // The service is not implemented for all languages.
@@ -122,11 +125,14 @@ internal sealed class CodeLensHandler : ILspServiceDocumentRequestHandler<LSP.Co
         }
 
         // Find test method members.
+        var memberNodes = members.SelectAsArray(static member => member.Node);
+        var testMethodNodes = await testMethodFinder.GetTestMethodsAsync(
+            document, memberNodes, useSemanticTestDiscovery, cancellationToken).ConfigureAwait(false);
+
         using var _ = ArrayBuilder<CodeLensMember>.GetInstance(out var testMethodMembers);
         foreach (var member in members)
         {
-            var isTestMethod = testMethodFinder.IsTestMethod(member.Node);
-            if (isTestMethod)
+            if (testMethodNodes.Contains(member.Node))
             {
                 testMethodMembers.Add(member);
             }

--- a/src/LanguageServer/Protocol/Handler/CodeLens/CodeLensHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/CodeLens/CodeLensHandler.cs
@@ -129,10 +129,13 @@ internal sealed class CodeLensHandler : ILspServiceDocumentRequestHandler<LSP.Co
         var testMethodNodes = await testMethodFinder.GetTestMethodsAsync(
             document, memberNodes, useSemanticTestDiscovery, cancellationToken).ConfigureAwait(false);
 
-        using var _ = ArrayBuilder<CodeLensMember>.GetInstance(out var testMethodMembers);
+        using var _1 = PooledHashSet<SyntaxNode>.GetInstance(out var testMethodNodeSet);
+        testMethodNodeSet.UnionWith(testMethodNodes);
+
+        using var _2 = ArrayBuilder<CodeLensMember>.GetInstance(out var testMethodMembers);
         foreach (var member in members)
         {
-            if (testMethodNodes.Contains(member.Node))
+            if (testMethodNodeSet.Contains(member.Node))
             {
                 testMethodMembers.Add(member);
             }

--- a/src/LanguageServer/Protocol/Handler/CodeLens/CodeLensHandler.cs
+++ b/src/LanguageServer/Protocol/Handler/CodeLens/CodeLensHandler.cs
@@ -76,7 +76,14 @@ internal sealed class CodeLensHandler : ILspServiceDocumentRequestHandler<LSP.Co
         {
             // Only return test codelenses if we're not using devkit.
             var useSemanticTestDiscovery = globalOptionService.GetOption(LspOptionsStorage.LspUseSemanticTestDiscovery, document.Project.Language);
-            await AddTestCodeLensAsync(codeLenses, members, document, text, textDocumentIdentifier, useSemanticTestDiscovery, cancellationToken).ConfigureAwait(false);
+            if (useSemanticTestDiscovery)
+            {
+                await AddSemanticTestCodeLensAsync(codeLenses, members, document, text, textDocumentIdentifier, cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                AddTestCodeLens(codeLenses, members, document, text, textDocumentIdentifier);
+            }
         }
 
         return codeLenses.ToArray();
@@ -108,14 +115,12 @@ internal sealed class CodeLensHandler : ILspServiceDocumentRequestHandler<LSP.Co
         }
     }
 
-    private static async Task AddTestCodeLensAsync(
+    private static void AddTestCodeLens(
         ArrayBuilder<LSP.CodeLens> codeLenses,
         ImmutableArray<CodeLensMember> members,
         Document document,
         SourceText text,
-        LSP.TextDocumentIdentifier textDocumentIdentifier,
-        bool useSemanticTestDiscovery,
-        CancellationToken cancellationToken)
+        LSP.TextDocumentIdentifier textDocumentIdentifier)
     {
         var testMethodFinder = document.GetLanguageService<ITestMethodFinder>();
         // The service is not implemented for all languages.
@@ -125,9 +130,36 @@ internal sealed class CodeLensHandler : ILspServiceDocumentRequestHandler<LSP.Co
         }
 
         // Find test method members.
+        using var _ = ArrayBuilder<CodeLensMember>.GetInstance(out var testMethodMembers);
+        foreach (var member in members)
+        {
+            if (testMethodFinder.IsTestMethod(member.Node))
+            {
+                testMethodMembers.Add(member);
+            }
+        }
+
+        AddTestCodeLensCommands(codeLenses, members, testMethodMembers, text, textDocumentIdentifier);
+    }
+
+    private static async Task AddSemanticTestCodeLensAsync(
+        ArrayBuilder<LSP.CodeLens> codeLenses,
+        ImmutableArray<CodeLensMember> members,
+        Document document,
+        SourceText text,
+        LSP.TextDocumentIdentifier textDocumentIdentifier,
+        CancellationToken cancellationToken)
+    {
+        var testMethodFinder = document.GetLanguageService<ITestMethodFinder>();
+        // The service is not implemented for all languages.
+        if (testMethodFinder == null)
+        {
+            return;
+        }
+
         var memberNodes = members.SelectAsArray(static member => member.Node);
-        var testMethodNodes = await testMethodFinder.GetTestMethodsAsync(
-            document, memberNodes, useSemanticTestDiscovery, cancellationToken).ConfigureAwait(false);
+        var testMethodNodes = await testMethodFinder.GetSemanticTestMethodsAsync(
+            document, memberNodes, cancellationToken).ConfigureAwait(false);
 
         using var _1 = PooledHashSet<SyntaxNode>.GetInstance(out var testMethodNodeSet);
         testMethodNodeSet.UnionWith(testMethodNodes);
@@ -141,6 +173,16 @@ internal sealed class CodeLensHandler : ILspServiceDocumentRequestHandler<LSP.Co
             }
         }
 
+        AddTestCodeLensCommands(codeLenses, members, testMethodMembers, text, textDocumentIdentifier);
+    }
+
+    private static void AddTestCodeLensCommands(
+        ArrayBuilder<LSP.CodeLens> codeLenses,
+        ImmutableArray<CodeLensMember> members,
+        ArrayBuilder<CodeLensMember> testMethodMembers,
+        SourceText text,
+        LSP.TextDocumentIdentifier textDocumentIdentifier)
+    {
         // Find any test container members based on the test method members we found (e.g. find the class containing the test methods).
         var testContainerNodes = testMethodMembers.Select(member => member.Node.Parent);
         var testContainerMembers = members.Where(member => testContainerNodes.Contains(member.Node));

--- a/src/LanguageServer/Protocol/Handler/CodeLens/CodeLensRefreshQueue.cs
+++ b/src/LanguageServer/Protocol/Handler/CodeLens/CodeLensRefreshQueue.cs
@@ -40,7 +40,10 @@ internal sealed class CodeLensRefreshQueue : AbstractRefreshQueue
 
     private void OnOptionChanged(object sender, object target, OptionChangedEventArgs e)
     {
-        if (e.HasOption(static option => option.Equals(LspOptionsStorage.LspEnableReferencesCodeLens) || option.Equals(LspOptionsStorage.LspEnableTestsCodeLens)))
+        if (e.HasOption(static option =>
+            option.Equals(LspOptionsStorage.LspEnableReferencesCodeLens) ||
+            option.Equals(LspOptionsStorage.LspEnableTestsCodeLens) ||
+            option.Equals(LspOptionsStorage.LspUseSemanticTestDiscovery)))
         {
             EnqueueRefreshNotification(documentUri: null);
         }

--- a/src/LanguageServer/Protocol/Handler/Configuration/DidChangeConfigurationNotificationHandler_OptionList.cs
+++ b/src/LanguageServer/Protocol/Handler/Configuration/DidChangeConfigurationNotificationHandler_OptionList.cs
@@ -55,6 +55,7 @@ internal sealed partial class DidChangeConfigurationNotificationHandler
         SolutionCrawlerOptionsStorage.CompilerDiagnosticsScopeOption,
         LspOptionsStorage.LspEnableReferencesCodeLens,
         LspOptionsStorage.LspEnableTestsCodeLens,
+        LspOptionsStorage.LspUseSemanticTestDiscovery,
         LspOptionsStorage.LspEnableAutoInsert,
         LanguageServerProjectSystemOptionsStorage.BinaryLogPath,
         LanguageServerProjectSystemOptionsStorage.EnableAutomaticRestore,

--- a/src/LanguageServer/Protocol/LspOptionsStorage.cs
+++ b/src/LanguageServer/Protocol/LspOptionsStorage.cs
@@ -32,6 +32,7 @@ internal sealed class LspOptionsStorage
 
     private static readonly OptionGroup s_codeLensOptionGroup = new(name: "code_lens", description: "");
     private static readonly OptionGroup s_formattingOptionGroup = new(name: "formatting", description: "");
+    private static readonly OptionGroup s_testingOptionGroup = new(name: "testing", description: "");
 
     private static readonly OptionGroup s_autoInsertOptionGroup = new(name: "auto_insert", description: "");
 
@@ -44,6 +45,11 @@ internal sealed class LspOptionsStorage
     /// Flag indicating whether or not test and debug code lens items should be returned.
     /// </summary>
     public static readonly PerLanguageOption2<bool> LspEnableTestsCodeLens = new("dotnet_enable_tests_code_lens", defaultValue: true, group: s_codeLensOptionGroup);
+
+    /// <summary>
+    /// Flag indicating whether test discovery should use semantic information to recognize derived test attributes.
+    /// </summary>
+    public static readonly PerLanguageOption2<bool> LspUseSemanticTestDiscovery = new("dotnet_use_semantic_test_discovery", defaultValue: false, group: s_testingOptionGroup);
 
     /// <summary>
     /// Flag indicating whether or not auto-insert should be abled by default in LSP.

--- a/src/LanguageServer/ProtocolUnitTests/CodeLens/CSharpCodeLensTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/CodeLens/CSharpCodeLensTests.cs
@@ -500,6 +500,79 @@ public sealed class CSharpCodeLensTests : AbstractCodeLensTests
     }
 
     [Theory, CombinatorialData]
+    public async Task TestSemanticDiscoveryFindsDerivedTestAttributeAsync(bool mutatingLspWorkspace)
+    {
+        var markup =
+            """
+            using System;
+            namespace Xunit
+            {
+                [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+                public class FactAttribute : Attribute { }
+            }
+            namespace Test
+            {
+                using Xunit;
+
+                public class ConditionalFactAttribute : FactAttribute { }
+                public sealed class WindowsOnlyFactAttribute : ConditionalFactAttribute { }
+
+                class A
+                {
+                    [WindowsOnlyFact]
+                    public void {|codeLens:M|}()
+                    {
+                    }
+                }
+            }
+            """;
+        await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, new InitializationOptions
+        {
+            ClientCapabilities = CapabilitiesWithVSExtensions,
+            OptionUpdater = (globalOptions) =>
+            {
+                globalOptions.SetGlobalOption(LspOptionsStorage.LspUsingDevkitFeatures, false);
+                globalOptions.SetGlobalOption(LspOptionsStorage.LspUseSemanticTestDiscovery, LanguageNames.CSharp, true);
+            }
+        });
+        await VerifyTestCodeLensAsync(testLspServer, FeaturesResources.Run_Test, FeaturesResources.Debug_Test);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestSemanticDiscoveryDisabledByDefaultAsync(bool mutatingLspWorkspace)
+    {
+        var markup =
+            """
+            using System;
+            namespace Xunit
+            {
+                [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+                public class FactAttribute : Attribute { }
+            }
+            namespace Test
+            {
+                using Xunit;
+
+                public sealed class ConditionalFactAttribute : FactAttribute { }
+
+                class A
+                {
+                    [ConditionalFact]
+                    public void {|codeLens:M|}()
+                    {
+                    }
+                }
+            }
+            """;
+        await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, new InitializationOptions
+        {
+            ClientCapabilities = CapabilitiesWithVSExtensions,
+            OptionUpdater = (globalOptions) => globalOptions.SetGlobalOption(LspOptionsStorage.LspUsingDevkitFeatures, false)
+        });
+        await VerifyTestCodeLensMissingAsync(testLspServer);
+    }
+
+    [Theory, CombinatorialData]
     public async Task TestHasAllTestsCommandAsync(bool mutatingLspWorkspace)
     {
         var markup =

--- a/src/LanguageServer/ProtocolUnitTests/Configuration/DidChangeConfigurationNotificationHandlerTest.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Configuration/DidChangeConfigurationNotificationHandlerTest.cs
@@ -145,6 +145,7 @@ public sealed class DidChangeConfigurationNotificationHandlerTest : AbstractLang
             "background_analysis.dotnet_compiler_diagnostics_scope",
             "code_lens.dotnet_enable_references_code_lens",
             "code_lens.dotnet_enable_tests_code_lens",
+            "testing.dotnet_use_semantic_test_discovery",
             "auto_insert.dotnet_enable_auto_insert",
             "projects.dotnet_binary_log_path",
             "projects.dotnet_enable_automatic_restore",

--- a/src/VisualStudio/Core/Test.Next/Options/VisualStudioOptionStorageTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Options/VisualStudioOptionStorageTests.cs
@@ -243,6 +243,7 @@ public sealed class VisualStudioOptionStorageTests
             "dotnet_lsp_using_devkit",                                                      // VSCode internal only option.  Does not need any UI.
             "dotnet_enable_references_code_lens",                                           // VSCode only option.  Does not apply to VS.
             "dotnet_enable_tests_code_lens",                                                // VSCode only option.  Does not apply to VS.
+            "dotnet_use_semantic_test_discovery",                                           // VSCode only option.  Does not apply to VS.
             "dotnet_enable_auto_insert",                                                    // VSCode only option.  Does not apply to VS.
             "dotnet_organize_imports_on_format",                                            // VSCode only option.  Does not apply to VS.
             "end_of_line",                                                                  // persisted by the editor


### PR DESCRIPTION
Allows LSP clients to opt-in to semantic test discovery which allows code bases with bespoke test attributes to participate in test discovery. Roslyn for instance has ConditionalFact which does not light up under the current syntactic test discovery. 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85255)