### PR TITLE
Improve IOperation shape for a cast utilizing user-defined conversions

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -2648,6 +2648,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else
                 {
+                    Debug.Assert(false, "Please add test coverage for this code path. Consider covering SemanticModel, Nullable Analysis and IOperation behavior too.");
                     // Conversion method's return type --> conversion's "to" type
                     Conversion fromReturnTypeConversion = Conversions.ClassifyStandardConversion(conversionReturnType, conversionToType, ref useSiteInfo);
                     Debug.Assert(fromReturnTypeConversion.IsNullable);

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundConversion.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundConversion.cs
@@ -114,13 +114,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                     else if ((InConversionGroupFlags & InConversionGroupFlags.UserDefinedReturnTypeAdjustment) != 0)
                     {
+                        Debug.Assert(false, "Please add test coverage for this tree shape. Consider covering SemanticModel, Nullable Analysis and IOperation behavior too.");
                         Debug.Assert((InConversionGroupFlags & InConversionGroupFlags.UserDefinedAllFlags) == InConversionGroupFlags.UserDefinedReturnTypeAdjustment);
                         Debug.Assert(Conversion.IsNullable);
                         Debug.Assert(Conversion.IsImplicit);
                         Debug.Assert(!Conversion.UnderlyingConversions[0].IsIdentity);
                         Debug.Assert(Operand is BoundConversion operandAsConversion &&
                                      operandAsConversion.ConversionGroupOpt == ConversionGroupOpt &&
-                                     operandAsConversion.Conversion.IsUserDefined);
+                                     operandAsConversion.Conversion.IsUserDefined &&
+                                     operandAsConversion.WasCompilerGenerated &&
+                                     operandAsConversion.Syntax == Syntax);
                     }
                     else if ((InConversionGroupFlags & InConversionGroupFlags.UserDefinedFinal) != 0)
                     {
@@ -128,8 +131,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         Debug.Assert(Operand is BoundConversion operandAsConversion &&
                                      operandAsConversion.ConversionGroupOpt == ConversionGroupOpt &&
-                                     (operandAsConversion.Conversion.IsUserDefined ||
-                                      (operandAsConversion.InConversionGroupFlags & InConversionGroupFlags.UserDefinedReturnTypeAdjustment) != 0));
+                                     operandAsConversion.WasCompilerGenerated &&
+                                     operandAsConversion.Conversion.IsUserDefined &&
+                                     operandAsConversion.Syntax == Syntax);
 
                     }
                     else

--- a/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
+++ b/src/Compilers/CSharp/Portable/Operations/CSharpOperationFactory.cs
@@ -1056,6 +1056,25 @@ namespace Microsoft.CodeAnalysis.Operations
             else
             {
                 isImplicit = !boundConversion.ExplicitCastInCode;
+
+                if (isImplicit && boundConversion.ConversionGroupOpt?.Conversion is { IsUserDefined: true, IsValid: true } &&
+                    (boundConversion.InConversionGroupFlags & InConversionGroupFlags.UserDefinedFinal) != 0)
+                {
+                    if (boundConversion.Operand is BoundConversion operandAsConversion &&
+                        operandAsConversion.ConversionGroupOpt == boundConversion.ConversionGroupOpt &&
+                        (operandAsConversion.InConversionGroupFlags & InConversionGroupFlags.UserDefinedOperator) != 0)
+                    {
+                        Debug.Assert(operandAsConversion.WasCompilerGenerated);
+                        if (operandAsConversion.ExplicitCastInCode && (operandAsConversion.WasCompilerGenerated || boundConversion.Syntax != operandAsConversion.Syntax))
+                        {
+                            isImplicit = false;
+                        }
+                    }
+                    else
+                    {
+                        ExceptionUtilities.UnexpectedValue(boundConversion); // Unexpected tree shape
+                    }
+                }
             }
 
             if (boundConversion.ConversionKind == ConversionKind.InterpolatedStringHandler)

