### PR TITLE
Use consistent keyword style for discards in symbol displays

### DIFF
--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Members.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Members.cs
@@ -820,7 +820,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     AddSpace();
                 }
-                var kind = symbol.IsThis ? SymbolDisplayPartKind.Keyword : SymbolDisplayPartKind.ParameterName;
+                var kind = symbol.IsThis || symbol.IsDiscard ? SymbolDisplayPartKind.Keyword : SymbolDisplayPartKind.ParameterName;
                 Builder.Add(CreatePart(kind, symbol, symbol.Name));
             }
 

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.cs
@@ -300,7 +300,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 AddSpace();
             }
 
-            Builder.Add(CreatePart(SymbolDisplayPartKind.Punctuation, symbol, "_"));
+            Builder.Add(CreatePart(SymbolDisplayPartKind.Keyword, symbol, "_"));
         }
 
         public override void VisitRangeVariable(IRangeVariableSymbol symbol)

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -8029,7 +8029,7 @@ class C
                 "var _",
                 SymbolDisplayPartKind.ErrorTypeName, // var
                 SymbolDisplayPartKind.Space,
-                SymbolDisplayPartKind.Punctuation); // _
+                SymbolDisplayPartKind.Keyword); // _
         }
 
         [Fact]

--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -3291,7 +3291,10 @@ public sealed class SemanticQuickInfoSourceTests : AbstractSemanticQuickInfoSour
                 }
             }
             """,
-            MainDescription($"({FeaturesResources.discard}) int _"));
+            MainDescription($"({FeaturesResources.discard}) int _"),
+            item => Assert.Equal(TextTags.Keyword,
+                item.Sections.Single(section => section.Kind == QuickInfoSectionKinds.Description)
+                    .TaggedParts.Single(part => part.Text == "_").Tag));
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/16662")]
     public Task TestUnderscoreLocalInAssignment()
@@ -3305,7 +3308,10 @@ public sealed class SemanticQuickInfoSourceTests : AbstractSemanticQuickInfoSour
                 }
             }
             """,
-            MainDescription($"({FeaturesResources.local_variable}) int _"));
+            MainDescription($"({FeaturesResources.local_variable}) int _"),
+            item => Assert.Equal(TextTags.Local,
+                item.Sections.Single(section => section.Kind == QuickInfoSectionKinds.Description)
+                    .TaggedParts.Single(part => part.Text == "_").Tag));
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/16662")]
     public Task TestShortDiscardInOutVar()
@@ -3320,7 +3326,10 @@ public sealed class SemanticQuickInfoSourceTests : AbstractSemanticQuickInfoSour
                 }
             }
             """,
-            MainDescription($"({FeaturesResources.discard}) int _"));
+            MainDescription($"({FeaturesResources.discard}) int _"),
+            item => Assert.Equal(TextTags.Keyword,
+                item.Sections.Single(section => section.Kind == QuickInfoSectionKinds.Description)
+                    .TaggedParts.Single(part => part.Text == "_").Tag));
 
     [Fact, WorkItem("https://github.com/dotnet/roslyn/issues/16667")]
     public Task TestDiscardInOutVar()
@@ -3366,33 +3375,48 @@ public sealed class SemanticQuickInfoSourceTests : AbstractSemanticQuickInfoSour
             }
             """); // No quick info (see issue #16667)
 
-    [Fact]
-    public Task TestLambdaDiscardParameter_FirstDiscard()
+    [Theory]
+    [InlineData("($$_, _) => 1", true)]
+    [InlineData("(string $$_, int _) => 1", true)]
+    [InlineData("delegate(string $$_, int _) { return 1; }", true)]
+    [InlineData("($$_, value) => 1", false)]
+    [InlineData("(string $$_, int value) => 1", false)]
+    [InlineData("delegate(string $$_, int value) { return 1; }", false)]
+    public Task TestAnonymousFunctionDiscardParameter_FirstDiscard(string expression, bool isDiscard)
         => TestAsync(
-            """
+            $$"""
             class C
             {
                 void M()
                 {
-                    System.Func<string, int, int> f = ($$_, _) => 1;
+                    System.Func<string, int, int> f = {{expression}};
                 }
             }
             """,
-            MainDescription($"({FeaturesResources.discard}) string _"));
+            MainDescription($"({(isDiscard ? FeaturesResources.discard : FeaturesResources.parameter)}) string _"),
+            item => Assert.Equal(isDiscard ? TextTags.Keyword : TextTags.Parameter,
+                item.Sections.Single(section => section.Kind == QuickInfoSectionKinds.Description)
+                    .TaggedParts.Single(part => part.Text == "_").Tag));
 
-    [Fact]
-    public Task TestLambdaDiscardParameter_SecondDiscard()
+    [Theory]
+    [InlineData("(_, $$_) => 1")]
+    [InlineData("(string _, int $$_) => 1")]
+    [InlineData("delegate(string _, int $$_) { return 1; }")]
+    public Task TestAnonymousFunctionDiscardParameter_SecondDiscard(string expression)
         => TestAsync(
-            """
+            $$"""
             class C
             {
                 void M()
                 {
-                    System.Func<string, int, int> f = (_, $$_) => 1;
+                    System.Func<string, int, int> f = {{expression}};
                 }
             }
             """,
-            MainDescription($"({FeaturesResources.discard}) int _"));
+            MainDescription($"({FeaturesResources.discard}) int _"),
+            item => Assert.Equal(TextTags.Keyword,
+                item.Sections.Single(section => section.Kind == QuickInfoSectionKinds.Description)
+                    .TaggedParts.Single(part => part.Text == "_").Tag));
 
     [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540871")]
     public Task TestLiterals()


### PR DESCRIPTION
This PR follows #85225 (nothing further planned). Currently, quick info tooltips show discards inconsistently with the code editor, with the `_` shown using the 'parameter name' style for lambda parameter discards and using the 'punctuation' style for `out` parameter discards and for discard assignments:

<img width="600" height="135" alt="image" src="https://github.com/user-attachments/assets/44e452c8-f72d-4719-b3bd-1b0ff0612eaf" />

<img width="369" height="106" alt="image" src="https://github.com/user-attachments/assets/77b88594-73e0-472b-ae5b-c83296db122f" />

<img width="519" height="113" alt="image" src="https://github.com/user-attachments/assets/b7d89341-4116-4437-adbb-06902b3d75e4" />

After this fix, the style matches the code editor:

<img width="595" height="134" alt="image" src="https://github.com/user-attachments/assets/be3efcea-34bd-4ae6-89e1-1279431798ec" />

<img width="391" height="119" alt="image" src="https://github.com/user-attachments/assets/951a259b-b6c9-4e7e-b443-727173637589" />

<img width="517" height="112" alt="image" src="https://github.com/user-attachments/assets/5539e23c-990c-4e56-a9fc-66b6d1821e2a" />

