### PR TITLE
Avoid Enum.HasFlag boxing in the compilers

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.ValueChecks.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -3105,7 +3106,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             string parameterName = parameter.Name;
             if (string.IsNullOrEmpty(parameterName))
             {
-                parameterName = parameter.Ordinal.ToString();
+                parameterName = parameter.Ordinal.ToString(CultureInfo.InvariantCulture);
             }
             return parameterName;
         }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_AnonymousTypes.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_AnonymousTypes.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -90,7 +91,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // build anonymous type field descriptor
                 fieldSyntaxNodes[i] = (nameToken.Kind() == SyntaxKind.IdentifierToken) ? (CSharpSyntaxNode)nameToken.Parent! : fieldInitializer;
                 fields[i] = new AnonymousTypeField(
-                    fieldName == null ? "$" + i.ToString() : fieldName,
+                    fieldName == null ? "$" + i.ToString(CultureInfo.InvariantCulture) : fieldName,
                     fieldSyntaxNodes[i].Location,
                     TypeWithAnnotations.Create(fieldType),
                     RefKind.None,

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -605,7 +605,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var elementType = BindType(node.ElementType, diagnostics, basesBeingResolved);
                 ReportUnsafeIfNotAllowed(node, diagnostics, disallowedUnder: MemorySafetyRulesVersion.Version1);
 
-                if (!Flags.HasFlag(BinderFlags.SuppressConstraintChecks))
+                if ((Flags & BinderFlags.SuppressConstraintChecks) == 0)
                 {
                     CheckManagedAddr(Compilation, elementType.Type, node.Location, diagnostics);
                 }

--- a/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/DecisionDagBuilder.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis.Collections;
@@ -2843,7 +2844,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
                         else
                         {
-                            return name + ".Item" + (t.Index + 1).ToString();
+                            return name + ".Item" + (t.Index + 1).ToString(CultureInfo.InvariantCulture);
                         }
                     }
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -1331,7 +1331,7 @@ outerDefault:
 
         public static bool TryInferParamsCollectionIterationType(Binder binder, TypeSymbol type, out TypeWithAnnotations elementType)
         {
-            if (binder.Flags.HasFlag(BinderFlags.AttributeArgument) && !type.IsSZArray())
+            if ((binder.Flags & BinderFlags.AttributeArgument) != 0 && !type.IsSZArray())
             {
                 // Other collection instances won't be valid arguments for an attribute anyway,
                 // but this way we prevent circularity in some edge cases.

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundDagTemp.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundDagTemp.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using System.Globalization;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Roslyn.Utilities;
 
@@ -73,7 +74,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else
                 {
-                    return name + ".Item" + (Index + 1).ToString();
+                    return name + ".Item" + (Index + 1).ToString(CultureInfo.InvariantCulture);
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNode_Source.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNode_Source.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Roslyn.Utilities;
@@ -537,7 +538,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         tempIdentifiers.Add(local, identifier);
                     }
 
-                    return "temp" + identifier.ToString();
+                    return "temp" + identifier.ToString(CultureInfo.InvariantCulture);
                 }
 
                 void appendLocal(LocalSymbol symbol)

--- a/src/Compilers/CSharp/Portable/BoundTree/Formatting.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Formatting.cs
@@ -5,6 +5,7 @@
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 using System.Diagnostics;
+using System.Globalization;
 using System.Runtime.CompilerServices;
 
 namespace Microsoft.CodeAnalysis.CSharp
@@ -206,7 +207,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 for (int i = 1; i < arguments.Length; i++)
                 {
-                    builder.Append($", {{{i.ToString()}}}");
+                    builder.Append($", {{{i.ToString(CultureInfo.InvariantCulture)}}}");
                     argumentDisplays[i] = arguments[i].Display;
                 }
 

--- a/src/Compilers/CSharp/Portable/Microsoft.CodeAnalysis.CSharp.csproj
+++ b/src/Compilers/CSharp/Portable/Microsoft.CodeAnalysis.CSharp.csproj
@@ -35,6 +35,7 @@
     <None Include="BoundTree\BoundNodes.xsd" />
     <None Include="Generated\CSharp.Generated.g4" />
     <AdditionalFiles Include="Syntax\Syntax.xml" />
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)..\..\Core\Portable\BannedSymbols.CompilerLibraries.txt" />
     <None Include="Syntax\Syntax.xsd" />
     <None Include="UseSiteDiagnosticsCheckEnforcer\BaseLine.txt" />
     <None Include="UseSiteDiagnosticsCheckEnforcer\Run.bat" />

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -5365,7 +5365,7 @@ parse_member_name:;
                     // We also accept: `for (int i = 0, ;` as that's likely an intermediary state prior to writing the
                     // next variable. Anything else we'll treat as as more likely to be the following conditional.
 
