### PR TITLE
Consolidate warn-as-error flags in build scripts

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -540,7 +540,7 @@ stages:
     steps:
       - template: eng/pipelines/checkout-unix-task.yml
 
-      - script: ./eng/build.sh --solution Roslyn.slnx --restore --build --configuration Debug --prepareMachine --ci --binaryLog --runanalyzers --warnaserror
+      - script: ./eng/build.sh --solution Roslyn.slnx --restore --build --configuration Debug --prepareMachine --ci --binaryLog --runanalyzers
         displayName: Build with analyzers
 
       - template: eng/pipelines/publish-logs.yml

--- a/eng/build-utils.ps1
+++ b/eng/build-utils.ps1
@@ -3,6 +3,9 @@
 Set-StrictMode -version 2.0
 $ErrorActionPreference="Stop"
 
+# Set the repository default before Arcade supplies its own default.
+$warnAsError = if (Test-Path variable:warnAsError) { $warnAsError } elseif (Test-Path variable:ci) { $ci } else { $false }
+
 # Import Arcade functions
 . (Join-Path $PSScriptRoot "common\tools.ps1")
 

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -44,7 +44,7 @@ param (
   [bool][Alias('mt')]$msbuildMultiThreaded = $false,
   [bool]$nodeReuse = $true,
   [switch]$useGlobalNuGetCache = $true,
-  [switch]$warnAsError = $false,
+  [switch]$warnAsError = $ci,
   [string]$warnNotAsError = "",
   [switch][Alias('pb')]$productBuild = $false,
   [switch]$fromVMR = $false,
@@ -129,7 +129,7 @@ function Print-Usage() {
   Write-Host "  -msbuildMultiThreaded <value> Sets MSBuild's multi-threaded mode, i.e. the -mt switch ('1' or '0') (short: -mt)"
   Write-Host "  -nodeReuse <value>        Sets nodereuse msbuild parameter ('1' or '0')"
   Write-Host "  -useGlobalNuGetCache      Use global NuGet cache."
-  Write-Host "  -warnAsError              Treat all warnings as errors"
+  Write-Host "  -warnAsError              Treat all warnings as errors (default: true with -ci)"
   Write-Host "  -warnNotAsError <codes>   Suppress specific warnings from being treated as errors (semi-colon delimited)"
   Write-Host "  -productBuild             Build the repository in product-build mode"
   Write-Host "  -fromVMR                  Set when building from within the VMR"
@@ -827,7 +827,7 @@ try {
   if ($bootstrap -and $bootstrapDir -eq "") {
     Write-Host "Building bootstrap Compiler"
     $bootstrapDir = Join-Path (Join-Path $ArtifactsDir "bootstrap") "build"
-    & eng/make-bootstrap.ps1 -output $bootstrapDir -force -ci:$ci
+    & eng/make-bootstrap.ps1 -output $bootstrapDir -force -ci:$ci -warnAsError:$warnAsError
     Test-LastExitCode
   }
 

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -39,7 +39,7 @@ usage()
   echo "  --prepareMachine           Prepare machine for CI run, clean up processes after build"
   echo "  --msbuildMultiThreaded <value> Sets MSBuild's multi-threaded mode, i.e. the -mt switch ('true' or 'false') (short: --mt)"
   echo "  --nodeReuse <value>        Sets nodereuse msbuild parameter ('true' or 'false')"
-  echo "  --warnAsError              Treat all warnings as errors"
+  echo "  --warnAsError [true|false] Treat all warnings as errors (default: true with --ci)"
   echo "  --warnNotAsError <codes>   Suppress specific warnings from being treated as errors (semi-colon delimited)"
   echo "  --sourceBuild              Build the repository in source-only mode"
   echo "  --productBuild             Build the repository in product-build mode."
@@ -86,7 +86,7 @@ skip_documentation=false
 prepare_machine=false
 # Empty means "not specified"; tools.sh leaves it off unless it's explicitly requested.
 msbuild_multi_threaded=''
-warn_as_error=false
+warn_as_error=""
 warn_not_as_error=""
 properties=()
 source_build=false
@@ -197,6 +197,13 @@ while [[ $# > 0 ]]; do
       ;;
     --warnaserror)
       warn_as_error=true
+      case "${2:-}" in
+        true|false)
+          warn_as_error=$2
+          args="$args $1"
+          shift
+          ;;
+      esac
       ;;
     --warnnotaserror)
       warn_not_as_error=$2
@@ -234,6 +241,9 @@ while [[ $# > 0 ]]; do
   shift
 done
 
+# Resolve the default after parsing so explicit overrides work in either argument order.
+warn_as_error=${warn_as_error:-$ci}
+
 # Import Arcade functions
 . "$scriptroot/common/tools.sh"
 
@@ -248,7 +258,12 @@ function MakeBootstrapBuild {
   local package_name="Microsoft.Net.Compilers.Toolset"
   local project_path=src/NuGet/$package_name/AnyCpu/$package_name.Package.csproj
 
-  dotnet pack -nologo "$project_path" -p:ContinuousIntegrationBuild=$ci -p:DotNetUseShippingVersions=true -p:InitialDefineConstants=BOOTSTRAP -p:PackageOutputPath="$dir" -bl:"$log_dir/Bootstrap.binlog"
+  local msbuild_warn_as_error=""
+  if [[ "$warn_as_error" == true ]]; then
+    msbuild_warn_as_error="/warnAsError"
+  fi
+
+  dotnet pack -nologo "$project_path" -p:TreatWarningsAsErrors=$warn_as_error $msbuild_warn_as_error -p:ContinuousIntegrationBuild=$ci -p:DotNetUseShippingVersions=true -p:InitialDefineConstants=BOOTSTRAP -p:PackageOutputPath="$dir" -bl:"$log_dir/Bootstrap.binlog"
   unzip "$dir/$package_name.*.nupkg" -d "$dir"
   chmod -R 755 "$dir"
 

--- a/eng/make-bootstrap.ps1
+++ b/eng/make-bootstrap.ps1
@@ -6,7 +6,8 @@ param (
   [string]$toolset = "Default",
   [string]$configuration = "Release",
   [switch]$force = $false,
-  [switch]$ci = $false
+  [switch]$ci = $false,
+  [switch]$warnAsError = $ci
 )
 
 Set-StrictMode -version 2.0
@@ -55,10 +56,14 @@ try {
   # that we do not reuse MSBuild nodes from other jobs/builds on the machine. Otherwise,
   # we'll run into issues such as https://github.com/dotnet/roslyn/issues/6211.
   # MSBuildAdditionalCommandLineArgs=
-  $args = "/p:TreatWarningsAsErrors=true /warnaserror /nologo /nodeReuse:false /p:Configuration=$configuration /v:m";
+  $args = "/p:TreatWarningsAsErrors=$warnAsError /nologo /nodeReuse:false /p:Configuration=$configuration /v:m";
   $args += " /p:RunAnalyzersDuringBuild=false /bl:$binaryLogFilePath"
   $args += " /t:Pack /p:DotNetUseShippingVersions=true /p:InitialDefineConstants=BOOTSTRAP"
   $args += " /p:PackageOutputPath=$output /p:NgenOptimization=false /p:PublishWindowsPdb=false"
+
+  if ($warnAsError) {
+    $args += " /warnaserror"
+  }
 
   if ($ci) {
     $args += " /p:ContinuousIntegrationBuild=true"

--- a/eng/test-build-correctness.ps1
+++ b/eng/test-build-correctness.ps1
@@ -15,6 +15,7 @@ param(
   [switch]$enableDumps = $false,
   [string]$bootstrapDir = "",
   [switch]$ci = $false,
+  [switch]$warnAsError = $ci,
   [switch]$help)
 
 Set-StrictMode -version 2.0
@@ -23,6 +24,7 @@ $ErrorActionPreference="Stop"
 function Print-Usage() {
   Write-Host "Usage: test-build-correctness.ps1"
   Write-Host "  -configuration            Build configuration ('Debug' or 'Release')"
+  Write-Host "  -warnAsError              Treat all warnings as errors (default: true with -ci)"
 }
 
 $docBranch = "main"
@@ -53,12 +55,12 @@ try {
   if ($bootstrapDir -eq "") {
     Write-Host "Building bootstrap compiler"
     $bootstrapDir = Join-Path $ArtifactsDir (Join-Path "bootstrap" "correctness")
-    & eng/make-bootstrap.ps1 -output $bootstrapDir -ci:$ci
+    & eng/make-bootstrap.ps1 -output $bootstrapDir -ci:$ci -warnAsError:$warnAsError
     Test-LastExitCode
   }
 
   Write-Host "Building Roslyn"
-  & eng/build.ps1 -restore -build -bootstrapDir:$bootstrapDir -ci:$ci -prepareMachine:$prepareMachine -runAnalyzers:$true -configuration:$configuration -pack -binaryLog -useGlobalNuGetCache:$false -warnAsError:$true
+  & eng/build.ps1 -restore -build -bootstrapDir:$bootstrapDir -ci:$ci -prepareMachine:$prepareMachine -runAnalyzers:$true -configuration:$configuration -pack -binaryLog -useGlobalNuGetCache:$false -warnAsError:$warnAsError
   Test-LastExitCode
 
   Subst-TempDir

--- a/eng/test-determinism.ps1
+++ b/eng/test-determinism.ps1
@@ -4,6 +4,7 @@ param([string]$configuration = "Debug",
       [string]$altRootDrive = "q:",
       [string]$bootstrapDir = "",
       [switch]$ci = $false,
+      [switch]$warnAsError = $ci,
       [switch]$help)
 
 Set-StrictMode -version 2.0
@@ -15,6 +16,7 @@ function Print-Usage() {
   Write-Host "  -msbuildEngine <value>    Msbuild engine to use to run build ('dotnet', 'vs', or unspecified)."
   Write-Host "  -bootstrapDir             Directory containing the bootstrap compiler"
   Write-Host "  -altRootDrive             The drive we build on (via subst) for verifying pathmap implementation"
+  Write-Host "  -warnAsError              Treat all warnings as errors (default: true with -ci)"
 }
 
 if ($help) {
@@ -75,7 +77,7 @@ function Run-Build([string]$rootDir, [string]$logFileName) {
      /p:Features="debug-determinism" `
      /p:DeployExtension=false `
      /p:RepoRoot=$rootDir `
-     /p:TreatWarningsAsErrors=true `
+     /p:TreatWarningsAsErrors=$warnAsError `
      /p:BootstrapBuildPath=$bootstrapDir `
      /p:DeterministicSourcePaths=true `
      /p:RunAnalyzers=false `
@@ -300,7 +302,7 @@ try {
   if ($bootstrapDir -eq "") {
     Write-Host "Building bootstrap compiler"
     $bootstrapDir = Join-Path $ArtifactsDir (Join-Path "bootstrap" "determinism")
-    & eng/make-bootstrap.ps1 -output $bootstrapDir -ci:$ci -force
+    & eng/make-bootstrap.ps1 -output $bootstrapDir -ci:$ci -force -warnAsError:$warnAsError
     Test-LastExitCode
   }
 

--- a/eng/test-rebuild.ps1
+++ b/eng/test-rebuild.ps1
@@ -6,6 +6,7 @@
 param(
   [string]$configuration = "Debug",
   [switch]$ci = $false,
+  [switch]$warnAsError = $ci,
   [switch]$prepareMachine = $false,
   [switch]$useGlobalNuGetCache = $true,
   [switch]$bootstrap = $false,
@@ -18,6 +19,7 @@ function Print-Usage() {
   Write-Host "Usage: test-rebuild.ps1"
   Write-Host "  -configuration            Build configuration ('Debug' or 'Release')"
   Write-Host "  -ci                       Set when running on CI server"
+  Write-Host "  -warnAsError              Treat all warnings as errors (default: true with -ci)"
   Write-Host "  -useGlobalNuGetCache      Use global NuGet cache."
   Write-Host "  -bootstrap                Do a bootstrap build before running the build validatior"
   Write-Host "  -help                     Print help and exit"
@@ -34,7 +36,7 @@ try {
 
   if ($bootstrap) {
     Write-Host "Building Roslyn"
-    & eng/build.ps1 -restore -build -bootstrap -prepareMachine:$prepareMachine -ci:$ci -useGlobalNuGetCache:$useGlobalNuGetCache -configuration:$configuration -pack -binaryLog
+    & eng/build.ps1 -restore -build -bootstrap -prepareMachine:$prepareMachine -ci:$ci -warnAsError:$warnAsError -useGlobalNuGetCache:$useGlobalNuGetCache -configuration:$configuration -pack -binaryLog
     Test-LastExitCode
   }
 

--- a/eng/validate-benchmarks.ps1
+++ b/eng/validate-benchmarks.ps1
@@ -7,7 +7,8 @@
 [CmdletBinding(PositionalBinding=$false)]
 param(
   [string]$configuration = "Release",
-  [switch]$ci = $false)
+  [switch]$ci = $false,
+  [switch]$warnAsError = $ci)
 
 Set-StrictMode -version 2.0
 $ErrorActionPreference="Stop"
@@ -42,6 +43,7 @@ foreach ($entry in $benchmarkProjects) {
     "run"
     "--project", $projectPath
     "-c", $configuration
+    "--property:TreatWarningsAsErrors=$warnAsError"
   )
 
   if ($ci) {

--- a/eng/validate-roslyn-sdk-samples.ps1
+++ b/eng/validate-roslyn-sdk-samples.ps1
@@ -6,7 +6,8 @@
 [CmdletBinding(PositionalBinding=$false)]
 param(
   [string]$configuration = "Release",
-  [switch]$ci = $false)
+  [switch]$ci = $false,
+  [switch]$warnAsError = $ci)
 
 Set-StrictMode -version 2.0
 $ErrorActionPreference="Stop"
@@ -61,9 +62,13 @@ $buildArgs = @(
   $solutionPath
   "-c", $configuration
   "--no-incremental"
-  "--warnaserror"
+  "/p:TreatWarningsAsErrors=$warnAsError"
   "/p:RunAnalyzersDuringBuild=true"
 )
+
+if ($warnAsError) {
+  $buildArgs += "--warnaserror"
+}
 
 if ($ci) {
   $logDir = Join-Path $repoDir "artifacts\log\$configuration"

--- a/eng/validate-rules-missing-documentation.ps1
+++ b/eng/validate-rules-missing-documentation.ps1
@@ -1,6 +1,7 @@
 [CmdletBinding(PositionalBinding=$false)]
 param (
-  [switch]$ci = $false
+  [switch]$ci = $false,
+  [switch]$warnAsError = $ci
 )
 
 Set-StrictMode -version 2.0
@@ -13,7 +14,8 @@ try {
   $prepareMachine = $ci
 
   $projectFilePath = Join-Path $RepoRoot "src\Features\Core\Portable\Microsoft.CodeAnalysis.Features.csproj"
-  Exec-DotNet "build $projectFilePath -t:GenerateRulesMissingDocumentation -p:RunAnalyzersDuringBuild=false -p:ContinuousIntegrationBuild=$ci -c Release"
+  $msbuildWarnAsError = if ($warnAsError) { "/warnAsError" } else { "" }
+  Exec-DotNet "build $projectFilePath -t:GenerateRulesMissingDocumentation -p:RunAnalyzersDuringBuild=false -p:ContinuousIntegrationBuild=$ci -p:TreatWarningsAsErrors=$warnAsError $msbuildWarnAsError -c Release"
 }
 catch {
   Write-Host $_


### PR DESCRIPTION
Makes the behavior of our build scripts' flags more consistent: `-warnAsError` is off by default locally, but on by default if `-ci` is also specified.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85261)