--- a/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IConversionExpression.cs
+++ b/src/Compilers/CSharp/Test/IOperation/IOperation/IOperationTests_IConversionExpression.cs
@@ -3458,6 +3458,137 @@ IVariableDeclaratorOperation (Symbol: System.ReadOnlySpan<System.Char> span) (Op
 
         [CompilerTrait(CompilerFeature.IOperation)]
         [Fact]
+        public void Cast_UserDefined_01()
+        {
+            string source = @"
+struct S1
+{
+    public static implicit operator S1(int x) => default;
+}
+
+class Program
+{
+    static void Main()
+    {
+        Test1();
+    }
+
+    static S1? Test1()
+    {
+        return /*<bind>*/ (S1)10 /*</bind>*/;
+    }   
+}
+";
+            string expectedOperationTree = @"
+IConversionOperation (TryCast: False, Unchecked) (OperatorMethod: S1 S1.op_Implicit(System.Int32 x)) (OperationKind.Conversion, Type: S1) (Syntax: '(S1)10')
+  Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: True) (MethodSymbol: S1 S1.op_Implicit(System.Int32 x))
+  Operand:
+    ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 10) (Syntax: '10')
+";
+
+            VerifyOperationTreeAndDiagnosticsForTest<CastExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics: []);
+        }
+
+        [CompilerTrait(CompilerFeature.IOperation)]
+        [Fact]
+        public void Cast_UserDefined_02()
+        {
+            string source = @"
+struct S1
+{
+    public static implicit operator S1(int x) => default;
+}
+
+class Program
+{
+    static void Main()
+    {
+        Test1();
+    }
+
+    static S1? Test1()
+    {
+        return /*<bind>*/ (S1?)10 /*</bind>*/;
+    }   
+}
+";
+            string expectedOperationTree = @"
+IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: S1?) (Syntax: '(S1?)10')
+    Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+    Operand:
+    IConversionOperation (TryCast: False, Unchecked) (OperatorMethod: S1 S1.op_Implicit(System.Int32 x)) (OperationKind.Conversion, Type: S1, IsImplicit) (Syntax: '(S1?)10')
+        Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: True) (MethodSymbol: S1 S1.op_Implicit(System.Int32 x))
+        Operand:
+        ILiteralOperation (OperationKind.Literal, Type: System.Int32, Constant: 10) (Syntax: '10')
+";
+
+            VerifyOperationTreeAndDiagnosticsForTest<CastExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics: []);
+        }
+
+        [CompilerTrait(CompilerFeature.IOperation)]
+        [Fact]
+        public void Cast_UserDefined_03()
+        {
+            string source = @"
+struct S1
+{
+    public static implicit operator int(S1 x) => default;
+}
+
+class Program
+{
+    static long? Test1(S1 x)
+    {
+        return /*<bind>*/ (long?)x /*</bind>*/;
+    }   
+}
+";
+            string expectedOperationTree = @"
+IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: System.Int64?) (Syntax: '(long?)x')
+  Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+  Operand:
+    IConversionOperation (TryCast: False, Unchecked) (OperatorMethod: System.Int32 S1.op_Implicit(S1 x)) (OperationKind.Conversion, Type: System.Int32, IsImplicit) (Syntax: '(long?)x')
+      Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: True) (MethodSymbol: System.Int32 S1.op_Implicit(S1 x))
+      Operand:
+        IParameterReferenceOperation: x (OperationKind.ParameterReference, Type: S1) (Syntax: 'x')
+";
+
+            VerifyOperationTreeAndDiagnosticsForTest<CastExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics: []);
+        }
+
+        [CompilerTrait(CompilerFeature.IOperation)]
+        [Fact]
+        public void Cast_UserDefined_04()
+        {
+            string source = @"
+struct S1
+{
+    public static implicit operator (int a, string b)(S1 x) => default;
+}
+
+class Program
+{
+    static (long c, string d)? Test1(S1 x)
+    {
+        return /*<bind>*/ ((long c, string d)?)x /*</bind>*/;
+    }   
+}
+";
+            string expectedOperationTree = @"
+IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: (System.Int64 c, System.String d)?) (Syntax: '((long c, string d)?)x')
+  Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
+  Operand:
+    IConversionOperation (TryCast: False, Unchecked) (OperatorMethod: (System.Int32 a, System.String b) S1.op_Implicit(S1 x)) (OperationKind.Conversion, Type: (System.Int32 a, System.String b), IsImplicit) (Syntax: '((long c, string d)?)x')
+      Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: True) (MethodSymbol: (System.Int32 a, System.String b) S1.op_Implicit(S1 x))
+      Operand:
+        IParameterReferenceOperation: x (OperationKind.ParameterReference, Type: S1) (Syntax: 'x')
+";
+
+            VerifyOperationTreeAndDiagnosticsForTest<CastExpressionSyntax>(source, expectedOperationTree, expectedDiagnostics: []);
+        }
+
+        [CompilerTrait(CompilerFeature.IOperation)]
+        [Fact]
         public void ConversionExpression_Explicit_ExplicitIdentityConversionCreatesIConversionExpression()
         {
             string source = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/FunctionPointerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/FunctionPointerTests.cs
@@ -647,7 +647,7 @@ ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: delegate*<Syst
   Left:
     IDiscardOperation (Symbol: delegate*<System.Int32*, System.Void> _) (OperationKind.Discard, Type: delegate*<System.Int32*, System.Void>) (Syntax: '_')
   Right:
-    IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: delegate*<System.Int32*, System.Void>, IsImplicit) (Syntax: '(delegate*< ... id>)new S()')
+    IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: delegate*<System.Int32*, System.Void>) (Syntax: '(delegate*< ... id>)new S()')
       Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
       Operand:
         IConversionOperation (TryCast: False, Unchecked) (OperatorMethod: delegate*<System.Void*, System.Void> S.op_Implicit(S _)) (OperationKind.Conversion, Type: delegate*<System.Void*, System.Void>, IsImplicit) (Syntax: '(delegate*< ... id>)new S()')
@@ -694,7 +694,7 @@ ISimpleAssignmentOperation (OperationKind.SimpleAssignment, Type: delegate*<Syst
   Left:
     IDiscardOperation (Symbol: delegate*<System.Int32*, System.Void> _) (OperationKind.Discard, Type: delegate*<System.Int32*, System.Void>) (Syntax: '_')
   Right:
-    IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: delegate*<System.Int32*, System.Void>, IsImplicit) (Syntax: '(delegate*< ... id>)new S()')
+    IConversionOperation (TryCast: False, Unchecked) (OperationKind.Conversion, Type: delegate*<System.Int32*, System.Void>) (Syntax: '(delegate*< ... id>)new S()')
       Conversion: CommonConversion (Exists: True, IsIdentity: False, IsNumeric: False, IsReference: False, IsUserDefined: False) (MethodSymbol: null)
       Operand:
         IConversionOperation (TryCast: False, Unchecked) (OperatorMethod: delegate*<System.Void*, System.Void> S.op_Explicit(S _)) (OperationKind.Conversion, Type: delegate*<System.Void*, System.Void>, IsImplicit) (Syntax: '(delegate*< ... id>)new S()')


### PR DESCRIPTION
Fixes #81781
Related to #85267.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/roslyn/pull/85262)