-                    if (flags.HasFlag(VariableFlags.ForStatement) && this.PeekToken(1).Kind != SyntaxKind.SemicolonToken)
+                    if ((flags & VariableFlags.ForStatement) != 0 && this.PeekToken(1).Kind != SyntaxKind.SemicolonToken)
                     {
                         var isLegalVariableDeclaratorStart =
                             IsTrueIdentifier(this.PeekToken(1)) &&

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser_Patterns.cs
@@ -572,7 +572,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             // However, such behavior isn't much desirable when parsing pattern of a case label in a switch statement. For instance, consider the following example: `case { Prop: { }: case ...`.
             // Normally we would skip second `:` and `case` keyword after it as bad tokens and continue parsing pattern, which produces a lot of noise errors.
             // In order to avoid that and produce single error of missing `}` we exit on unexpected `:` in such cases.
-            if (@this._termState.HasFlag(TerminatorState.IsExpressionOrPatternInCaseLabelOfSwitchStatement) && @this.CurrentToken.Kind is SyntaxKind.ColonToken)
+            if ((@this._termState & TerminatorState.IsExpressionOrPatternInCaseLabelOfSwitchStatement) != 0 && @this.CurrentToken.Kind is SyntaxKind.ColonToken)
                 return PostSkipAction.Abort;
 
             // This is pretty much the same as above, but for switch expressions and `=>` and `:` tokens.
@@ -581,7 +581,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             // However, if we treated `=>` as "exit" token, parsing wouldn't consume full case label properly and would produce a lot of noise errors.
             // We can afford `:` to be the exit token for switch expressions because error recovery is already good enough and treats `:` as bad `=>`,
             // meaning that switch expression arm `{ : 1` can be recovered to `{ } => 1` where the closing `}` is missing and instead of `=>` we have `:`.
-            if (@this._termState.HasFlag(TerminatorState.IsPatternInSwitchExpressionArm) && @this.CurrentToken.Kind is SyntaxKind.EqualsGreaterThanToken or SyntaxKind.ColonToken)
+            if ((@this._termState & TerminatorState.IsPatternInSwitchExpressionArm) != 0 && @this.CurrentToken.Kind is SyntaxKind.EqualsGreaterThanToken or SyntaxKind.ColonToken)
                 return PostSkipAction.Abort;
 
             return @this.SkipBadSeparatedListTokensWithExpectedKind(ref open, list,

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/ObjectDisplay.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/ObjectDisplay.cs
@@ -319,7 +319,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (options.IncludesOption(ObjectDisplayOptions.IncludeCodePoints))
             {
-                builder.Append(options.IncludesOption(ObjectDisplayOptions.UseHexadecimalNumbers) ? "0x" + ((int)c).ToString("x4") : ((int)c).ToString());
+                builder.Append(options.IncludesOption(ObjectDisplayOptions.UseHexadecimalNumbers) ? "0x" + ((int)c).ToString("x4") : ((int)c).ToString(CultureInfo.InvariantCulture));
                 builder.Append(' ');
             }
 

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplay.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplay.cs
@@ -289,7 +289,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             symbol.Accept(visitor);
 
             if (symbol is INamedTypeSymbol { IsExtension: true } extension
-                && format.CompilerInternalOptions.HasFlag(SymbolDisplayCompilerInternalOptions.UseMetadataMemberNames))
+                && (format.CompilerInternalOptions & SymbolDisplayCompilerInternalOptions.UseMetadataMemberNames) != 0)
             {
                 visitor.AddExtensionMarkerName(extension);
             }

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
@@ -309,7 +309,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private void AddNestedTypeSeparator()
         {
-            AddPunctuation(Format.CompilerInternalOptions.HasFlag(SymbolDisplayCompilerInternalOptions.UsePlusForNestedTypes) ? SyntaxKind.PlusToken : SyntaxKind.DotToken);
+            AddPunctuation((Format.CompilerInternalOptions & SymbolDisplayCompilerInternalOptions.UsePlusForNestedTypes) != 0 ? SyntaxKind.PlusToken : SyntaxKind.DotToken);
         }
 
         private bool ShouldDisplayAsValueTuple(INamedTypeSymbol symbol)
@@ -340,7 +340,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             NamedTypeSymbol? underlyingTypeSymbol = (symbol as Symbols.PublicModel.NamedTypeSymbol)?.UnderlyingNamedTypeSymbol;
             if (symbol.IsExtension)
             {
-                if (Format.CompilerInternalOptions.HasFlag(SymbolDisplayCompilerInternalOptions.UseMetadataMemberNames))
+                if ((Format.CompilerInternalOptions & SymbolDisplayCompilerInternalOptions.UseMetadataMemberNames) != 0)
                 {
                     Builder.Add(CreatePart(SymbolDisplayPartKind.ClassName, symbol, symbol.ExtensionGroupingName));
                 }
@@ -465,7 +465,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             void addExtensionParameter(INamedTypeSymbol symbol)
             {
-                if (!Format.CompilerInternalOptions.HasFlag(SymbolDisplayCompilerInternalOptions.UseMetadataMemberNames)
+                if ((Format.CompilerInternalOptions & SymbolDisplayCompilerInternalOptions.UseMetadataMemberNames) == 0
                     && symbol.ExtensionParameter is { } extensionParameter)
                 {
                     AddPunctuation(SyntaxKind.OpenParenToken);

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -466,7 +466,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 doGetExtensionMembers(members, name, alternativeName, arity, options, ref implementationsToShadow, fieldsBeingBound);
             }
 
-            if (!options.HasFlag(LookupOptions.MustBeOperator))
+            if ((options & LookupOptions.MustBeOperator) == 0)
             {
                 DoGetExtensionMethods(members, name, arity, options, implementationsToShadow);
                 if (alternativeName is not null)

--- a/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.ByteTC.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.ByteTC.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -56,7 +57,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             ConstantValue INumericTC<byte>.ToConstantValue(byte value) => ConstantValue.Create(value);
 
-            string INumericTC<byte>.ToString(byte value) => value.ToString();
+            string INumericTC<byte>.ToString(byte value) => value.ToString(CultureInfo.InvariantCulture);
 
             byte INumericTC<byte>.Random(Random random)
             {

--- a/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.IntTC.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.IntTC.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -66,7 +67,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             public ConstantValue ToConstantValue(int value) => ConstantValue.Create(value);
 
-            string INumericTC<int>.ToString(int value) => value.ToString();
+            string INumericTC<int>.ToString(int value) => value.ToString(CultureInfo.InvariantCulture);
 
             public int Random(Random random)
             {

--- a/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.LongTC.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.LongTC.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -56,7 +57,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             ConstantValue INumericTC<long>.ToConstantValue(long value) => ConstantValue.Create(value);
 
-            string INumericTC<long>.ToString(long value) => value.ToString();
+            string INumericTC<long>.ToString(long value) => value.ToString(CultureInfo.InvariantCulture);
 
             long INumericTC<long>.Random(Random random)
             {

--- a/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.SByteTC.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.SByteTC.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -55,7 +56,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             public ConstantValue ToConstantValue(sbyte value) => ConstantValue.Create(value);
 
-            string INumericTC<sbyte>.ToString(sbyte value) => value.ToString();
+            string INumericTC<sbyte>.ToString(sbyte value) => value.ToString(CultureInfo.InvariantCulture);
 
             sbyte INumericTC<sbyte>.Random(Random random)
             {

--- a/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.ShortTC.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.ShortTC.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -56,7 +57,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             ConstantValue INumericTC<short>.ToConstantValue(short value) => ConstantValue.Create(value);
 
-            string INumericTC<short>.ToString(short value) => value.ToString();
+            string INumericTC<short>.ToString(short value) => value.ToString(CultureInfo.InvariantCulture);
 
             short INumericTC<short>.Random(Random random)
             {

--- a/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.StringTC.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.StringTC.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -33,7 +34,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     int remain = scope - i;
                     if (random.NextDouble() * remain < need)
                     {
-                        result[next++] = i.ToString();
+                        result[next++] = i.ToString(CultureInfo.InvariantCulture);
                     }
                 }
 

--- a/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.UIntTC.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.UIntTC.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -50,7 +51,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             public ConstantValue ToConstantValue(uint value) => ConstantValue.Create(value);
 
-            string INumericTC<uint>.ToString(uint value) => value.ToString();
+            string INumericTC<uint>.ToString(uint value) => value.ToString(CultureInfo.InvariantCulture);
 
             uint INumericTC<uint>.Prev(uint value)
             {

--- a/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.ULongTC.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.ULongTC.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -56,7 +57,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             ConstantValue INumericTC<ulong>.ToConstantValue(ulong value) => ConstantValue.Create(value);
 
-            string INumericTC<ulong>.ToString(ulong value) => value.ToString();
+            string INumericTC<ulong>.ToString(ulong value) => value.ToString(CultureInfo.InvariantCulture);
 
             ulong INumericTC<ulong>.Random(Random random)
             {

--- a/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.UShortTC.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/ValueSetFactory.UShortTC.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -50,7 +51,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             ConstantValue INumericTC<ushort>.ToConstantValue(ushort value) => ConstantValue.Create(value);
 
-            string INumericTC<ushort>.ToString(ushort value) => value.ToString();
+            string INumericTC<ushort>.ToString(ushort value) => value.ToString(CultureInfo.InvariantCulture);
 
             ushort INumericTC<ushort>.Prev(ushort value)
             {

--- a/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
@@ -1951,7 +1951,7 @@ comp => comp.VerifyDiagnostics(
             using (var reader = new PEReader(image))
             {
                 var flags = reader.PEHeaders.CorHeader.Flags;
-                Assert.Equal(expectSigned, flags.HasFlag(CorFlags.StrongNameSigned));
+                Assert.Equal(expectSigned, (flags & CorFlags.StrongNameSigned) != 0);
             }
         }
 
@@ -3610,7 +3610,7 @@ class C
             Assert.False(peHeaders.Requires64Bits());
             Assert.True(peHeaders.IsDll);
             Assert.False(peHeaders.IsExe);
-            Assert.False(peHeaders.CoffHeader.Characteristics.HasFlag(Characteristics.LargeAddressAware));
+            Assert.False((peHeaders.CoffHeader.Characteristics & Characteristics.LargeAddressAware) != 0);
             //interesting Optional PE header bits
             //We will use a range beginning with 0x30 to identify the Roslyn compiler family.
             Assert.Equal(0x30, peHeaders.PEHeader.MajorLinkerVersion);
@@ -3644,7 +3644,7 @@ class C
             Assert.True(peHeaders.Requires64Bits());
             Assert.True(peHeaders.IsDll);
             Assert.False(peHeaders.IsExe);
-            Assert.True(peHeaders.CoffHeader.Characteristics.HasFlag(Characteristics.LargeAddressAware));
+            Assert.True((peHeaders.CoffHeader.Characteristics & Characteristics.LargeAddressAware) != 0);
             //interesting Optional PE header bits
             //We will use a range beginning with 0x30 to identify the Roslyn compiler family.
             Assert.Equal(0x30, peHeaders.PEHeader.MajorLinkerVersion);
@@ -3694,7 +3694,7 @@ class C
             Assert.False(peHeaders.Requires64Bits());
             Assert.True(peHeaders.IsDll);
             Assert.False(peHeaders.IsExe);
-            Assert.True(peHeaders.CoffHeader.Characteristics.HasFlag(Characteristics.LargeAddressAware));
+            Assert.True((peHeaders.CoffHeader.Characteristics & Characteristics.LargeAddressAware) != 0);
             //interesting Optional PE header bits
             //We will use a range beginning with 0x30 to identify the Roslyn compiler family.
             Assert.Equal(0x30, peHeaders.PEHeader.MajorLinkerVersion);
@@ -3734,7 +3734,7 @@ class C
             Assert.False(peHeaders.Requires64Bits());
             Assert.True(peHeaders.IsExe);
             Assert.False(peHeaders.IsDll);
-            Assert.True(peHeaders.CoffHeader.Characteristics.HasFlag(Characteristics.LargeAddressAware));
+            Assert.True((peHeaders.CoffHeader.Characteristics & Characteristics.LargeAddressAware) != 0);
             //interesting Optional PE header bits
             //We will use a range beginning with 0x30 to identify the Roslyn compiler family.
             Assert.Equal(0x30, peHeaders.PEHeader.MajorLinkerVersion);
@@ -3774,7 +3774,7 @@ class C
             Assert.True(peHeaders.Requires64Bits());
             Assert.True(peHeaders.IsExe);
             Assert.False(peHeaders.IsDll);
-            Assert.True(peHeaders.CoffHeader.Characteristics.HasFlag(Characteristics.LargeAddressAware));
+            Assert.True((peHeaders.CoffHeader.Characteristics & Characteristics.LargeAddressAware) != 0);
             //interesting Optional PE header bits
             //We will use a range beginning with 0x30 to identify the Roslyn compiler family.
             Assert.Equal(0x30, peHeaders.PEHeader.MajorLinkerVersion);

--- a/src/Compilers/CSharp/Test/Emit3/Attributes/InternalsVisibleToAndStrongNameTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/Attributes/InternalsVisibleToAndStrongNameTests.cs
@@ -594,7 +594,7 @@ public class C {}
                 using (var reader = new PEReader(outStream))
                 {
                     var flags = reader.PEHeaders.CorHeader.Flags;
-                    Assert.Equal(expectedToBeSigned, flags.HasFlag(CorFlags.StrongNameSigned));
+                    Assert.Equal(expectedToBeSigned, (flags & CorFlags.StrongNameSigned) != 0);
                 }
             }
         }

--- a/src/Compilers/CSharp/Test/Emit3/PartialEventsAndConstructorsTests.cs
+++ b/src/Compilers/CSharp/Test/Emit3/PartialEventsAndConstructorsTests.cs
@@ -1890,7 +1890,7 @@ public sealed class PartialEventsAndConstructorsTests : CSharpTestBase
         {
             Assert.True(accessor.GetPublicSymbol().IsExtern);
             Assert.Equal(expectedMetadataName, accessor.MetadataName);
-            Assert.False(accessor.ImplementationAttributes.HasFlag(MethodImplAttributes.Synchronized));
+            Assert.False((accessor.ImplementationAttributes & MethodImplAttributes.Synchronized) != 0);
 
             var importData = accessor.GetDllImportData()!;
             Assert.Equal("something.dll", importData.ModuleName);
@@ -1934,11 +1934,11 @@ public sealed class PartialEventsAndConstructorsTests : CSharpTestBase
             Assert.True(ev.AddMethod!.GetPublicSymbol().IsExtern);
             Assert.Null(ev.AddMethod!.GetDllImportData());
             Assert.Equal(MethodImplAttributes.InternalCall, ev.AddMethod.ImplementationAttributes);
-            Assert.False(ev.AddMethod.ImplementationAttributes.HasFlag(MethodImplAttributes.Synchronized));
+            Assert.False((ev.AddMethod.ImplementationAttributes & MethodImplAttributes.Synchronized) != 0);
             Assert.True(ev.RemoveMethod!.GetPublicSymbol().IsExtern);
             Assert.Null(ev.RemoveMethod!.GetDllImportData());
             Assert.Equal(MethodImplAttributes.InternalCall, ev.RemoveMethod.ImplementationAttributes);
-            Assert.False(ev.RemoveMethod.ImplementationAttributes.HasFlag(MethodImplAttributes.Synchronized));
+            Assert.False((ev.RemoveMethod.ImplementationAttributes & MethodImplAttributes.Synchronized) != 0);
 
             var c = module.GlobalNamespace.GetMember<SourceConstructorSymbol>("C..ctor");
             Assert.True(c.GetPublicSymbol().IsExtern);
@@ -1953,11 +1953,11 @@ public sealed class PartialEventsAndConstructorsTests : CSharpTestBase
             Assert.False(ev.AddMethod!.GetPublicSymbol().IsExtern);
             Assert.Null(ev.AddMethod!.GetDllImportData());
             Assert.Equal(MethodImplAttributes.InternalCall, ev.AddMethod.ImplementationAttributes);
-            Assert.False(ev.AddMethod.ImplementationAttributes.HasFlag(MethodImplAttributes.Synchronized));
+            Assert.False((ev.AddMethod.ImplementationAttributes & MethodImplAttributes.Synchronized) != 0);
             Assert.False(ev.RemoveMethod!.GetPublicSymbol().IsExtern);
             Assert.Null(ev.RemoveMethod!.GetDllImportData());
             Assert.Equal(MethodImplAttributes.InternalCall, ev.RemoveMethod.ImplementationAttributes);
-            Assert.False(ev.RemoveMethod.ImplementationAttributes.HasFlag(MethodImplAttributes.Synchronized));
+            Assert.False((ev.RemoveMethod.ImplementationAttributes & MethodImplAttributes.Synchronized) != 0);
 
             var c = module.GlobalNamespace.GetMember<MethodSymbol>("C..ctor");
             Assert.False(c.GetPublicSymbol().IsExtern);
@@ -2073,8 +2073,8 @@ public sealed class PartialEventsAndConstructorsTests : CSharpTestBase
         static void validate(ModuleSymbol module)
         {
             var e = module.GlobalNamespace.GetMember<EventSymbol>("C.E");
-            Assert.True(e.AddMethod!.ImplementationAttributes.HasFlag(MethodImplAttributes.Synchronized));
-            Assert.True(e.RemoveMethod!.ImplementationAttributes.HasFlag(MethodImplAttributes.Synchronized));
+            Assert.True((e.AddMethod!.ImplementationAttributes & MethodImplAttributes.Synchronized) != 0);
+            Assert.True((e.RemoveMethod!.ImplementationAttributes & MethodImplAttributes.Synchronized) != 0);
         }
     }
 

--- a/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/SourceGeneration/GeneratorDriverTests.cs
@@ -3544,7 +3544,7 @@ class C { }
                 if (kind == IncrementalGeneratorOutputKind.None)
                     continue;
 
-                if (disabledOutput.HasFlag(kind))
+                if ((disabledOutput & kind) == kind)
                 {
                     if (kind == IncrementalGeneratorOutputKind.Host)
                     {

--- a/src/Compilers/Core/Portable/BannedSymbols.CompilerLibraries.txt
+++ b/src/Compilers/Core/Portable/BannedSymbols.CompilerLibraries.txt
@@ -1,3 +1,4 @@
+M:System.Enum.HasFlag(System.Enum); Use bitwise operations instead to avoid boxing on .NET Framework.
 M:System.IO.Path.GetTempPath(); Cannot be used safely in APIs or compiler server as underlying environment variables can change during build.
 P:System.Environment.CurrentDirectory; Cannot be used safely in APIs or compiler server as underlying environment variables can change during build.
 M:System.Text.StringBuilder.Append(System.SByte); Use ToString(CultureInfo.InvariantCulture) to avoid culture-sensitive formatting.

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AsyncQueue.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AsyncQueue.cs
@@ -99,7 +99,7 @@ retry:
                 waiter = _waiters.Dequeue();
             }
 
-            Debug.Assert(waiter.Task.CreationOptions.HasFlag(TaskCreationOptions.RunContinuationsAsynchronously));
+            Debug.Assert((waiter.Task.CreationOptions & TaskCreationOptions.RunContinuationsAsynchronously) != 0);
             if (!waiter.TrySetResult(value))
             {
                 // A waiter was available in the queue, but was cancelled before we were able to assign this value
@@ -197,12 +197,12 @@ retry:
                 Debug.Assert(this.Count == 0, "we should not be cancelling the waiters when we have items in the queue");
                 foreach (var tcs in existingWaiters)
                 {
-                    Debug.Assert(tcs.Task.CreationOptions.HasFlag(TaskCreationOptions.RunContinuationsAsynchronously));
+                    Debug.Assert((tcs.Task.CreationOptions & TaskCreationOptions.RunContinuationsAsynchronously) != 0);
                     tcs.TrySetResult(default);
                 }
             }
 
-            Debug.Assert(_whenCompleted.Task.CreationOptions.HasFlag(TaskCreationOptions.RunContinuationsAsynchronously));
+            Debug.Assert((_whenCompleted.Task.CreationOptions & TaskCreationOptions.RunContinuationsAsynchronously) != 0);
             _whenCompleted.SetResult(true);
 
             return true;
@@ -313,7 +313,7 @@ retry:
                 cancelableTaskCompletionSource,
                 useSynchronizationContext: false);
 
-            Debug.Assert(taskCompletionSource.Task.CreationOptions.HasFlag(TaskCreationOptions.RunContinuationsAsynchronously));
+            Debug.Assert((taskCompletionSource.Task.CreationOptions & TaskCreationOptions.RunContinuationsAsynchronously) != 0);
             taskCompletionSource.Task.ContinueWith(
                 static (_, s) =>
                 {

--- a/src/Compilers/Core/Portable/MetadataReference/ModuleMetadata.cs
+++ b/src/Compilers/Core/Portable/MetadataReference/ModuleMetadata.cs
@@ -229,7 +229,7 @@ namespace Microsoft.CodeAnalysis
             {
                 unsafe
                 {
-                    Action? onDispose = options.HasFlag(PEStreamOptions.LeaveOpen)
+                    Action? onDispose = (options & PEStreamOptions.LeaveOpen) != 0
                         ? null
                         : unmanagedMemoryStream.Dispose;
 

--- a/src/Compilers/Core/Portable/PEWriter/PeWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/PeWriter.cs
@@ -295,7 +295,7 @@ namespace Microsoft.Cci
 
                 PatchModuleVersionIds(mvidFixup, mvidSectionFixup, mvidStringFixup, peContentId.Guid);
 
-                if (privateKeyOpt != null && corFlags.HasFlag(CorFlags.StrongNameSigned))
+                if (privateKeyOpt != null && (corFlags & CorFlags.StrongNameSigned) != 0)
                 {
                     Debug.Assert(strongNameProvider != null);
                     strongNameProvider.SignBuilder(peBuilder, emitBuilders.PortableExecutableBlobBuilder, privateKeyOpt.Value);

--- a/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/GeneratorDriver.cs
@@ -492,7 +492,7 @@ namespace Microsoft.CodeAnalysis
                 foreach (var outputNode in outputNodes)
                 {
                     // if we're looking for this output kind, and it has not been explicitly disabled
-                    if (outputKind.HasFlag(outputNode.Kind) && !_state.DisabledOutputs.HasFlag(outputNode.Kind))
+                    if ((outputKind & outputNode.Kind) == outputNode.Kind && (_state.DisabledOutputs & outputNode.Kind) != outputNode.Kind)
                     {
                         outputNode.AppendOutputs(context, cancellationToken);
                     }

--- a/src/Compilers/Core/Portable/SourceGeneration/Nodes/SyntaxValueProvider_ForAttributeWithSimpleName.cs
+++ b/src/Compilers/Core/Portable/SourceGeneration/Nodes/SyntaxValueProvider_ForAttributeWithSimpleName.cs
@@ -68,7 +68,7 @@ public partial struct SyntaxValueProvider
 
         // Create a provider that provides (and updates) the global aliases for any particular file when it is edited.
         var individualFileGlobalAliasesProvider = syntaxTreesProvider
-            .Where(static (info, _) => info.Info.HasFlag(SourceGeneratorSyntaxTreeInfo.ContainsGlobalAliases))
+            .Where(static (info, _) => (info.Info & SourceGeneratorSyntaxTreeInfo.ContainsGlobalAliases) != 0)
             .Select((info, cancellationToken) => getGlobalAliasesInCompilationUnit(syntaxHelper, info.Tree.GetRoot(cancellationToken)))
             .WithTrackingName("individualFileGlobalAliases_ForAttribute");
 
@@ -100,7 +100,7 @@ public partial struct SyntaxValueProvider
         // Combine the two providers so that we reanalyze every file if the global aliases change, or we reanalyze a
         // particular file when it's compilation unit changes.
         var syntaxTreeAndGlobalAliasesProvider = syntaxTreesProvider
-            .Where(static (info, _) => info.Info.HasFlag(SourceGeneratorSyntaxTreeInfo.ContainsAttributeList))
+            .Where(static (info, _) => (info.Info & SourceGeneratorSyntaxTreeInfo.ContainsAttributeList) != 0)
             .Combine(allUpGlobalAliasesProvider)
             .WithTrackingName("compilationUnitAndGlobalAliases_ForAttribute");
 

--- a/src/Compilers/Test/Core/CompilationVerifier.cs
+++ b/src/Compilers/Test/Core/CompilationVerifier.cs
@@ -365,7 +365,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                     DumpAssemblyData(emitData.Modules, dumpPath);
                 }
 
-                if (peVerify.Status.HasFlag(VerificationStatus.PassesOrFailFast))
+                if ((peVerify.Status & VerificationStatus.PassesOrFailFast) != 0)
                 {
                     var il = DumpIL();
                     Console.WriteLine(il);
@@ -436,7 +436,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
         internal static void ILVerify(Verification verification, ModuleData mainModule, ImmutableArray<ModuleData> modules)
         {
-            if (verification.Status.HasFlag(VerificationStatus.Skipped))
+            if ((verification.Status & VerificationStatus.Skipped) != 0)
             {
                 return;
             }
@@ -447,7 +447,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 string name = module.SimpleName;
                 if (readersByName.ContainsKey(name))
                 {
-                    if (verification.Status.HasFlag(VerificationStatus.FailsILVerify) && verification.ILVerifyMessage is null)
+                    if ((verification.Status & VerificationStatus.FailsILVerify) != 0 && verification.ILVerifyMessage is null)
                     {
                         return;
                     }
@@ -462,7 +462,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             var mscorlibModule = modules.SingleOrDefault(m => m.IsCorLib);
             if (mscorlibModule is null)
             {
-                if (verification.Status.HasFlag(VerificationStatus.FailsILVerify) && verification.ILVerifyMessage is null)
+                if ((verification.Status & VerificationStatus.FailsILVerify) != 0 && verification.ILVerifyMessage is null)
                 {
                     return;
                 }
@@ -474,7 +474,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             var mainModuleReader = resolver.Resolve(mainModule.SimpleName);
 
             var (actualSuccess, actualMessage) = verify(verifier, mscorlibModule.FullName, mainModuleReader);
-            var expectedSuccess = !verification.Status.HasFlag(VerificationStatus.FailsILVerify);
+            var expectedSuccess = (verification.Status & VerificationStatus.FailsILVerify) == 0;
 
             if (actualSuccess != expectedSuccess)
             {

--- a/src/Compilers/Test/Core/Platform/Custom/MetadataSignatureHelper.cs
+++ b/src/Compilers/Test/Core/Platform/Custom/MetadataSignatureHelper.cs
@@ -43,11 +43,11 @@ namespace Roslyn.Test.Utilities
             if (showGenericConstraints && type.IsGenericParameter)
             {
                 var typeInfo = type.GetTypeInfo();
-                if (typeInfo.GenericParameterAttributes.HasFlag(GenericParameterAttributes.ReferenceTypeConstraint))
+                if ((typeInfo.GenericParameterAttributes & GenericParameterAttributes.ReferenceTypeConstraint) != 0)
                     sb.Append("class ");
-                if (typeInfo.GenericParameterAttributes.HasFlag(GenericParameterAttributes.NotNullableValueTypeConstraint))
+                if ((typeInfo.GenericParameterAttributes & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0)
                     sb.Append("valuetype ");
-                if (typeInfo.GenericParameterAttributes.HasFlag(GenericParameterAttributes.DefaultConstructorConstraint))
+                if ((typeInfo.GenericParameterAttributes & GenericParameterAttributes.DefaultConstructorConstraint) != 0)
                     sb.Append(".ctor ");
 
                 var genericConstraints = typeInfo.GetGenericParameterConstraints();
@@ -492,29 +492,29 @@ namespace Roslyn.Test.Utilities
             sb.Append(')');
 
             var implFlags = constructor.GetMethodImplementationFlags();
-            if (implFlags.HasFlag(MethodImplAttributes.IL))
+            if ((implFlags & MethodImplAttributes.IL) == MethodImplAttributes.IL)
                 sb.Append(" cil");
-            if (implFlags.HasFlag(MethodImplAttributes.ForwardRef))
+            if ((implFlags & MethodImplAttributes.ForwardRef) != 0)
                 sb.Append(" forwardref");
-            if (implFlags.HasFlag(MethodImplAttributes.InternalCall))
+            if ((implFlags & MethodImplAttributes.InternalCall) != 0)
                 sb.Append(" internalcall");
-            if (implFlags.HasFlag(MethodImplAttributes.Managed))
+            if ((implFlags & MethodImplAttributes.Managed) == MethodImplAttributes.Managed)
                 sb.Append(" managed");
-            if (implFlags.HasFlag(MethodImplAttributes.Native))
+            if ((implFlags & MethodImplAttributes.Native) != 0)
                 sb.Append(" native");
-            if (implFlags.HasFlag(MethodImplAttributes.NoInlining))
+            if ((implFlags & MethodImplAttributes.NoInlining) != 0)
                 sb.Append(" noinlining");
-            if (implFlags.HasFlag(MethodImplAttributes.NoOptimization))
+            if ((implFlags & MethodImplAttributes.NoOptimization) != 0)
                 sb.Append(" nooptimization");
-            if (implFlags.HasFlag(MethodImplAttributes.OPTIL))
+            if ((implFlags & MethodImplAttributes.OPTIL) != 0)
                 sb.Append(" optil");
-            if (implFlags.HasFlag(MethodImplAttributes.PreserveSig))
+            if ((implFlags & MethodImplAttributes.PreserveSig) != 0)
                 sb.Append(" preservesig");
-            if (implFlags.HasFlag(MethodImplAttributes.Runtime))
+            if ((implFlags & MethodImplAttributes.Runtime) == MethodImplAttributes.Runtime)
                 sb.Append(" runtime");
-            if (implFlags.HasFlag(MethodImplAttributes.Synchronized))
+            if ((implFlags & MethodImplAttributes.Synchronized) != 0)
                 sb.Append(" synchronized");
-            if (implFlags.HasFlag(MethodImplAttributes.Unmanaged))
+            if ((implFlags & MethodImplAttributes.Unmanaged) != 0)
                 sb.Append(" unmanaged");
         }
 
@@ -553,9 +553,9 @@ namespace Roslyn.Test.Utilities
                 sb.Append("writeonly ");
             }
 
-            if (property.Attributes.HasFlag(PropertyAttributes.SpecialName))
+            if ((property.Attributes & PropertyAttributes.SpecialName) != 0)
                 sb.Append("specialname ");
-            if (property.Attributes.HasFlag(PropertyAttributes.RTSpecialName))
+            if ((property.Attributes & PropertyAttributes.RTSpecialName) != 0)
                 sb.Append("rtspecialname ");
 
             var propertyAccessors = property.GetAccessors();
@@ -623,9 +623,9 @@ namespace Roslyn.Test.Utilities
                 sb.Append("literal ");
             if (field.IsNotSerialized)
                 sb.Append("notserialized ");
-            if (field.Attributes.HasFlag(FieldAttributes.SpecialName))
+            if ((field.Attributes & FieldAttributes.SpecialName) != 0)
                 sb.Append("specialname ");
-            if (field.Attributes.HasFlag(FieldAttributes.RTSpecialName))
+            if ((field.Attributes & FieldAttributes.RTSpecialName) != 0)
                 sb.Append("rtspecialname ");
             if (field.IsPinvokeImpl)
                 sb.Append("pinvokeimpl ");
@@ -651,9 +651,9 @@ namespace Roslyn.Test.Utilities
                 sb.Append(' ');
             }
 
-            if (@event.Attributes.HasFlag(EventAttributes.SpecialName))
+            if ((@event.Attributes & EventAttributes.SpecialName) != 0)
                 sb.Append("specialname ");
-            if (@event.Attributes.HasFlag(EventAttributes.RTSpecialName))
+            if ((@event.Attributes & EventAttributes.RTSpecialName) != 0)
                 sb.Append("rtspecialname ");
 
             AppendType(@event.EventHandlerType, sb);

--- a/src/Compilers/Test/Core/Platform/Desktop/DesktopRuntimeEnvironment.cs
+++ b/src/Compilers/Test/Core/Platform/Desktop/DesktopRuntimeEnvironment.cs
@@ -175,12 +175,12 @@ namespace Roslyn.Test.Utilities.Desktop
                 return;
             }
 
-            if (verification.Status.HasFlag(VerificationStatus.Skipped))
+            if ((verification.Status & VerificationStatus.Skipped) != 0)
             {
                 return;
             }
 
-            var shouldSucceed = !verification.Status.HasFlag(VerificationStatus.FailsPEVerify);
+            var shouldSucceed = (verification.Status & VerificationStatus.FailsPEVerify) == 0;
 
             try
             {

--- a/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory_Methods.vb
+++ b/src/Compilers/VisualBasic/Portable/Operations/VisualBasicOperationFactory_Methods.vb
@@ -575,7 +575,7 @@ Namespace Microsoft.CodeAnalysis.Operations
                 Dim conversion = DirectCast(expression, BoundConversion)
                 Dim conversionKind = conversion.ConversionKind
                 Dim method As MethodSymbol = Nothing
-                If conversionKind.HasFlag(VisualBasic.ConversionKind.UserDefined) AndAlso conversion.Operand.Kind = BoundKind.UserDefinedConversion Then
+                If (conversionKind And VisualBasic.ConversionKind.UserDefined) <> 0 AndAlso conversion.Operand.Kind = BoundKind.UserDefinedConversion Then
                     method = DirectCast(conversion.Operand, BoundUserDefinedConversion).Call.Method
                 End If
                 Return New Conversion(KeyValuePair.Create(conversionKind, method))

--- a/src/Compilers/VisualBasic/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.vb
+++ b/src/Compilers/VisualBasic/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.vb
@@ -190,7 +190,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Sub
 
         Private Sub AddNestedTypeSeparator()
-            If Format.CompilerInternalOptions.HasFlag(SymbolDisplayCompilerInternalOptions.UsePlusForNestedTypes) Then
+            If (Format.CompilerInternalOptions And SymbolDisplayCompilerInternalOptions.UsePlusForNestedTypes) <> 0 Then
                 AddOperator(SyntaxKind.PlusToken)
             Else
                 AddOperator(SyntaxKind.DotToken)

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.vb
@@ -55,7 +55,7 @@ Partial Public Class InternalsVisibleToAndStrongNameTests
             outStream.Position = 0
 
             Dim headers = New PEHeaders(outStream)
-            Assert.Equal(expectedToBeSigned, headers.CorHeader.Flags.HasFlag(CorFlags.StrongNameSigned))
+            Assert.Equal(expectedToBeSigned, (headers.CorHeader.Flags And CorFlags.StrongNameSigned) <> 0)
         End Using
     End Sub
 
@@ -1966,7 +1966,7 @@ End Class
         Using reader As New PEReader(stream)
             Assert.True(reader.HasMetadata)
             Dim flags = reader.PEHeaders.CorHeader.Flags
-            Assert.True(flags.HasFlag(CorFlags.StrongNameSigned))
+            Assert.True((flags And CorFlags.StrongNameSigned) <> 0)
         End Using
     End Sub
 

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/CompilationEmitTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/CompilationEmitTests.vb
@@ -2119,7 +2119,7 @@ End Module
             Assert.False(peHeaders.Requires64Bits)
             Assert.True(peHeaders.IsDll)
             Assert.False(peHeaders.IsExe)
-            Assert.True(peHeaders.CoffHeader.Characteristics.HasFlag(Characteristics.LargeAddressAware))
+            Assert.True((peHeaders.CoffHeader.Characteristics And Characteristics.LargeAddressAware) <> 0)
 
             'interesting Optional PE header bits
             'We will use a range beginning with &H50 to identify the Roslyn VB compiler family.
@@ -2180,7 +2180,7 @@ End Module
             Assert.False(peHeaders.Requires64Bits)
             Assert.True(peHeaders.IsDll)
             Assert.False(peHeaders.IsExe)
-            Assert.True(peHeaders.CoffHeader.Characteristics.HasFlag(Characteristics.LargeAddressAware))
+            Assert.True((peHeaders.CoffHeader.Characteristics And Characteristics.LargeAddressAware) <> 0)
 
             'interesting Optional PE header bits
             'We will use a range beginning with &H50 to identify the Roslyn VB compiler family.
@@ -2241,7 +2241,7 @@ End Module
             Assert.True(peHeaders.Requires64Bits)
             Assert.True(peHeaders.IsDll)
             Assert.False(peHeaders.IsExe)
-            Assert.True(peHeaders.CoffHeader.Characteristics.HasFlag(Characteristics.LargeAddressAware))
+            Assert.True((peHeaders.CoffHeader.Characteristics And Characteristics.LargeAddressAware) <> 0)
 
             'interesting Optional PE header bits
             'We will use a range beginning with &H50 to identify the Roslyn VB compiler family.


### PR DESCRIPTION
## Summary

`Enum.HasFlag` introduces boxing overhead on .NET Framework, where the compiler still runs. Replace 70 calls in compiler code and test helpers with equivalent bitwise checks to avoid these allocations.

The replacements preserve all-bits semantics, including zero-valued and composite masks. Test inputs that intentionally exercise `Enum.HasFlag` remain unchanged.

Add `Enum.HasFlag` to the existing `BannedSymbols.CompilerLibraries.txt` and include that list in the C# compiler project, matching Core and Visual Basic. This also exposes 16 existing numeric-formatting violations in C#; those calls now use `CultureInfo.InvariantCulture`. This was already a part of the banned APIs in Microsoft.CodeAnalysis and Microsoft.CodeAnalysis.VisualBasic. It _appears_ that this was accidentally omitted from Microsoft.CodeAnalysis.CSharp. Rather than having two banned symbol files, the existing one was added to Microsoft.CodeAnalysis.CSharp, the issues fixed and then `Enum.HasFlag` was added.

## Allocation impact

Compared baseline and changed **Release/net472** builds using `src/Tools/Replay` against the same build binlog: **1,650 compilations per run**, maximum concurrency **6**, and **three runs per variant** in alternating order. Allocations were captured with PerfView ETW tracing and analyzed with [pvanalyze](https://github.com/adityamandaleeka/pvanalyze).

Average cumulative allocations per replay:

| Process | Baseline | Changed | Reduction |
|---|---:|---:|---:|
| Compiler servers | 103.173 GB | 100.146 GB | **2.93%** |
| Replay | 2.649 GB | 2.647 GB | Essentially unchanged |
| Combined | 105.823 GB | 102.793 GB | **2.86%** |

The dominant improvement is removal of `LookupOptions` boxing, which accounted for approximately **3.106 GB per baseline run** and produced no allocation samples in the changed runs. `BinderFlags` boxing accounted for another approximately **58 MB**.

Every changed run allocated less than every baseline run. These figures are sampled allocation estimates, use decimal GB, and describe cumulative allocations, not peak memory usage.